### PR TITLE
chore: add PR limit and reviewers to renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,11 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:base"
-    ],
+    "extends": ["config:base"],
     "labels": ["dependencies"],
     "schedule": ["after 10am every monday"],
     "stabilityDays": 14,
+    "prConcurrentLimit": 3,
+    "reviewers": ["team:admins"],
     "packageRules": [
         {
             "matchPackagePatterns": ["^eslint"],


### PR DESCRIPTION
# What changed

This change limits the number of PRs Renovate bot can open to 3. This should greatly reduce the number of open PRs we have at a given time.

It also sets the admin team members as the reviewers that the bot should tag.

