### PR TITLE
Migrate formatting rules for ESlint and StyleLint.

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -7,29 +7,14 @@
         "stylelint-order"
     ],
     "rules": {
-        "block-closing-brace-newline-before": "always-multi-line",
         "color-hex-length": "short",
         "color-named": "never",
         "comment-empty-line-before": null,
         "declaration-no-important": true,
-        "declaration-block-trailing-semicolon": "always",
-        "indentation": 2,
         "length-zero-no-unit": null,
-        "max-line-length": 100,
         "max-nesting-depth": 4,
         "no-descending-specificity": null,
-        "no-eol-whitespace": [
-            true,
-            {
-                "ignore": [
-                    "empty-lines"
-                ]
-            }
-        ],
         "shorthand-property-no-redundant-values": null,
-        "selector-list-comma-newline-after": "always-multi-line",
-        "string-quotes": "single",
-        "value-list-comma-newline-after": "always-multi-line",
         "scss/at-rule-no-unknown": [
             true,
             {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,21 +1,23 @@
-import globals from 'globals'
-import tsPlugin from '@typescript-eslint/eslint-plugin'
-import tsParser from '@typescript-eslint/parser'
-import vuePlugin from 'vue-eslint-parser'
-import eslintJsPlugin from '@eslint/js'
+import globals from 'globals';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+import vuePlugin from 'vue-eslint-parser';
+import eslintJsPlugin from '@eslint/js';
+import stylistic from '@stylistic/eslint-plugin';
 
-const gqlSchemaPath = '././typeDefs/schema.graphql'
+const gqlSchemaPath = '././typeDefs/schema.graphql';
 
 export default [
     // GLOBAL configuration
     {
-        ignores: ['dist/*',
+        ignores: [
+            'dist/*',
             'output/*',
             '.nuxt/*',
             'coverage/*',
             'cypress/videos/*',
             '.yarn/*'
-        ]
+        ],
     },
     // Typescript and JS Linter combined (for all the main code files)
     {
@@ -26,22 +28,17 @@ export default [
             // },
             globals: {
                 ...globals.node,
-                ...globals.es2021
+                ...globals.es2021,
             }
         },
-        files: [
-            '__tests__/**/*.ts',
-            './**/*.{js,ts,vue}',
-        ],
+        files: ['__tests__/**/*.ts', './**/*.{js,ts,vue}'],
         plugins: {
             '@typescript-eslint': tsPlugin,
             tsPlugin,
-            vuePlugin
+            vuePlugin,
+            '@stylistic': stylistic,
         },
-        ignores: [
-            './typeDefs/gqlTypes.ts',
-            './typesgeneratorconfig.ts',
-        ],
+        ignores: ['./typeDefs/gqlTypes.ts', './typesgeneratorconfig.ts'],
         // 'off' or 0 - turn the rule off
         // 'warn' or 1 - turn the rule on as a warning (doesn’t affect exit code)
         // 'error' or 2 - turn the rule on as an error (exit code will be 1)
@@ -65,25 +62,35 @@ export default [
             'no-alert': 'error',
             'no-multi-spaces': 'error',
             'no-redeclare': 'error',
-            'no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
+            'no-unused-expressions': [
+                'error',
+                { allowShortCircuit: true, allowTernary: true },
+            ],
             'vars-on-top': 'off',
             yoda: ['error', 'never', { exceptRange: true }],
             'no-console': 'error', // we should use the logger instead
 
             // Stylistic Issues and Opinions
             'arrow-body-style': 'error',
-            'array-bracket-spacing': ['error', 'never'],
-            'arrow-parens': ['error', 'as-needed'],
-            'arrow-spacing': 'error',
-            'block-spacing': ['error', 'always'],
-            'brace-style': ['error', '1tbs', { allowSingleLine: true }],
+            '@stylistic/array-bracket-spacing': ['error', 'never'],
+            '@stylistic/arrow-parens': ['error', 'as-needed'],
+            '@stylistic/arrow-spacing': 'error',
+            '@stylistic/block-spacing': ['error', 'always'],
+            '@stylistic/brace-style': [
+                'error',
+                '1tbs',
+                { allowSingleLine: true },
+            ],
             camelcase: ['error', { allow: ['639_3'] }],
-            'comma-dangle': ['error', 'never'],
-            'comma-spacing': ['error', { before: false, after: true }],
-            'comma-style': 'error',
-            'computed-property-spacing': ['error', 'never'],
-            'function-paren-newline': ['error', 'consistent'],
-            indent: [
+            '@stylistic/comma-dangle': ['error', 'never'],
+            '@stylistic/comma-spacing': [
+                'error',
+                { before: false, after: true },
+            ],
+            '@stylistic/comma-style': 'error',
+            '@stylistic/computed-property-spacing': ['error', 'never'],
+            '@stylistic/function-paren-newline': ['error', 'consistent'],
+            '@stylistic/indent': [
                 'error',
                 4,
                 {
@@ -93,46 +100,58 @@ export default [
                     ObjectExpression: 1,
                     FunctionDeclaration: { parameters: 'off' },
                     VariableDeclarator: { var: 2, let: 2, const: 3 },
-                    CallExpression: { arguments: 'first' }
-                }
+                    CallExpression: { arguments: 'first' },
+                },
             ],
-            'key-spacing': ['error', { beforeColon: false, afterColon: true }],
-            'keyword-spacing': ['error', { before: true, after: true }],
-            'linebreak-style': ['error', 'unix'], // no carriage returns
-            'max-len': ['error', {
-                code: 130,
-                ignoreComments: true,
-                ignoreTrailingComments: true,
-                ignoreUrls: true,
-                ignoreStrings: true,
-                ignoreTemplateLiterals: true,
-                ignoreRegExpLiterals: true
-            }], // be friendly to laptops
-            'padding-line-between-statements': 'off', //we can choose newlines after variable declarations
+            '@stylistic/key-spacing': [
+                'error',
+                { beforeColon: false, afterColon: true },
+            ],
+            '@stylistic/keyword-spacing': ['error', { before: true, after: true }],
+            '@stylistic/linebreak-style': ['error', 'unix'], // no carriage returns
+            '@stylistic/max-len': [
+                'error',
+                {
+                    code: 130,
+                    ignoreComments: true,
+                    ignoreTrailingComments: true,
+                    ignoreUrls: true,
+                    ignoreStrings: true,
+                    ignoreTemplateLiterals: true,
+                    ignoreRegExpLiterals: true,
+                },
+            ], // be friendly to laptops
+            '@stylistic/padding-line-between-statements': 'off', //we can choose newlines after variable declarations
             'require-atomic-updates': 'warn',
             'no-constant-condition': 'error',
             'no-dupe-class-members': 'error',
             'no-lonely-if': 'error',
-            'no-multiple-empty-lines': ['error', { max: 1, maxEOF: 1 }],
+            '@stylistic/no-multiple-empty-lines': ['error', { max: 1, maxEOF: 1 }],
             'no-underscore-dangle': 'error',
             'no-var': 'error',
-            'object-curly-newline': ['error', { consistent: true }],
-            'object-property-newline': ['error', { allowAllPropertiesOnSameLine: true }],
+            '@stylistic/object-curly-newline': ['error', { consistent: true }],
+            '@stylistic/object-property-newline': [
+                'error',
+                { allowAllPropertiesOnSameLine: true },
+            ],
             'object-shorthand': ['error', 'methods'],
-            'operator-linebreak': [0, 'before'],
-            'padded-blocks': ['error', 'never'],
+            '@stylistic/operator-linebreak': [0, 'before'],
+            '@stylistic/padded-blocks': ['error', 'never'],
             'prefer-arrow-callback': 'error',
             'prefer-const': 'error',
             'prefer-spread': 'error',
             'prefer-template': 'error',
-            'quote-props': ['error', 'as-needed'],
-            quotes: ['error', 'single', 'avoid-escape'],
-            semi: ['error', 'never'],
-            'semi-spacing': 'error',
-            'space-before-blocks': 'error',
-            'space-before-function-paren': ['error', { anonymous: 'never', named: 'never', asyncArrow: 'always' }],
-            'space-in-parens': 'error',
-            'space-infix-ops': 'error'
-        }
-    }
-]
+            '@stylistic/quote-props': ['error', 'as-needed'],
+            '@stylistic/quotes': ['error', 'single', 'avoid-escape'],
+            '@stylistic/semi': ['error', 'never'],
+            '@stylistic/semi-spacing': 'error',
+            '@stylistic/space-before-blocks': 'error',
+            '@stylistic/space-before-function-paren': [
+                'error',
+                { anonymous: 'never', named: 'never', asyncArrow: 'always' },
+            ],
+            '@stylistic/space-in-parens': 'error',
+            '@stylistic/space-infix-ops': 'error',
+        },
+    },
+];

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@microsoft/eslint-formatter-sarif": "^3.0.0",
         "@nuxt/types": "^2.17.2",
         "@nuxtjs/i18n": "next",
+        "@stylistic/eslint-plugin": "^1.6.0",
         "@swc/core": "^1.3.100",
         "@testing-library/vue": "^6.6.1",
         "@typescript-eslint/eslint-plugin": "^6.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4189,6 +4189,70 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@stylistic/eslint-plugin-js@npm:1.6.0, @stylistic/eslint-plugin-js@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@stylistic/eslint-plugin-js@npm:1.6.0"
+  dependencies:
+    acorn: "npm:^8.11.3"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-visitor-keys: "npm:^3.4.3"
+    espree: "npm:^10.0.0"
+  peerDependencies:
+    eslint: ">=8.40.0"
+  checksum: 80f97203907080ab5049d4bcafc54d8618e73a6bef9464ccb93b4c90d9ab9cdb1973b91a919cefec72316daca5f52755b39d58d24f9ff09bf814cfe6af0e2040
+  languageName: node
+  linkType: hard
+
+"@stylistic/eslint-plugin-jsx@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@stylistic/eslint-plugin-jsx@npm:1.6.0"
+  dependencies:
+    "@stylistic/eslint-plugin-js": "npm:^1.6.0"
+    estraverse: "npm:^5.3.0"
+    picomatch: "npm:^3.0.1"
+  peerDependencies:
+    eslint: ">=8.40.0"
+  checksum: da0fae77f70641456f93ad2644bb6a321cd7fe4d4768216d1b96f5f81a1fbb424d8e1f4e41ece9907da050d490827de64a057461a5ae2afca8c3a2e70d3c7fda
+  languageName: node
+  linkType: hard
+
+"@stylistic/eslint-plugin-plus@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@stylistic/eslint-plugin-plus@npm:1.6.0"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^6.20.0"
+  peerDependencies:
+    eslint: "*"
+  checksum: 781c1574285ce32452c74cbf6d6d0bc861f479f5e142d27ab38d5852edde19984734e086f513d80f2e0d0e6a32ee49c6fe5ff54e877a226f4b8a4687c0f9e9fc
+  languageName: node
+  linkType: hard
+
+"@stylistic/eslint-plugin-ts@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@stylistic/eslint-plugin-ts@npm:1.6.0"
+  dependencies:
+    "@stylistic/eslint-plugin-js": "npm:1.6.0"
+    "@typescript-eslint/utils": "npm:^6.20.0"
+  peerDependencies:
+    eslint: ">=8.40.0"
+  checksum: 45bf901ac5ec798837009fc6834470ef42dc0dca3d5eb5dc6aafe95061a4d8c4ba8c1971e40e8d5b8adc4721baf44e1e21c419d25c138102158295f5b41a9bfd
+  languageName: node
+  linkType: hard
+
+"@stylistic/eslint-plugin@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@stylistic/eslint-plugin@npm:1.6.0"
+  dependencies:
+    "@stylistic/eslint-plugin-js": "npm:1.6.0"
+    "@stylistic/eslint-plugin-jsx": "npm:1.6.0"
+    "@stylistic/eslint-plugin-plus": "npm:1.6.0"
+    "@stylistic/eslint-plugin-ts": "npm:1.6.0"
+  peerDependencies:
+    eslint: ">=8.40.0"
+  checksum: d35deeb3e9e319395f89ac2200dfd18536af5cc1f949ace74b687b0c87ed1e4541555cbde8b6e6cfe72f1e45c4ffa6a95da8a194969cf9f3375b53946d9ab06f
+  languageName: node
+  linkType: hard
+
 "@swc/core-darwin-arm64@npm:1.3.100":
   version: 1.3.100
   resolution: "@swc/core-darwin-arm64@npm:1.3.100"
@@ -4933,6 +4997,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/visitor-keys": "npm:6.21.0"
+  checksum: fe91ac52ca8e09356a71dc1a2f2c326480f3cccfec6b2b6d9154c1a90651ab8ea270b07c67df5678956c3bbf0bbe7113ab68f68f21b20912ea528b1214197395
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:6.13.2":
   version: 6.13.2
   resolution: "@typescript-eslint/type-utils@npm:6.13.2"
@@ -4957,6 +5031,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/types@npm:6.21.0"
+  checksum: e26da86d6f36ca5b6ef6322619f8ec55aabcd7d43c840c977ae13ae2c964c3091fc92eb33730d8be08927c9de38466c5323e78bfb270a9ff1d3611fe821046c5
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:6.13.2":
   version: 6.13.2
   resolution: "@typescript-eslint/typescript-estree@npm:6.13.2"
@@ -4972,6 +5053,25 @@ __metadata:
     typescript:
       optional: true
   checksum: 8fa1344228858fa8171a9660e11eb0d5ed88de2ada343bce4a02a957724ccbeb9b67da1083eada29247f444aeba6908a4145d1758b528d320928abbb4e48dca7
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/visitor-keys": "npm:6.21.0"
+    debug: "npm:^4.3.4"
+    globby: "npm:^11.1.0"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:9.0.3"
+    semver: "npm:^7.5.4"
+    ts-api-utils: "npm:^1.0.1"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: b32fa35fca2a229e0f5f06793e5359ff9269f63e9705e858df95d55ca2cd7fdb5b3e75b284095a992c48c5fc46a1431a1a4b6747ede2dd08929dc1cbacc589b8
   languageName: node
   linkType: hard
 
@@ -4992,6 +5092,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^6.20.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/utils@npm:6.21.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@types/json-schema": "npm:^7.0.12"
+    "@types/semver": "npm:^7.5.0"
+    "@typescript-eslint/scope-manager": "npm:6.21.0"
+    "@typescript-eslint/types": "npm:6.21.0"
+    "@typescript-eslint/typescript-estree": "npm:6.21.0"
+    semver: "npm:^7.5.4"
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: b404a2c55a425a79d054346ae123087d30c7ecf7ed7abcf680c47bf70c1de4fabadc63434f3f460b2fa63df76bc9e4a0b9fa2383bb8a9fcd62733fb5c4e4f3e3
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:6.13.2":
   version: 6.13.2
   resolution: "@typescript-eslint/visitor-keys@npm:6.13.2"
@@ -4999,6 +5116,16 @@ __metadata:
     "@typescript-eslint/types": "npm:6.13.2"
     eslint-visitor-keys: "npm:^3.4.1"
   checksum: eb6f3a3fa4dae6003533eac41bd2a8181a0353f352640e92b619e353b4bd5a5cd4c076018cbdf4b1ba45b826be0c1d15293d87e956fc9a8aa2fb8d8aa04a7c98
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:6.21.0"
+    eslint-visitor-keys: "npm:^3.4.1"
+  checksum: 30422cdc1e2ffad203df40351a031254b272f9c6f2b7e02e9bfa39e3fc2c7b1c6130333b0057412968deda17a3a68a578a78929a8139c6acef44d9d841dc72e1
   languageName: node
   linkType: hard
 
@@ -5839,6 +5966,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: ff559b891382ad4cd34cc3c493511d0a7075a51f5f9f02a03440e92be3705679367238338566c5fbd3521ecadd565d29301bc8e16cb48379206bffbff3d72500
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.11.3":
+  version: 8.11.3
+  resolution: "acorn@npm:8.11.3"
+  bin:
+    acorn: bin/acorn
+  checksum: b688e7e3c64d9bfb17b596e1b35e4da9d50553713b3b3630cf5690f2b023a84eac90c56851e6912b483fe60e8b4ea28b254c07e92f17ef83d72d78745a8352dd
   languageName: node
   linkType: hard
 
@@ -8820,6 +8956,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"espree@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "espree@npm:10.0.0"
+  dependencies:
+    acorn: "npm:^8.11.3"
+    acorn-jsx: "npm:^5.3.2"
+    eslint-visitor-keys: "npm:^3.4.1"
+  checksum: f577b624888b3dabec909d05669526c9ee7fae67374cb116f185b75b682ebfdd0dfc19b17fd9ce7fb954e30023b2eacfc96a310bea4e286fafff3983e2e7d48f
+  languageName: node
+  linkType: hard
+
 "espree@npm:^9.0.0, espree@npm:^9.6.0, espree@npm:^9.6.1":
   version: 9.6.1
   resolution: "espree@npm:9.6.1"
@@ -8897,7 +9044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estraverse@npm:^5.1.0, estraverse@npm:^5.2.0":
+"estraverse@npm:^5.1.0, estraverse@npm:^5.2.0, estraverse@npm:^5.3.0":
   version: 5.3.0
   resolution: "estraverse@npm:5.3.0"
   checksum: 37cbe6e9a68014d34dbdc039f90d0baf72436809d02edffcc06ba3c2a12eb298048f877511353b130153e532aac8d68ba78430c0dd2f44806ebc7c014b01585e
@@ -9358,6 +9505,7 @@ __metadata:
     "@nuxt/types": "npm:^2.17.2"
     "@nuxtjs/i18n": "npm:next"
     "@pinia/nuxt": "npm:^0.5.1"
+    "@stylistic/eslint-plugin": "npm:^1.6.0"
     "@swc/core": "npm:^1.3.100"
     "@testing-library/vue": "npm:^6.6.1"
     "@typescript-eslint/eslint-plugin": "npm:^6.13.2"
@@ -12314,6 +12462,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:9.0.3, minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "minimatch@npm:9.0.3"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: c81b47d28153e77521877649f4bab48348d10938df9e8147a58111fe00ef89559a2938de9f6632910c4f7bf7bb5cd81191a546167e58d357f0cfb1e18cecc1c5
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -12329,15 +12486,6 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^2.0.1"
   checksum: 3bcc271af1e5e95260fb9acd859628db9567a27ff1fe45b42fcf9b37f17dddbc5a23a614108755a6e076a5109969cabdc0b266ae6929fab12e679ec0f07f65ec
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: c81b47d28153e77521877649f4bab48348d10938df9e8147a58111fe00ef89559a2938de9f6632910c4f7bf7bb5cd81191a546167e58d357f0cfb1e18cecc1c5
   languageName: node
   linkType: hard
 
@@ -13769,6 +13917,13 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 60c2595003b05e4535394d1da94850f5372c9427ca4413b71210f437f7b2ca091dbd611c45e8b37d10036fa8eade25c1b8951654f9d3973bfa66a2ff4d3b08bc
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "picomatch@npm:3.0.1"
+  checksum: 65ac837fedbd0640586f7c214f6c7481e1e12f41cdcd22a95eb6a2914d1773707ed0f0b5bd2d1e39b5ec7860b43a4c9150152332a3884cd8dd1d419b2a2fa5b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #378 

# What changed

1. I have added the Stylistic plugin to our ESlint config file, and used it to implement our formatting rules.
2. I have removed the formatting rules in our Stylelint config file.

ESlint and StyleLint have deprecated there formatting rules. At the moment I don't have a solution yet for the formatting rules in StyleLint, I need to do some more research.

Here you find the deprecated formatting rules for StyleLint: https://stylelint.io/migration-guide/to-15/
Here you find the deprecated formatting rules for ESlint: https://eslint.org/blog/2023/10/deprecating-formatting-rules/
