### PR TITLE
chore: remove start:test script that is no longer used

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "prod:build": "yarn && yarn generate && nuxi generate",
         "prod:start": "nuxi start",
         "prepare:ci": "nuxi prepare",
-        "start:test": "start-server-and-test 'yarn start' 3000 'yarn test:e2e'",
         "test:pinia": "vitest",
         "test:pinia:coverage": "vitest run --coverage",
         "test:e2e": "cypress run --e2e --browser chrome"


### PR DESCRIPTION
# What changed
Removes the `yarn start:test` script that is no longer used to run tests.
