### PR TITLE
fix: improve responsiveness and component visibility

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,22 +1,31 @@
 <template>
-    <div>
+    <!-- The main app should be set to h-screen. This is to ensure that the TopNav and Footer are
+        always visible on desktop screens without scrolling.
+    -->
+    <div class="h-screen w-full">
         <div v-if="store.enableModerationPanel" class="h-full flex flex-col font-sans text-primary-text bg-primary-bg">
             <NuxtPage class="flex flex-1" />
         </div>
-        <div v-else-if="!store.enableModerationPanel" class="h-full flex flex-col font-sans text-primary-text bg-primary-bg">
+        <div v-else-if="!store.enableModerationPanel && $viewport.isGreaterThan('desktop')" class="h-full w-full flex flex-col font-sans text-primary-text bg-primary-bg">
             <TopNav />
-            <NuxtPage class="flex flex-1" />
+            <NuxtPage />
             <Footer />
-        </div>      
+        </div>
+        <div v-else class="h-full w-full flex flex-col font-sans text-primary-text bg-primary-bg">
+            <TopNav />
+            <NuxtPage />
+        </div>
     </div>
 </template>
 
 <script setup lang="ts">
 import { useModerationScreenStore } from './stores/moderationScreenStore.js'
 import { initializeGqlClient } from './utils/graphql.js'
+import { useNuxtApp } from "#app";
+const { $viewport } = useNuxtApp();
+
 
 const store = useModerationScreenStore()
 
 initializeGqlClient()
 </script>
-./utils/graphql.js

--- a/components/HamburgerComponent.vue
+++ b/components/HamburgerComponent.vue
@@ -9,7 +9,7 @@
                     v-show="menuStore.menuOpen"
                     class="z-20 absolute top-[50px] w-[200px] p-8 rounded bg-white border-2">
                     <div
-                        v-for="(item, index) in menuStore.menuItems"
+                        v-for="(item, index) in menuStore.hamburgerMenuItems"
                         :key="index">
                         <NuxtLink :to="item.route">
                             <span

--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -4,12 +4,11 @@ import SearchResultDetails from './SearchResultDetails.vue';
     <div class="h-full w-full">
         <div id="landscape-content" v-if="$viewport.isGreaterThan('tablet')"
             class="bg-secondary-bg/20 hover:shadow-inner hover:shadow-secondary-bg/90 h-full w-full">
-            <!-- <WelcomeSection /> -->
             <Loader />
             <Modal v-show="store.$state.isOpen" class="min-h-1/2 ml-8 mt-12">
                 <SearchResultDetails />
             </Modal>
-            <div class="flex-1 h-screen">
+            <div class="flex-1 h-full">
                 <MapContainer />
             </div>
         </div>

--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -17,10 +17,10 @@ import SearchResultDetails from './SearchResultDetails.vue';
             <Modal v-show="store.$state.isOpen" class="min-h-1/2 ml-8 mt-12">
                 <SearchResultDetails />
             </Modal>
-            <div class="h-[50vh]">
+            <div class="h-1/2">
                 <MapContainer />
             </div>
-            <div class="min-h-[50vh]">
+            <div class="h-1/2 overflow-y-auto">
                 <SearchResultsList />
             </div>
         </div>

--- a/components/MapContainer.vue
+++ b/components/MapContainer.vue
@@ -1,17 +1,19 @@
 <template>
