### PR TITLE
feat: add page for moderation panel

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -144,7 +144,9 @@ export default defineNuxtConfig({
     runtimeConfig: {
         public: {
             // eslint-disable-next-line
-            GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY
+            GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY,
+            // eslint-disable-next-line
+            ENABLE_MODERATION_PANEL: process.env.ENABLE_MODERATION_PANEL
         }
     },
     telemetry: false 

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -1,0 +1,13 @@
+<template>
+    <div v-if="enableModerationPanel" class="flex flex-col h-full">
+       Moderation Panel
+    </div>
+</template>
+
+<script setup lang="ts">
+import { useRuntimeConfig } from "#imports"
+
+const runtimeConfig = useRuntimeConfig();
+const enableModerationPanel = runtimeConfig.public.ENABLE_MODERATION_PANEL || false
+
+</script>


### PR DESCRIPTION
Resolves #461 

## 🔧 What changed
- Before there was no route for the moderation panel, but the route `/moderation` was added.
- It conditionally renders the page when `ENABLE_MODERATION_PANEL=true` is in `.env` file.

## 📸 Screenshots


-   ### After

![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/38a311ce-31c1-46f0-98bd-a45824155ab2)
