### PR TITLE
docs: update PR template to include screenshots

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,11 @@
 Resolves #[Issue number]
 
+## 🔧 What changed
 
-# What changed
+## 🧪 Testing instructions
 
+## 📸 Screenshots
 
-# Testing instructions
+-   ### Before
 
+-   ### After


### PR DESCRIPTION
# What changed
Adds a "Screenshots" section the PR template to help devs to remember to include Before and After screenshots for UI changes that are made.

