### PR TITLE
Add healthcare professional degrees to SearchResultDetails

### DIFF
--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -10,6 +10,9 @@
             <div class="result-header mt-7 ml-4">
                 <span class="w-4 text-3xl font-bold pl-2 self-center">{{
                     healthcareProfessionalName
+                }}, </span>
+                  <span class="w-4 text-2xl font-semibold pl-2 self-center">{{
+                    healthcareProfessionalDegrees
                 }}</span>
             </div>
             <div class="result-details flex flex-col mb-1 ml-4 pl-2 mt-2 text-sm">
@@ -96,6 +99,11 @@ const healthcareProfessionalName = computed(() => {
     return localeStore.locale.code === Locale.EnUs
         ? englishFullName
         : japaneseFullName
+})
+const healthcareProfessionalDegrees = computed(() => {
+    const healthcareProfessionalDegreesText =
+        resultsStore.$state.activeResult?.professional.degrees.join(", ")
+    return healthcareProfessionalDegreesText
 })
 const specialties = computed(() => {
     const specialties =

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -20,7 +20,8 @@
                 <div class="flex-1 h-24 w-6/8 border-b-2 border-primary/20 p-3
                     hover:border-transparent hover:bg-primary/5 transition-all hover:cursor-pointer">
                     <SearchResultsListItem
-                        :name="`${searchResult.professional.names[0].firstName}, ${searchResult.professional.names[0].lastName}`"
+                        :name="`${searchResult.professional.names[0].firstName} ${searchResult.professional.names[0].lastName}`"
+                        :degrees="searchResult.professional.degrees"
                         :facility-name="localeStore.locale?.code == Locale.EnUs ? searchResult.facilities[0]?.nameEn : searchResult.facilities[0]?.nameJa"
                         :specialties="searchResult.professional.specialties"
                         :spoken-languages="searchResult.professional.spokenLanguages" />

--- a/components/SearchResultsListItem.vue
+++ b/components/SearchResultsListItem.vue
@@ -4,7 +4,8 @@
             <svg role="img" alt="profile icon" title="profile icon" class="profile-icon w-8 h-8 stroke-primary inline">
                 <use xlink:href="../assets/images/profile-icon.svg#profile-icon-svg" class="w-[20px] h-[20px]" />
             </svg>
-            <span class="w-4 font-bold pl-2 self-center"> {{ name }} </span>
+            <span class="w-4 font-bold pl-2 self-center"> {{ name }}, </span>
+            <span class="w-4 pl-2 font-semibold self-center">{{ degrees.length === 1 ? degrees[0] : degrees[0] + ", ... +" + (degrees.length - 1).toString() }}</span>
         </div>
         <div class="result-details flex flex-col my-2 ml-4">
             <span class="px-2 text-primary font-medium">
@@ -40,6 +41,10 @@ const specialtiesStore = useSpecialtiesStore()
 const props = defineProps({
     name: {
         type: String,
+        required: true,
+    },
+    degrees: {
+        type: Array,
         required: true,
     },
     specialties: {


### PR DESCRIPTION
previously the degrees were not displayed anywhere on the SearchResults

Resolves #335 

## 🔧 What changed
- Before there were no degrees displayed in either the SearchResultsList or the the SearchResultDetails. 
- The first degree is show with an ellipsis and number of degrees that are not shown in the List.
- In the details, the full list of the doctor are shown.
- The unnecessary comma in the Romaji names was removed.

## 🧪 Testing instructions
- Currently there are no tests for this

## 📸 Screenshots

-   ### Before
<img width="252" alt="image" src="https://github.com/ourjapanlife/findadoc-web/assets/124335161/68e6f74c-829f-4e03-b291-44d3ae189354">
<img width="348" alt="image" src="https://github.com/ourjapanlife/findadoc-web/assets/124335161/4616003f-fe69-49ff-a041-4c50af146396">

-   ### After
<img width="246" alt="image" src="https://github.com/ourjapanlife/findadoc-web/assets/124335161/580dd856-d684-49d4-8a5b-02299b26bf3e">
<img width="352" alt="image" src="https://github.com/ourjapanlife/findadoc-web/assets/124335161/eebe00be-cdb2-4fc1-9ee3-72245bc01fd8">



## To Do
- Create tests for the changes in the components