### PR TITLE
Fix SearchResultList component partially hidden

### DIFF
--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="h-full">
+    <div class="h-full flex flex-col">
         <div class="results-header flex flex-row ml-9 mr-5 mb-6 pt-5">
             <span class="flex-1 w-1/2 font-bold self-center">
                 {{ $t('searchResultsList.doctorsNearby') }}


### PR DESCRIPTION
Resolves #341

# What changed

Small fix. The SearchResultList was not showing all the healthcare professionals since it was hidden.
Before:

![image](https://github.com/ourjapanlife/findadoc-web/assets/114712265/103fe490-985c-4bca-a67f-5dc70469362c)

After (kept the dev layout on) :

I have added a flex on the outer div of the SearchResultList component.
 
![image](https://github.com/ourjapanlife/findadoc-web/assets/114712265/4682f567-afde-42dc-8534-63692d5a2d36)