### PR TITLE
fix: disables telemetry on local dev

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -146,5 +146,6 @@ export default defineNuxtConfig({
             // eslint-disable-next-line
             GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY
         }
-    }
+    },
+    telemetry: false 
 })


### PR DESCRIPTION
## 🔧 What changed
This change fixes a nuxt error to do with telemetry opt-in that is preventing `yarn dev` from working. It will set the opt-in to no by default.
<img width="1000" alt="image" src="https://github.com/ourjapanlife/findadoc-web/assets/39023563/bc17baa8-e227-4eff-921a-e57405b17356">

