### PR TITLE
fix: contain root template in one element

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,10 +1,12 @@
 <template>
-    <BetaBanner />
-    <div class="flex overflow-hidden">
-        <LeftNavbar class="flex-0 bg-primary-bg w-[358px]" />
-        <div class="flex-1">
-            <div class="flex flex-col md:flex-row h-full">
-                <MainContentContainer />
+    <div class="flex flex-col">
+        <BetaBanner />
+        <div class="flex overflow-hidden">
+            <LeftNavbar class="flex-0 bg-primary-bg w-[358px]" />
+            <div class="flex-1">
+                <div class="flex flex-col md:flex-row h-full">
+                    <MainContentContainer />
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This PR is part of a 🥞

1. https://github.com/ourjapanlife/findadoc-web/pull/352 👈🏼 You are here
2. https://github.com/ourjapanlife/findadoc-web/pull/351
3. https://github.com/ourjapanlife/findadoc-web/pull/353

# What changed
Root template in Vue/Nuxt require exactly one element. This wraps the temporary Beta Banner and the other components in one `div`.

![Screenshot 2023-12-31 at 4 46 32 AM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/b1efdc97-4859-437d-b957-737e7ba3a75f)

# Testing instructions
View the preview of the site and ensure that the UI hasn't changed.

