### PR TITLE
feat: Add email address to SearchResultDetails

### DIFF
--- a/assets/images/email-icon.svg
+++ b/assets/images/email-icon.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" xmlns="http://www.w3.org/2000/svg">
+    <symbol id="email-icon-svg" viewBox="0 0 20 20" fill="none">
+        <path d="M2.5 4.5H17.5C17.8978 4.5 18.2794 4.65804 18.5607 4.93934C18.842 5.22064 19 5.60218 19 6V14C19 14.3978 18.842 14.7794 18.5607 15.0607C18.2794 15.342 17.8978 15.5 17.5 15.5H2.5C2.10218 15.5 1.72064 15.342 1.43934 15.0607C1.15804 14.7794 1 14.3978 1 14V6C1 5.60218 1.15804 5.22064 1.43934 4.93934C1.72064 4.65804 2.10218 4.5 2.5 4.5V4.5Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M19 6L10 11L1 6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+</svg>

--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -59,6 +59,13 @@
                     </svg>
                     {{ phone }}
                 </div>
+                <div class="email flex my-4" v-if="email !== 'none' && email !== 'email@email.com'">
+                    <svg role="img" alt="Facility Banner Image" title="banner image"
+                        class="banner-icon w-6 h-6 stroke-primary mr-2 self-center">
+                        <use xlink:href="../assets/images/email-icon.svg#email-icon-svg" />
+                    </svg>
+                    {{ email }}
+                </div>
             </div>
         </div>
     </div>
@@ -147,6 +154,9 @@ const website = computed(
 )
 const phone = computed(
     () => resultsStore.$state.activeResult?.facilities[0]?.contact?.phone
+)
+const email = computed(
+    () => resultsStore.$state.activeResult?.facilities[0]?.contact?.email
 )
 </script>
 

--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -59,7 +59,7 @@
                     </svg>
                     {{ phone }}
                 </div>
-                <div class="email flex my-4" v-if="email !== 'none' && email !== 'email@email.com'">
+                <div class="email flex my-4" v-if="!excludedEmailAddresses.includes(email)">
                     <svg role="img" alt="Facility Banner Image" title="banner image"
                         class="banner-icon w-6 h-6 stroke-primary mr-2 self-center">
                         <use xlink:href="../assets/images/email-icon.svg#email-icon-svg" />
@@ -158,6 +158,8 @@ const phone = computed(
 const email = computed(
     () => resultsStore.$state.activeResult?.facilities[0]?.contact?.email
 )
+
+const excludedEmailAddresses = ['none', 'email@email.com'];
 </script>
 
 <style>

--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -64,7 +64,7 @@
                         class="banner-icon w-6 h-6 stroke-primary mr-2 self-center">
                         <use xlink:href="../assets/images/email-icon.svg#email-icon-svg" />
                     </svg>
-                    {{ email }}
+                    <a :href="`mailto:${email}`" class="email-link">{{ email }}</a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Resolves #336 

Previously a facility's email address was not displayed in the `SearchDetailsResult`. This renders the email.

# What changed
1. Implemented logic to conditionally display the facility's email address.
2. Added an SVG icon for email addresses.
3. Email addresses with a value of `none` or `email@email.com` are filtered out with a `v-if` statement. (See the images below. I can remove this if necessary.)

<img height="350" alt="Screenshot 2024-02-03 at 17 22 35" src="https://github.com/ourjapanlife/findadoc-web/assets/86333067/b227174a-e6f9-48f6-afad-e5862db00739">

<img height="350" alt="Screenshot 2024-02-03 at 17 21 44" src="https://github.com/ourjapanlife/findadoc-web/assets/86333067/27b1b145-8f33-4454-b8ec-c85c1cc2814d">

# Testing instructions
Open the app, click on a doc and check out their email!