### PR TITLE
fix: remove duplicate variable key breaking submit page

### DIFF
--- a/stores/submissionStore.ts
+++ b/stores/submissionStore.ts
@@ -32,9 +32,7 @@ export const useSubmissionStore = defineStore('submissionStore', () => {
         } satisfies CreateSubmissionInput
 
         await gqlClient.request<Submission>(createSubmissionMutation, {
-            variables: {
-                input: submission
-            }
+            input: submission
         })
 
         submissionCompleted.value = true


### PR DESCRIPTION
## 🔧 What changed

We removed the `variable` key from the input, because we noticed on the backend that it was creating an additional nested key for one that already exists.

## 🧪 Testing instructions
1. Run the backend dev db using `npm run dev:startlocaldb`
2. Run the backend dev server using `npm run dev`
3. Point the frontend endpoint to the backend server
4. Fill out the Submit form on the local frontend server and verify the payload that prints in the backend console.

## 📸 Screenshots
![Screenshot 2024-05-27 at 8 30 13 PM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/765268f8-f801-48ba-9deb-7b17fe1cb6f6)
