### PR TITLE
feat: implement main container for submission

### DIFF
--- a/components/ModMainContent.vue
+++ b/components/ModMainContent.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="h-full">
-        <div v-if="store.activeScreen === ModerationScreen.dashboard ">
-            <p class="text-xl font-bold">MAIN CONTAINER MODERATION DASHBOARD</p>
+        <div v-if="store.activeScreen === ModerationScreen.dashboard">
+            <ModSubmissionListContainer />
         </div>
         <div v-else-if="store.activeScreen === ModerationScreen.editSubmission">
             <p class="text-xl font-bold">MAIN CONTAINER REVIEW SUBMISSION</p>
@@ -11,6 +11,7 @@
 
 <script setup lang="ts">
 import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
+import ModSubmissionListContainer from './ModSubmissionListContainer.vue';
 
 const store = useModerationScreenStore()
 

--- a/components/ModSubmissionListContainer.vue
+++ b/components/ModSubmissionListContainer.vue
@@ -1,0 +1,40 @@
+<template>
+    <div :style="submissionListItemTableColumns" :class="`grid grid-cols-${submissionListItemHeaders.length} p-2`">
+        <div v-for="(submissionListItemHeader, index) in submissionListItemHeaders" :key="index"
+            class="font-bold text-left p-1">
+            {{ $t(submissionListItemHeader) }}
+        </div>
+
+        <!-- <div v-for="(fakeDatum, index) in fakeData" :key="index" class="grid grid-cols-subgrid col-span-5 bg-gray-200">
+            <span>{{ index + 1 }}</span>
+            <span>{{ $t(fakeDatum.Name) }}</span>
+            <span>{{ $t(fakeDatum.Status) }}</span>
+            <span>{{ $t(fakeDatum.Modified) }}</span>
+            <span>{{ $t(fakeDatum.Submitted) }}</span>
+        </div> -->
+
+    </div>
+
+</template>
+
+
+
+<script setup lang="ts">
+import { ref, Ref, computed } from 'vue';
+
+const submissionListItemHeaders: Ref<String[]> = ref(["#", "Name", "Status", "Modified", "Submitted"]);
+
+const submissionListItemTableColumns = computed(() => {
+    const numColumns = submissionListItemHeaders.value.length;
+    const defaultColumnWidth = 10;
+    const remainingWidth = 100 - defaultColumnWidth;
+    const columnWidth = remainingWidth / (numColumns - 1);
+    return `grid-template-columns: ${defaultColumnWidth}% repeat(${numColumns - 1}, ${columnWidth}%);`;
+});
+
+// const fakeData = [
+//     { "#": 1, "Name": "Name 1", "Status": "forReview", "Modified": "Modified 1", "Submitted": "Submitted 1" },
+//     { "#": 2, "Name": "Name 2", "Status": "accepted", "Modified": "Modified 2", "Submitted": "Submitted 2" },
+//     { "#": 3, "Name": "Name 3", "Status": "rejected", "Modified": "Modified 3", "Submitted": "Submitted 3" }
+// ];
+</script>


### PR DESCRIPTION
Resolves #455 

## 🔧 What changed
Before there was no main component for us to hold the submissions. This created a list component that can hold the data based on the state and will change what is displayed under the heading based on what is clicked in the dashboard. There is commented out code to show how it can be implemented in the future to use data to preview the data we want. We will set the data it is looping through based on the states in the sidebar component that in the future will run a function that can filter the data based on the states.
The grid system was chosen due to recommendations to avoid semantic tables from @ermish due to css problems that could arise.

## 📸 Screenshots

-   ### Before
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/1330d951-44c8-4dcf-94d0-3efb07881dc2)


-   ### After

![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/8c08b15c-08ac-46fa-95d3-46d1bd54e824)

![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/f536a5db-c05c-4530-a582-a44245b9b5aa)

