### PR TITLE
feat: add git hook to enforce conventional commit

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit ${1}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional']
+}


### PR DESCRIPTION
Resolves #41 


# What changed

See https://www.conventionalcommits.org/ and https://github.com/conventional-changelog/commitlint

# Testing instructions

run following:
- `yarn && yarn prepare`
- `touch bar && git add bar && git commit -m 'foobar'`

output should be similar to below:

```
$ git commit                                    
⧗   input: foobar
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]

✖   found 2 problems, 0 warnings
```
