### PR TITLE
updating the api url

### DIFF
--- a/utils/apollo.ts
+++ b/utils/apollo.ts
@@ -13,7 +13,7 @@ export const initializeApollo = () => {
 
     apollo = new ApolloClient({
         link: createHttpLink({
-            uri: 'https://findadoc-api-9brq4.ondigitalocean.app/api',
+            uri: 'https://api.findadoc.jp',
         }),
         cache: new InMemoryCache()
     })


### PR DESCRIPTION
Resolves #330


# What changed
updating the api url to point to `api.findadoc.jp` instead of the `/api` route

# Testing instructions

