### PR TITLE
Enforce Typescript on scripts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -145,7 +145,7 @@ module.exports = {
             singleline: 'beside',
             multiline: 'beside'
         }],
-        'vue/block-lang': ['warn',
+        'vue/block-lang': ['error',
                            {
                                script: {
                                    lang: 'ts'

--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -53,7 +53,7 @@
     </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue'
 
 const specialtyMockData = [{

--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -20,7 +20,7 @@
     </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 
 defineProps({
     name: {

--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -38,11 +38,11 @@ defineProps({
     spokenLanguages: {
         type: Array,
         required: true,
-        validator(arrayValue) {
+        validator(arrayValue: Array<any>) {
             // must match accepted languages
             const acceptedLanguages = ['japanese', 'english']
 
-            return arrayValue.every(x => acceptedLanguages.includes(x))
+            return arrayValue.every((x: any) => { acceptedLanguages.includes(x) })
         }
     }
 })

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -21,7 +21,7 @@
     </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref } from 'vue'
 
 const defaultResults = [{


### PR DESCRIPTION
Resolves #137 


# What changed
- turn up eslint to error
- add typescript to scripts

# Testing instructions
- linter should pass
- code should build and run

Note I had some hiccups with the VS Code extension "Vetur" complaining about the vue import, but since that is a very sluggish tool and geared to Vue 2, I removed it and am fully on Volar. [See this thread.](https://stackoverflow.com/questions/54839057/vscode-showing-cannot-find-module-ts-error-for-vue-import-while-compiling-doe)
