### PR TITLE
fix: display facility data in romaji for non-JaJp locales

### DIFF
--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -148,16 +148,16 @@ const addressLine1 = computed(() => {
 
     const englishAddress = `${addressObj?.addressLine1En} ${addressObj?.addressLine2En}`
     const japaneseAddress = `${addressObj?.postalCode} ${addressObj?.prefectureJa}${addressObj?.cityJa}${addressObj?.addressLine1Ja}${addressObj?.addressLine2Ja}`
-    return localeStore.locale.code === Locale.EnUs
-        ? englishAddress
-        : japaneseAddress
+    return localeStore.locale.code === Locale.JaJp
+        ? japaneseAddress
+        : englishAddress
 })
 const addressLine2 = computed(() => {
     const addressObj =
         resultsStore.$state.activeResult?.facilities[0].contact.address
 
     const englishAddress = `${addressObj?.cityEn}, ${addressObj?.prefectureEn} ${addressObj?.postalCode}`
-    return localeStore.locale.code === Locale.EnUs ? englishAddress : ""
+    return localeStore.locale.code !== Locale.JaJp ? englishAddress : ""
 })
 const website = computed(
     () => resultsStore.$state.activeResult?.facilities[0]?.contact?.website

--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -124,7 +124,7 @@ const specialties = computed(() => {
 const facilityName = computed(() => {
     const englishName = resultsStore.$state.activeResult?.facilities[0].nameEn
     const japaneseName = resultsStore.$state.activeResult?.facilities[0].nameJa
-    return localeStore.locale.code === Locale.EnUs ? englishName : japaneseName
+    return localeStore.locale.code === Locale.JaJp ? japaneseName : englishName
 })
 
 const spokenLanguages = computed(() => {

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -22,7 +22,7 @@
                         <SearchResultsListItem
                             :name="`${searchResult.professional.names[0].firstName} ${searchResult.professional.names[0].lastName}`"
                             :degrees="searchResult.professional.degrees"
-                            :facility-name="localeStore.locale?.code == Locale.EnUs ? searchResult.facilities[0]?.nameEn : searchResult.facilities[0]?.nameJa"
+                            :facility-name="localeStore.locale.code == Locale.JaJp ? searchResult.facilities[0]?.nameJa : searchResult.facilities[0]?.nameEn"
                             :specialties="searchResult.professional.specialties"
                             :spoken-languages="searchResult.professional.spokenLanguages" />
                     </div>


### PR DESCRIPTION
## 🔧 What changed

This PR will change it so that facility names will be shown in romaji for locales other than Japanese. Currently, if someone selects Swahili from the dropdown button, it will show all of the details in English except for the facility name. English should be the default, because there's a high chance that users will be unable to read Japanese.

## 🧪 Testing instructions

Select Swahili from the dropdown menu and confirm the following:

1. The facility name is shown in romaji in the search results list
2. The facility name is shown in romaji in the search result details card

## 📸 Screenshots

-   ### Before
![Screenshot 2024-05-25 at 6 52 38 PM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/8925284a-df5d-41cb-aa53-d2dfd1de3aaa)


-   ### After
![Screenshot 2024-05-25 at 6 52 11 PM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/e4ea0ca0-bbb8-428f-ab67-367ad64325f1)

