### PR TITLE
docs: remove prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Have a look at the [CONTRIBUTING](/CONTRIBUTING.md) and [CODE_OF_CONDUCT](/CODE_
 ### Code Style
 
 -   [ESLint](https://eslint.org/)
--   [Prettier](https://prettier.io/)
 
 ## Getting started developing
 


### PR DESCRIPTION
# What changed

Removes prettier from the README since we're just using eslint in the repo for now.

