### PR TITLE
test: add tests for loadingStore

### DIFF
--- a/test/functional/loadingStore.spec.ts
+++ b/test/functional/loadingStore.spec.ts
@@ -12,5 +12,16 @@ describe('LoadingStore', () => {
         const loadingStore = useLoadingStore()
         expect(loadingStore.isLoading).to.be.false;
     });
+
+    it('should update isLoading with the boolean passed to setIsLoading', () => {
+        const loadingStore = useLoadingStore()
+
+        loadingStore.setIsLoading(true);
+        expect(loadingStore.isLoading).to.be.true;
+
+        loadingStore.setIsLoading(false);
+        expect(loadingStore.isLoading).to.be.false;
+
+    });
 })
 

--- a/test/functional/loadingStore.spec.ts
+++ b/test/functional/loadingStore.spec.ts
@@ -1,0 +1,16 @@
+import { setActivePinia, createPinia } from "pinia";
+import { useLoadingStore } from "@/stores/loadingStore";
+import { expect } from "chai";
+
+describe('LoadingStore', () => {
+
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    });
+
+    it('should initialize with default values', () => {
+        const loadingStore = useLoadingStore()
+        expect(loadingStore.isLoading).to.be.false;
+    });
+})
+


### PR DESCRIPTION
Part of #395 

## 🔧 What changed
This PR adds Pinia tests to test the functionality of the loadingStore.

## 🧪 Testing instructions
Run `yarn test:pinia` and confirm that the loadingStore tests pass.
