### PR TITLE
Add layout component for moderation panel

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,13 +1,21 @@
 <template>
-    <div class="h-full flex flex-col font-sans text-primary-text bg-primary-bg">
-        <TopNav />
-        <NuxtPage class="flex flex-1" />
-        <Footer />
+    <div>
+        <div v-if="store.enableModerationPanel" class="h-full flex flex-col font-sans text-primary-text bg-primary-bg">
+            <NuxtPage class="flex flex-1" />
+        </div>
+        <div v-else-if="!store.enableModerationPanel" class="h-full flex flex-col font-sans text-primary-text bg-primary-bg">
+            <TopNav />
+            <NuxtPage class="flex flex-1" />
+            <Footer />
+        </div>      
     </div>
 </template>
 
 <script setup lang="ts">
+import { useModerationScreenStore } from './stores/moderationScreenStore.js'
 import { initializeGqlClient } from './utils/graphql.js'
+
+const store = useModerationScreenStore()
 
 initializeGqlClient()
 </script>

--- a/components/ModLeftNavbar.vue
+++ b/components/ModLeftNavbar.vue
@@ -1,12 +1,18 @@
 <template>
-    <div class="border-r border-secondary-bg/40 hover:shadow-inner hover:shadow-secondary-bg/50 transition-shadow">
-        <div v-if="activeNavbar === 'modDashboardNavbar' ">if it is modDashboardNavbar</div>
-        <div v-else-if="activeNavbar === 'submissionNavbar'">If it is submissionNavbar</div>
-        <div v-else>Ahhhhh else</div>
+    <div class="w-64 p-4 border-r border-slate-300">
+        <div v-if="store.activeScreen === ModerationScreen.dashboard ">
+            <p class="text-xl font-bold">NAVBAR MODERATION DASHBOARD</p>
+        </div>
+        <div v-else-if="store.activeScreen === ModerationScreen.editSubmission">
+            <p class="text-xl font-bold">NAVBAR REVIEW SUBMISSION</p>
+        </div>
     </div>
 </template>
+
 <script setup lang="ts">
-import {ref} from 'vue'
-const activeNavbar = ref<String>('modDashboardNavbar')
+import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
+
+const store = useModerationScreenStore()
+
 </script>
 

--- a/components/ModLeftNavbar.vue
+++ b/components/ModLeftNavbar.vue
@@ -1,0 +1,12 @@
+<template>
+    <div class="border-r border-secondary-bg/40 hover:shadow-inner hover:shadow-secondary-bg/50 transition-shadow">
+        <div v-if="activeNavbar === 'modDashboardNavbar' ">if it is modDashboardNavbar</div>
+        <div v-else-if="activeNavbar === 'submissionNavbar'">If it is submissionNavbar</div>
+        <div v-else>Ahhhhh else</div>
+    </div>
+</template>
+<script setup lang="ts">
+import {ref} from 'vue'
+const activeNavbar = ref<String>('modDashboardNavbar')
+</script>
+

--- a/components/ModMainContent.vue
+++ b/components/ModMainContent.vue
@@ -1,0 +1,3 @@
+<template>
+    <div>MAIN Content container</div>
+</template>

--- a/components/ModMainContent.vue
+++ b/components/ModMainContent.vue
@@ -1,3 +1,17 @@
 <template>
-    <div>MAIN Content container</div>
+    <div class="h-full">
+        <div v-if="store.activeScreen === ModerationScreen.dashboard ">
+            <p class="text-xl font-bold">MAIN CONTAINER MODERATION DASHBOARD</p>
+        </div>
+        <div v-else-if="store.activeScreen === ModerationScreen.editSubmission">
+            <p class="text-xl font-bold">MAIN CONTAINER REVIEW SUBMISSION</p>
+        </div>
+    </div>
 </template>
+
+<script setup lang="ts">
+import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
+
+const store = useModerationScreenStore()
+
+</script>

--- a/components/ModTopbar.vue
+++ b/components/ModTopbar.vue
@@ -1,0 +1,3 @@
+<template>
+    <div>TOP BAR HERE</div>
+</template>

--- a/components/ModTopbar.vue
+++ b/components/ModTopbar.vue
@@ -1,3 +1,18 @@
 <template>
-    <div>TOP BAR HERE</div>
+    <!-- styling will change from px to rm -->
+    <div class="h-[76px] bg-emerald-100">
+        <div v-if="store.activeScreen === ModerationScreen.dashboard ">
+            <p class="text-xl font-bold">TOPBAR MODERATION DASHBOARD</p>
+        </div>
+        <div v-else-if="store.activeScreen === ModerationScreen.editSubmission">
+            <p class="text-xl font-bold">TOPBAR REVIEW SUBMISSION</p> 
+        </div>
+    </div>
 </template>
+
+<script setup lang="ts">
+import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
+
+const store = useModerationScreenStore()
+
+</script>

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -1,15 +1,17 @@
 <template>
-    <div v-if="enableModerationPanel" class="flex flex-col h-full">
+    <div v-if="store.enableModerationPanel" class="flex flex-row min-h-screen">
+        <!-- This button exists solely for testing that the states work and how you can implement it on other components. -->
+        <!-- <button @click="store.setActiveScreen(ModerationScreen.editSubmission)">Change state!</button> -->
        <ModLeftNavbar />
-       <ModTopbar />
-       <ModMainContent />
+       <div class="w-full flex flex-col items-stretch">
+            <ModTopbar />
+            <ModMainContent />
+       </div>
     </div>
 </template>
 
 <script setup lang="ts">
-import { useRuntimeConfig } from "#imports"
+import { useModerationScreenStore, ModerationScreen } from "~/stores/moderationScreenStore"
 
-const runtimeConfig = useRuntimeConfig();
-const enableModerationPanel = runtimeConfig.public.ENABLE_MODERATION_PANEL || false
-
+const store = useModerationScreenStore()
 </script>

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -1,6 +1,8 @@
 <template>
     <div v-if="enableModerationPanel" class="flex flex-col h-full">
-       Moderation Panel
+       <ModLeftNavbar />
+       <ModTopbar />
+       <ModMainContent />
     </div>
 </template>
 

--- a/stores/moderationScreenStore.ts
+++ b/stores/moderationScreenStore.ts
@@ -1,0 +1,18 @@
+import { defineStore } from 'pinia'
+import { Ref, ref } from 'vue'
+
+export enum ModerationScreen {
+    'dashboard',
+    'editSubmission'
+}
+
+export const useModerationScreenStore = defineStore('moderationScreenStore', () => {
+    const activeScreen: Ref<ModerationScreen> = ref(ModerationScreen.dashboard)
+    const enableModerationPanel: Ref<boolean> = ref(false)
+
+    function setActiveScreen(newValue: ModerationScreen) {
+        activeScreen.value = newValue
+    }
+
+    return { activeScreen, enableModerationPanel, setActiveScreen }
+})


### PR DESCRIPTION
Resolves #466 

## 🔧 What changed

In this PR we have created the layout for the components of the moderation panel.

- Create components for modTopBar, modMainContainer and modLeftNavbar
- Create store for managing the state for switching between our dashboard screen an review submission screen
- Create the basic layout by adding basic styling

## 📸 Screenshots

![image](https://github.com/ourjapanlife/findadoc-web/assets/114712265/4509356c-b639-4bc7-9672-dae5d39c7658)