-    <GoogleMap data-testid="map-of-japan" ref="mapRef" :api-key="runtimeConfig.public.GOOGLE_MAPS_API_KEY"
-        map-id="153d718018a2577e" style="height: 100%; width: 100%;" :center="center" :zoom="9">
-        <CustomMarker @click="searchResultsStore.setActiveSearchResult(location.professional.id)" :options="{
-        position: {
-            lat: location.facilities[0]?.mapLatitude ?? defaultLocation.lat,
-            lng: location.facilities[0]?.mapLongitude ?? defaultLocation.lng
-        }
-    }" :key="index" v-for="(location, index) in searchResultsStore.searchResultsList">
-            <div style="text-align: center">
-                <SVGSVGBlueMapPin class="w-[45px] h-[73px]" />
-            </div>
-        </CustomMarker>
-    </GoogleMap>
+    <div class="h-full w-full">
+        <GoogleMap data-testid="map-of-japan" ref="mapRef" :api-key="runtimeConfig.public.GOOGLE_MAPS_API_KEY"
+            map-id="153d718018a2577e" class="h-full w-full" :center="center" :zoom="9">
+            <CustomMarker @click="searchResultsStore.setActiveSearchResult(location.professional.id)" :options="{
+            position: {
+                lat: location.facilities[0]?.mapLatitude ?? defaultLocation.lat,
+                lng: location.facilities[0]?.mapLongitude ?? defaultLocation.lng
+            }
+        }" :key="index" v-for="(location, index) in searchResultsStore.searchResultsList">
+                <div style="text-align: center">
+                    <SVGSVGBlueMapPin class="w-[45px] h-[73px]" />
+                </div>
+            </CustomMarker>
+        </GoogleMap>
+    </div>
 </template>
 
 <script setup lang="ts">

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         class="p-4 pl-8 border border-secondary-bg/20 flex justify-between items-center bg-gradient-to-t from-secondary-bg/30 via-primary-bg to-primary-bg">
-        <div v-if="$viewport.isGreaterThan('tablet')" class="flex items-center">
+        <div v-if="$viewport.isGreaterThan('desktop')" class="flex items-center">
             <div class="font-semibold text-xl group transition-colors items-start">
                 <NuxtLink class="flex" to="/">
                     <SVGSiteLogo role="img" title="site icon"
@@ -31,7 +31,6 @@
 
 <script lang="ts" setup>
 import SVGSiteLogo from '~/assets/icons/site-logo.svg'
-import { useSubmissionStore } from "~/stores/submissionStore"
 import { useMenuStore } from "~/stores/menuStore"
 import { useNuxtApp } from "#app"
 

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -77,5 +77,15 @@
         "about": "About",
         "home": "Home",
         "submit": "Add a Doctor"
+    },
+    "hamburgerMenu": {
+        "about": "About Find a Doc, Japan",
+        "home": "Home",
+        "contact": "Contact",
+        "submit": "Submit",
+        "privacy": "Privacy",
+        "terms": "Terms",
+        "github": "Github",
+        "netlify": "Powered by Netlify"
     }
 }

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="flex h-full flex-col w-full">
-        <div class="flex flex-col items-center mx-32">
+    <div class="overflow-y-auto w-full">
+        <div class="flex flex-col items-center px-10 md:px-32">
             <SvgHeartPlus role="img" alt="pink heart with a white plus in the middle to symbolize health" title="heart icon"
                 class="my-4 h-32" />
             <h1 data-testid="about-heading" class="mb-12 font-bold text-4xl">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,15 +1,11 @@
 <template>
-    <div class="flex flex-col h-full">
+    <div id="index" class="h-full w-full">
         <div v-if="$viewport.isGreaterThan('tablet')" class="flex h-full overflow-hidden">
             <LeftNavbar class="bg-primary-bg w-[358px]" />
             <MainContentContainer />
         </div>
-        <div v-else>
-            <div class="flex-1">
-                <div class="flex flex-col h-full">
-                    <MainContentContainer />
-                </div>
-            </div>
+        <div v-else class="h-full w-full">
+            <MainContentContainer />
         </div>
     </div>
 </template>

--- a/pages/privacypolicy.vue
+++ b/pages/privacypolicy.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col place-items-center mx-10">
+    <div class="overflow-y-auto w-full px-10 md:px-32">
         <div>
             <h1
                 class="mb-20 text-black text-5xl font-bold font-['Noto Sans JP']"

