### PR TITLE
Fix eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,7 +113,7 @@ module.exports = {
         'no-shadow': 2,
 
         // Vue
-        'vue/multi-word-component-names': 0,
+        'vue/multi-word-component-names': 1,
         'vue/html-indent': ['error', 4, {
             attribute: 1,
             baseIndent: 1,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -113,7 +113,7 @@ module.exports = {
         'no-shadow': 2,
 
         // Vue
-        'vue/multi-word-component-names': 1,
+        'vue/multi-word-component-names': 0,
         'vue/html-indent': ['error', 4, {
             attribute: 1,
             baseIndent: 1,

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -26,12 +26,14 @@ export default defineComponent({
     props: {
         msg: {
             type: String,
+            default: '',
             required: false
         }
     },
     data() {
         return {
             name: '',
+
         }
     }
 })

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -15,8 +15,15 @@
 import { defineComponent } from 'vue'
 export default defineComponent({
     props: {
-        name: String,
-        msg: { type: String, required: false }
+        name: {
+            type: String,
+            default: '',
+        },
+        msg: { 
+            type: String, 
+            required: false,
+            default: '',
+        }
     },
     data() {
         return {


### PR DESCRIPTION
# What changed

- disable `vue/multi-word-component-names` rule as per conversation with @ann-kilzer on slack
- add default value to prop where required

# Testing instructions

run `yarn lint` and 0 warning should appear. 
