### PR TITLE
feat: add conditional for local server endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "scripts": {
         "prepare": "husky",
-        "dev": "yarn && nuxi dev",
+        "dev": "NODE_ENV=development yarn && nuxi dev",
         "generate": "graphql-codegen --config ./typesgeneratorconfig.ts",
         "lint": "ESLINT_USE_FLAT_CONFIG=true eslint . -c eslint.config.js && stylelint **/*.{vue,css,scss} --ignore-path .gitignore",
         "lint:ci": "eslint . --config eslint.config.js --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",

--- a/utils/graphql.ts
+++ b/utils/graphql.ts
@@ -1,24 +1,32 @@
-import { GraphQLClient } from "graphql-request"
+import { GraphQLClient } from "graphql-request";
 
-export let gqlClient: GraphQLClient;
+export let gqlClient: GraphQLClient
 
 export const initializeGqlClient = () => {
     if (gqlClient) {
         return gqlClient
     }
 
-    const endpoint = "https://api.findadoc.jp"
-    const client = new GraphQLClient(endpoint)
+    let apiURL
+
+    if (process.env.NODE_ENV == 'development') {
+        apiURL = "http://127.0.0.1:4000"
+
+    } else {
+        apiURL = "https://api.findadoc.jp"
+    }
+
+    const client = new GraphQLClient(apiURL)
     gqlClient = client
 };
 
 export interface gqlMutation<T> extends gqlRequest {
     variables: {
         input: T
-    }
+    };
 }
 
 export interface gqlRequest {
-    query: string
+    query: string;
     variables: unknown
 }


### PR DESCRIPTION
## 🔧 What changed
This adds a new command to the package.json that can be used to connect the FE to findadoc-server when a dev is running it locally.

## 🧪 Testing instructions
1. Follow the steps in the findadoc-server repo to start the Firebase database and backend server locally.
2. Start the frontend server using the `yarn dev:localdb` command.
3. Confirm that the FE displays data from the local database.