--- a/pages/submit.vue
+++ b/pages/submit.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col place-self-center mb-10">
+    <div class="flex flex-col h-full place-self-center overflow-y-auto">
         <SubmissionForm v-show="!store.submissionCompleted" />
         <SubmissionCompleted v-show="store.submissionCompleted" />
     </div>

--- a/pages/terms.vue
+++ b/pages/terms.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex flex-col place-items-center mx-10">
+    <div class="flex flex-col overflow-y-auto w-full px-10 md:px-32">
         <div>
             <h1
                 class="mb-20 text-black text-5xl font-bold font-['Noto Sans JP']"

--- a/stores/menuStore.ts
+++ b/stores/menuStore.ts
@@ -3,9 +3,34 @@ import { ref } from 'vue'
 
 export const useMenuStore = defineStore('menuStore', () => {
     const menuOpen = ref(false)
+    const hamburgerMenuItems = {
+        "about": { "displayText": "hamburgerMenu.about", "route": "/about" },
+        "home": { "displayText": "hamburgerMenu.home", "route": "/" },
+        "contact": {
+            "displayText": "hamburgerMenu.contact", "route": "https://forms.gle/4E763qfaq46kEsn99"
+        },
+        "submit": { "displayText": "hamburgerMenu.submit", "route": "/submit" },
+        "privacy": {
+            "displayText": "hamburgerMenu.privacy", "route": "/privacypolicy"
+
+        },
+        "terms": {
+            "displayText": "hamburgerMenu.terms", "route": "/terms"
+
+        },
+        "github": {
+            "displayText": "hamburgerMenu.github", "route": "https://github.com/ourjapanlife/findadoc-web/"
+
+        },
+        "netlify": {
+            "displayText": "hamburgerMenu.netlify", "route": "https://www.netlify.com/"
+
+        },
+    }
+
     const menuItems = {
-        "home": { "displayText": "topNav.home", "route": "/" },
         "about": { "displayText": "topNav.about", "route": "/about" },
+        "home": { "displayText": "topNav.home", "route": "/" },
         "submit": { "displayText": "topNav.submit", "route": "/submit" },
     }
 
@@ -14,6 +39,7 @@ export const useMenuStore = defineStore('menuStore', () => {
     }
 
     return {
+        hamburgerMenuItems,
         menuItems,
         menuOpen,
         toggleMenu


### PR DESCRIPTION
## 🔧 What changed

When a user is viewing the site on a desktop, the TopNav and Footer should always be visible without having to scroll. Meaning, the main content should be contained between them and be the only component that scrolls up and down.

This behavior wouldn't work that great on tablet and mobile screens due to their much smaller sizes. So, some adjustments were made to what items will be displayed depending on what screen size the user is using.

1. Makes the TopNav and Footer always visible on desktop
2. Makes the TopNav display the HamburgerComponent on screens smaller than desktop. This remedies the issue of menu items overlapping for sizes between tablets and desktop.
3. Creates separate menu items for the hamburger menu. Items that were previously included in the footer were moved here, but formatting will be needed to improve the UI/UX.
4. Improves the responsiveness of the map and search results list on screen sizes smaller than desktop.

## 🧪 Testing instructions
1. Check the preview and confirm that the TopNav and Footer are visible without scrolling on all pages on desktop.
2. Check the preview and confirm that the hamburger menu is visible and the footer is invisible on all pages for screens smaller than desktop.
3.  Check that the hamburger menu items include the Privacy, Terms, Github, and Netlify links.


## 📸 Demo Video

### Desktop
https://github.com/ourjapanlife/findadoc-web/assets/31802656/367f092b-227c-44ce-a865-64e093f63260

### Mobile
https://github.com/ourjapanlife/findadoc-web/assets/31802656/85278198-5eb0-4c2b-a1f1-5bbb5a4cec77





