### PR TITLE
Make the map visible again on desktop

### DIFF
--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -7,7 +7,7 @@ import SearchResultDetails from './SearchResultDetails.vue';
             class="bg-secondary-bg/20 hover:shadow-inner hover:shadow-secondary-bg/90 h-full w-full"
         >
             <!-- <WelcomeSection /> -->
-            <!-- <Loader /> -->
+            <Loader />
             <Modal v-show="store.$state.isOpen" class="min-h-1/2 ml-8 mt-12">
                 <SearchResultDetails />
             </Modal>

--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -1,17 +1,19 @@
 import SearchResultDetails from './SearchResultDetails.vue';
 
 <template>
-    <div class="h-full">
+    <div class="h-full w-full">
         <div
             v-if="$viewport.isGreaterThan('tablet')"
-            class="flex flex-1 bg-secondary-bg/20 hover:shadow-inner hover:shadow-secondary-bg/90"
+            class="bg-secondary-bg/20 hover:shadow-inner hover:shadow-secondary-bg/90 h-full w-full"
         >
             <!-- <WelcomeSection /> -->
-            <Loader />
+            <!-- <Loader /> -->
             <Modal v-show="store.$state.isOpen" class="min-h-1/2 ml-8 mt-12">
                 <SearchResultDetails />
             </Modal>
-            <MapContainer />
+            <div class="flex-1 h-full">
+                <MapContainer />
+            </div>
         </div>
         <div v-else class="h-full">
             <Modal v-show="store.$state.isOpen" class="min-h-1/2 ml-8 mt-12">

--- a/components/MapContainer.vue
+++ b/components/MapContainer.vue
@@ -7,40 +7,33 @@
     </GoogleMap>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { defineComponent, ref, computed } from "vue"
 import { GoogleMap, Marker as GMarker } from "vue3-google-map"
 import { useRuntimeConfig } from "#imports"
 import customIcon from "../assets/images/blue-map-pin.svg"
 import { useSearchResultsStore } from "../stores/searchResultsStore"
 
-export default defineComponent({
-    components: { GoogleMap, GMarker },
-    setup() {
-        //tokyo is the default location
-        const defaultLocation = { lat: 35.6804, lng: 139.769 };
 
-        const center = computed(() => {
-            const lng = useSearchResultsStore().activeResult?.facilities[0]?.mapLongitude
-            const lat = useSearchResultsStore().activeResult?.facilities[0]?.mapLatitude
-            const locationExists = lng && lat;
+    const defaultLocation = { lat: 35.6804, lng: 139.769 };
 
-            return locationExists ? { lat, lng } : defaultLocation;
-        });
+    const center = computed(() => {
+        const lng = useSearchResultsStore().activeResult?.facilities[0]?.mapLongitude
+        const lat = useSearchResultsStore().activeResult?.facilities[0]?.mapLatitude
+        const locationExists = lng && lat;
 
-        const markerIcon = {
-            url: customIcon,
-            scaledSize: {
-                width: 45,
-                height: 73
-            }
-        };
+        return locationExists ? { lat, lng } : defaultLocation;
+    });
 
-        const searchResultsStore = useSearchResultsStore();
-        const mapRef = ref(null);
-        const runtimeConfig = useRuntimeConfig();
+    const markerIcon = {
+        url: customIcon,
+        scaledSize: {
+            width: 45,
+            height: 73
+        }
+    };
 
-        return { center, mapRef, markerIcon, defaultLocation, runtimeConfig, searchResultsStore };
-    }
-});
+    const searchResultsStore = useSearchResultsStore();
+    const mapRef = ref(null);
+    const runtimeConfig = useRuntimeConfig();
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,16 +1,12 @@
 <template>
-    <div class="flex flex-col">
+    <div class="flex flex-col h-full">
         <BetaBanner />
         <div
             v-if="$viewport.isGreaterThan('tablet')"
-            class="flex overflow-hidden"
+            class="flex h-full overflow-hidden"
         >
-            <LeftNavbar class="flex-0 bg-primary-bg w-[358px]" />
-            <div class="flex-1">
-                <div class="flex flex-col md:flex-row h-full">
-                    <MainContentContainer />
-                </div>
-            </div>
+            <LeftNavbar class="bg-primary-bg w-[358px]" />
+            <MainContentContainer />
         </div>
         <div v-else>
             <div class="flex-1">


### PR DESCRIPTION
Part of #347 

# What changed

- I have refactored the Mapcontainer component. In Vue3 we can add the `setup` in `<script>`. Since we are doing this in the other components it seemed better for consistency.
- To make the the map visible in desktop, I have changed some tailwind elements. During testing and reviewing I have notice that some elements were  unnecessary and have removed them.
