### PR TITLE
fix: add breakpoint to fix margins on mobile

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="flex h-full flex-col w-full">
-        <div class="flex flex-col items-center mx-32">
+        <div class="flex flex-col items-center mx-10 md:mx-32">
             <SvgHeartPlus role="img" alt="pink heart with a white plus in the middle to symbolize health" title="heart icon"
                 class="my-4 h-32" />
             <h1 data-testid="about-heading" class="mb-12 font-bold text-4xl">


### PR DESCRIPTION
Resolves #474 

## 🔧 What changed

This change will add a breakpoint for the margins so the About page is easier to read on mobile screens.

## 🧪 Testing instructions

Check the preview in mobile mode. I recommend previewing it with iPhone 12 settings.

## 📸 Screenshots

## Mobile
-   ### Before
![Screenshot 2024-05-25 at 6 23 12 PM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/54ea5aa4-f66d-463e-942d-044a15c5cfb4)

-   ### After
![Screenshot 2024-05-25 at 6 23 25 PM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/d48d0733-07e4-4297-87ec-d2e0d2f92770)

## Desktop
-   ### Before
![Screenshot 2024-05-25 at 6 23 41 PM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/d5d5f8ac-1c24-46ce-8a53-0687365f2e6e)


-   ### After
![Screenshot 2024-05-25 at 6 24 03 PM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/31ddb67f-de0e-4dfd-a748-95bc0b416517)
