### PR TITLE
Debug undefined name when name does not exist in locale language.

### DIFF
--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -94,11 +94,21 @@ const healthcareProfessionalName = computed(() => {
         resultsStore.$state.activeResult?.professional.names.find(
             (n) => n.locale === Locale.JaJp
         )
+  
     const englishFullName = `${englishName?.firstName} ${englishName?.lastName}`
     const japaneseFullName = `${japaneseName?.lastName} ${japaneseName?.firstName}`
-    return localeStore.locale.code === Locale.EnUs
-        ? englishFullName
-        : japaneseFullName
+
+    const isEnglishFullNameNotEmpty = englishFullName.length > 0
+    const isJapanseFullNameNotEmpty = japaneseFullName.length > 0
+
+    switch (localeStore.locale.code) {
+        case Locale.EnUs:
+            return isEnglishFullNameNotEmpty ? englishFullName : japaneseFullName
+        case Locale.JaJp:
+            return isJapanseFullNameNotEmpty ? japaneseFullName : englishFullName
+        default:
+            return isEnglishFullNameNotEmpty ? englishFullName : japaneseFullName
+    }
 })
 const healthcareProfessionalDegrees = computed(() => {
     const healthcareProfessionalDegreesText =

--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -98,16 +98,13 @@ const healthcareProfessionalName = computed(() => {
     const englishFullName = `${englishName?.firstName} ${englishName?.lastName}`
     const japaneseFullName = `${japaneseName?.lastName} ${japaneseName?.firstName}`
 
-    const isEnglishFullNameNotEmpty = englishFullName.length > 0
-    const isJapanseFullNameNotEmpty = japaneseFullName.length > 0
-
     switch (localeStore.locale.code) {
         case Locale.EnUs:
-            return isEnglishFullNameNotEmpty ? englishFullName : japaneseFullName
+            return englishFullName ? englishFullName : japaneseFullName
         case Locale.JaJp:
-            return isJapanseFullNameNotEmpty ? japaneseFullName : englishFullName
+            return japaneseFullName ? japaneseFullName : englishFullName
         default:
-            return isEnglishFullNameNotEmpty ? englishFullName : japaneseFullName
+            return englishFullName ? englishFullName : japaneseFullName
     }
 })
 const healthcareProfessionalDegrees = computed(() => {


### PR DESCRIPTION
Resolves #368 

## 📝 Description

Previously, if a professional's profile only contained a Japanese name (and vice versa) and the user switched the language locale to anything other than Japanese, the name would appear empty or undefined. Now it also shows a name when toggle to Swahili.

## 🔧 What changed

1. I have refactor the conditional statement, by using a switch case.

## 🧪 Testing instructions

Currently we actually don't have a professional that misses a English name or Japanese name. But if you want to test it please change the following  variables and toggle the locale:
```
    const englishFullName = undefined
    const japaneseFullName = `${japaneseName?.lastName} ${japaneseName?.firstName}`
```
