### PR TITLE
fix: add breakpoints to make site usable on mobile

### DIFF
--- a/components/HamburgerComponent.vue
+++ b/components/HamburgerComponent.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="cursor-pointer md:hidden w-full">
+    <div class="cursor-pointer w-full">
         <div class="flex justify-between w-full">
             <div>
                 <img

--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -1,20 +1,36 @@
-
 import SearchResultDetails from './SearchResultDetails.vue';
 
 <template>
-    <div class="flex flex-1 bg-secondary-bg/20 hover:shadow-inner hover:shadow-secondary-bg/90">
-        <!-- <WelcomeSection /> -->
-        <Loader />
-        <Modal v-show="store.$state.isOpen" class="min-h-1/2 ml-8 mt-12">
-            <SearchResultDetails />
-        </Modal>
-        <MapContainer />
+    <div class="h-full">
+        <div
+            v-if="$viewport.isGreaterThan('tablet')"
+            class="flex flex-1 bg-secondary-bg/20 hover:shadow-inner hover:shadow-secondary-bg/90"
+        >
+            <!-- <WelcomeSection /> -->
+            <Loader />
+            <Modal v-show="store.$state.isOpen" class="min-h-1/2 ml-8 mt-12">
+                <SearchResultDetails />
+            </Modal>
+            <MapContainer />
+        </div>
+        <div v-else class="h-full">
+            <Modal v-show="store.$state.isOpen" class="min-h-1/2 ml-8 mt-12">
+                <SearchResultDetails />
+            </Modal>
+            <div class="h-[50vh]">
+                <MapContainer />
+            </div>
+            <div class="h-[50vh]">
+                <SearchResultsList />
+            </div>
+        </div>
     </div>
 </template>
 
 <script lang="ts" setup>
-import { useModalStore } from '~/stores/modalStore'
+import { useNuxtApp } from "#app";
+const { $viewport } = useNuxtApp();
+import { useModalStore } from "~/stores/modalStore";
 
-const store = useModalStore()
-
+const store = useModalStore();
 </script>

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -2,8 +2,7 @@
     <div
         class="p-4 pl-8 border border-secondary-bg/20 flex justify-between items-center bg-gradient-to-t from-secondary-bg/30 via-primary-bg to-primary-bg"
     >
-        <HamburgerComponent />
-        <div class="hidden md:flex items-center">
+        <div v-if="$viewport.isGreaterThan('tablet')" class="flex items-center">
             <div
                 class="font-semibold text-xl group transition-colors items-start"
             >
@@ -50,12 +49,20 @@
             </nav>
             <LocaleSelector />
         </div>
+        <HamburgerComponent v-else />
     </div>
 </template>
 
 <script lang="ts" setup>
 import { useSubmissionStore } from "~/stores/submissionStore";
 import { useMenuStore } from "~/stores/menuStore";
+import { useNuxtApp } from "#app";
+import { watch } from "vue";
+const { $viewport } = useNuxtApp();
+
+watch($viewport.breakpoint, (newBreakpoint, oldBreakpoint) => {
+    console.log("Breakpoint updated:", oldBreakpoint, "->", newBreakpoint);
+});
 
 const submissionStore = useSubmissionStore();
 const menuStore = useMenuStore();

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -57,12 +57,8 @@
 import { useSubmissionStore } from "~/stores/submissionStore";
 import { useMenuStore } from "~/stores/menuStore";
 import { useNuxtApp } from "#app";
-import { watch } from "vue";
-const { $viewport } = useNuxtApp();
 
-watch($viewport.breakpoint, (newBreakpoint, oldBreakpoint) => {
-    console.log("Breakpoint updated:", oldBreakpoint, "->", newBreakpoint);
-});
+const { $viewport } = useNuxtApp();
 
 const submissionStore = useSubmissionStore();
 const menuStore = useMenuStore();

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -96,8 +96,32 @@ export default defineNuxtConfig({
     modules: [
         '@nuxtjs/i18n',
         '@pinia/nuxt',
-        'nuxt-viewport'
+        'nuxt-viewport',
     ],
+
+    viewport: {
+        breakpoints: {
+            desktop: 1024,
+            desktopMedium: 1280,
+            desktopWide: 1600,
+
+            mobile: 320,
+            mobileMedium: 375,
+            mobileWide: 425,
+
+            tablet: 768,
+          },
+
+          cookieName: 'viewport',
+
+          defaultBreakpoints: {
+            desktop: 'desktop',
+            mobile: 'mobile',
+            tablet: 'tablet',
+          },
+
+          fallbackBreakpoint: 'desktop',
+    },
 
     i18n: {
         vueI18n: './i18n.options.ts'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,10 @@
 <template>
     <div class="flex flex-col">
         <BetaBanner />
-        <div class="flex overflow-hidden">
+        <div
+            v-if="$viewport.isGreaterThan('tablet')"
+            class="flex overflow-hidden"
+        >
             <LeftNavbar class="flex-0 bg-primary-bg w-[358px]" />
             <div class="flex-1">
                 <div class="flex flex-col md:flex-row h-full">
@@ -9,5 +12,25 @@
                 </div>
             </div>
         </div>
+        <div v-else>
+            <div class="flex-1">
+                <div class="flex flex-col h-full">
+                    <MainContentContainer />
+                </div>
+            </div>
+        </div>
     </div>
 </template>
+
+<script setup lang="ts">
+import { useNuxtApp } from "#app";
+import { watch } from "vue";
+const { $viewport } = useNuxtApp();
+import { useModalStore } from "~/stores/modalStore";
+
+const store = useModalStore();
+
+watch($viewport.breakpoint, (newBreakpoint, oldBreakpoint) => {
+    console.log("Breakpoint updated:", oldBreakpoint, "->", newBreakpoint);
+});
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,13 +24,8 @@
 
 <script setup lang="ts">
 import { useNuxtApp } from "#app";
-import { watch } from "vue";
-const { $viewport } = useNuxtApp();
 import { useModalStore } from "~/stores/modalStore";
 
+const { $viewport } = useNuxtApp();
 const store = useModalStore();
-
-watch($viewport.breakpoint, (newBreakpoint, oldBreakpoint) => {
-    console.log("Breakpoint updated:", oldBreakpoint, "->", newBreakpoint);
-});
 </script>


### PR DESCRIPTION
Resolves #347 

This PR is part of a 🥞

1. https://github.com/ourjapanlife/findadoc-web/pull/352 
2. https://github.com/ourjapanlife/findadoc-web/pull/351 
3. https://github.com/ourjapanlife/findadoc-web/pull/353 👈🏼 You are here

# What changed
Creates different layouts based on whether or not the screen is larger or smaller than a tablet.
See the mobile design on [Figma](https://www.figma.com/file/QXQxlw4jNFIhMxkKU7bbwq/Find-a-doc%2C-Japan?type=design&node-id=704-12700&mode=design).

# Testing instructions
Click the Netlify preview in the comment below, and resize the page to mobile and check that it's responsive.

# Screenshots

## Before
![Screenshot 2023-12-31 at 6 21 59 AM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/94468d06-7acc-44d4-95ce-4f77efac4d95)

## After
![Screenshot 2023-12-31 at 6 21 02 AM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/b3081efa-65b5-4b17-bf1d-14b863d87b43)

