### PR TITLE
Add tests for localeStore

### DIFF
--- a/test/functional/localStore.spec.ts
+++ b/test/functional/localStore.spec.ts
@@ -17,7 +17,7 @@ describe("LocalStore", () => {
         expect(localStore.locale.displayText).to.equal('English (US)')
     })
 
-    it('should update locale when new locale is passed in setLocalethe', () => {
+    it('should update locale when new locale is passed in setLocale', () => {
         const localStore = useLocaleStore()
         localStore.setLocale(Locale.JaJp)
 

--- a/test/functional/localStore.spec.ts
+++ b/test/functional/localStore.spec.ts
@@ -1,0 +1,28 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { useLocaleStore } from '@/stores/localeStore'
+import { Locale } from '~/typedefs/gqlTypes.js'
+import { expect } from 'chai'
+
+describe("LocalStore", () => {
+
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    });
+
+    it('should initialize with default values', () => {
+        const localStore = useLocaleStore()
+
+        expect(localStore.locale.code).to.equal(Locale.EnUs)
+        expect(localStore.locale.simpleText).to.equal('English')
+        expect(localStore.locale.displayText).to.equal('English (US)')
+    })
+
+    it('should update locale when new locale is passed in setLocalethe', () => {
+        const localStore = useLocaleStore()
+        localStore.setLocale(Locale.JaJp)
+
+        expect(localStore.locale.code).to.equal(Locale.JaJp)
+        expect(localStore.locale.simpleText).to.equal('日本語')
+        expect(localStore.locale.displayText).to.equal('日本語 (Japan)')
+    })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,9 @@ export default defineConfig({
     },
     resolve: {
         alias: {
-            '@': path.resolve(__dirname, '.')
+            '@': path.resolve(__dirname, '.'),
+            '~': path.resolve(__dirname, '.')
+
         }
     },
     root: '.' //Define the root


### PR DESCRIPTION
Resolves #395 
## 🔧 What changed
- I have added the basic tests for `localeStore`
- I have added an extra path in the vitetest config file, so it could recognize `~`

## 🧪 Testing instructions
Run `yarn test:pinia`
## 📸 Screenshots

## To do
- Add testing for types?
