### PR TITLE
cypress skeleton tests + logo adjustment

### DIFF
--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -42,7 +42,7 @@
             <button id="searchButton"
                 class="flex flex-0 flex-row rounded-full bg-primary w-28 pl-1 pr-2 py-2 text-sm align-middle justify-center
                     hover:bg-primary-hover transition-all"
-                data-testid="searchbutton">
+                data-testid="search-button">
                 <svg role="img" alt="search icon" title="search icon"
                     class="search-icon w-5 h-5 mr-1 fill-primary-text-inverted">
                     <use xlink:href="../assets/images/search-icon.svg#search-icon-svg" />

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -6,12 +6,12 @@
                 <svg role="img" title="site icon" class="mr-1 w-10 h-10 align-middle fill-primary group-hover:fill-primary-hover">
                     <use xlink:href="../assets/images/site-logo.svg#site-logo-svg" />
                 </svg>
-                <div class="title-text flex flex-col">
-                    <div class="text-xs text-primary group-hover:text-primary-hover">
-                        Find a
+                <div class="title-text flex flex-col" data-testid="logo">
+                    <div class="text-lg text-primary group-hover:text-primary-hover">
+                        Find a Doc 
                     </div>
-                    <div class="text-xl text-primary leading-none group-hover:text-primary-hover">
-                        Doc Japan
+                    <div class="text-sm text-primary leading-none group-hover:text-primary-hover">
+                        Japan
                     </div>
                 </div>
             </NuxtLink>

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -2,7 +2,42 @@ describe('Visits the home page', () => {
     before(() => {
         cy.visit('/')
     })
-    it('Displays the Hero Section', () => {
-        cy.get('[data-testid="searchbutton"]').should('be.visible')
+
+    it('Displays the Logo', () => {
+        cy.get('[data-testid="logo"]')
+            .should('be.visible')
+            .contains('Find a Doc Japan')
+        // TODO: clicking it should take us to '/'
+    })
+
+    it('allows setting search fields', () => {
+        cy.get('[data-testid="search-button"]').should('be.visible')
+        // TODO
+    })
+
+    it.skip('selects a language', () => {
+        // TODO
+    })
+
+    it.skip('renders the map', () => {
+        // TODO
+    })
+
+    it.skip('shows doctors nearby', () => {
+
+    })
+
+    it.skip('displays the footer', () => {
+        // TODO
+
+        // verify link to GitHub
+
+        // verify feedback link
+
+        // verify Netlify citation
+
+        // privacy
+
+        // terms
     })
 })


### PR DESCRIPTION
Part of #169 and resolves #151

# What changed
- Create some skeleton tests for cypress (will be easier to divvy up among contributors)
- Adjust Logo to emphasize "Find a Doc" and read more naturally

# Testing instructions
Confirm the logo looks like this:
<img width="182" alt="localhost_3000" src="https://user-images.githubusercontent.com/4602369/215501636-19369f9f-23c5-4ede-b7d1-24ff271c242a.png">

Confirm the cypress tests pass: `yarn run test:e2e`
