### PR TITLE
fix: update build and start commands for cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,25 +1,25 @@
-name: 'Tests: Cypress e2e'
+name: "Tests: Cypress e2e"
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
-  schedule:
-    - cron: '45 15 * * 4'
+    push:
+        branches: ["main"]
+    pull_request:
+        # The branches below must be a subset of the branches above
+        branches: ["main"]
+    schedule:
+        - cron: "45 15 * * 4"
 
 jobs:
-  cypress-run:
-    name: Running Cypress tests ✨
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      # Install yarn dependencies, cache them correctly
-      # and run all Cypress tests
-      - name: Cypress run
-        uses: cypress-io/github-action@v5.6.1
-        with:
-          build: yarn build
-          start: yarn start
+    cypress-run:
+        name: Running Cypress tests ✨
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+            # Install yarn dependencies, cache them correctly
+            # and run all Cypress tests
+            - name: Cypress run
+              uses: cypress-io/github-action@v5.6.1
+              with:
+                  build: yarn prod:build
+                  start: yarn prod:start


### PR DESCRIPTION
# What changed

Prior to this PR, the GitHub CI was failing to run the Cypress tests, because the workflow was looking for a command we no longer use. It was returning an error such as the following:

```
Usage Error: Couldn't find a script named "build".

$ yarn run [--inspect] [--inspect-brk] [-T,--top-level] [-B,--binaries-only] [--require #0] <scriptName> ...
Error: The process '/usr/local/bin/yarn' failed with exit code 1
```

# Testing instructions
Click the "Details" button for the Cypress e2e tests in the GitHub CI. Confirm that the tests are being ran instead of seeing the error message above.
