### PR TITLE
fix: add test for modal store to fix failing vitest workflow

### DIFF
--- a/test/functional/modalStore.spec.ts
+++ b/test/functional/modalStore.spec.ts
@@ -1,0 +1,28 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { useModalStore } from '@/stores/modalStore';
+import { expect } from 'chai';
+
+describe('ModalStore', () => {
+
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    });
+
+    it('should initialize with default values', () => {
+        const modalStore = useModalStore()
+        expect(modalStore.isOpen).to.be.false;
+    });
+
+    it('should update isOpen when showModal is called', () => {
+        const modalStore = useModalStore()
+        modalStore.showModal();
+        expect(modalStore.isOpen).to.be.true;
+    });
+
+    it('should update isOpen when hideModal is called', () => {
+        const modalStore = useModalStore()
+        modalStore.showModal();
+        modalStore.hideModal();
+        expect(modalStore.isOpen).to.be.false;
+    });
+});


### PR DESCRIPTION
Prior to this change the Vitest/Pinia workflow was failing because there weren't any tests to run. This change introduces a test for the workflow to execute and no longer fail.
