### PR TITLE
Change the husky install command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "prepare": "husky install",
+        "prepare": "husky",
         "dev": "yarn && nuxi dev",
         "generate": "graphql-codegen --config ./typesgeneratorconfig.ts",
         "lint": "ESLINT_USE_FLAT_CONFIG=true eslint . -c eslint.config.js && stylelint **/*.{vue,css,scss} --ignore-path .gitignore",


### PR DESCRIPTION
Resolves #437 

## 🔧 What changed

We were still using the old `husky install` command. I have updated the command to the version 9 command `husky`.

Documentation v9: https://github.com/typicode/husky/releases/tag/v9.0.1

## 🧪 Testing instructions

run `yarn prepare` should not get an error anymore.
