### PR TITLE
BUGFIX: fixing netlify production build error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
 
 [build.environment]
   NETLIFY_USE_YARN="true"
-  YARN_VERSION="3.2.4"
+  YARN_VERSION="3.4.1"


### PR DESCRIPTION
Resolves #206 


# What changed
- [x] Yarn version was mismatching between netlify env variables, the netlify toml config, and the `.yarn` folder. 
- [x] Removed `yarn version` from netlify build variables on the site. This will allow the `toml` variables to be the main source. 

# Testing instructions
- check if the netlify build works now. 
    -  https://app.netlify.com/sites/findadoc/deploys/63f313f939e9550c4d3f5a21
