### PR TITLE
feat: add typescript check to vue block

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -144,7 +144,14 @@ module.exports = {
         'vue/first-attribute-linebreak': ['error', {
             singleline: 'beside',
             multiline: 'beside'
-        }]
+        }],
+        'vue/block-lang': ['warn',
+                           {
+                               script: {
+                                   lang: 'ts'
+                               }
+                           }
+        ]
 
     }
 }


### PR DESCRIPTION
Part of #137 

# What changed
Warn when blocks are not using typescript

# Testing instructions
Run `yarn lint` on the branch, should see: 

```sh
.../ourjapanlife/findadoc-web/components/SearchBar.vue
  53:1  warning  The 'lang' attribute of '<script>' is missing  vue/block-lang

.../ourjapanlife/findadoc-web/components/SearchResult.vue
  23:1  warning  The 'lang' attribute of '<script>' is missing  vue/block-lang

.../ourjapanlife/findadoc-web/components/SearchResultsList.vue
  22:1  warning  The 'lang' attribute of '<script>' is missing
```
