### PR TITLE
fix: add runtime config variable to store

### DIFF
--- a/stores/moderationScreenStore.ts
+++ b/stores/moderationScreenStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { Ref, ref } from 'vue'
+import { useRuntimeConfig } from "#imports"
 
 export enum ModerationScreen {
     'dashboard',
@@ -7,8 +8,9 @@ export enum ModerationScreen {
 }
 
 export const useModerationScreenStore = defineStore('moderationScreenStore', () => {
+    const runtimeConfig = useRuntimeConfig();
     const activeScreen: Ref<ModerationScreen> = ref(ModerationScreen.dashboard)
-    const enableModerationPanel: Ref<boolean> = ref(false)
+    const enableModerationPanel: Ref<boolean> = ref(runtimeConfig.public.ENABLE_MODERATION_PANEL || false)
 
     function setActiveScreen(newValue: ModerationScreen) {
         activeScreen.value = newValue


### PR DESCRIPTION
Resolves #471 

## 🔧 What changed

Before `enableModerationPanel` was hardcoded to false instead of checking the `env` file for the variable that sets it to true that allows us to see it in development.

## 📸 Screenshots

-   ### Before
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/0112eb18-0a42-4288-96d6-dad4ebe6c07c)


-   ### After

![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/bc166d4c-f127-4123-b722-d925d2be87cf)
