### PR TITLE
DOCS: Create default issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,20 @@
+---
+name: default
+about: Default Issue Template
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Requirements
+---
+
+- [ ] Add
+- [ ] Requirements
+- [ ] here
+
+---
+# Dependencies
+
+- None (Add any issue dependencies here)


### PR DESCRIPTION
This resolves #109 

- [x] added GitHub issue template. Kept it simple