### PR TITLE
chore: wrap submit request in try catch

### DIFF
--- a/stores/submissionStore.ts
+++ b/stores/submissionStore.ts
@@ -31,11 +31,16 @@ export const useSubmissionStore = defineStore('submissionStore', () => {
             "notes": otherNotes.value
         } satisfies CreateSubmissionInput
 
-        await gqlClient.request<Submission>(createSubmissionMutation, {
-            input: submission
-        })
+        try {
+            await gqlClient.request<Submission>(createSubmissionMutation, {
+                input: submission
+            })
+            submissionCompleted.value = true
+        }
+        catch (e) {
+            console.error(`There was an error creating the submission ${e}`)
+        }
 
-        submissionCompleted.value = true
     }
 
     function resetForm() {
@@ -54,13 +59,5 @@ export const useSubmissionStore = defineStore('submissionStore', () => {
 const createSubmissionMutation = gql`mutation CreateSubmission($input: CreateSubmissionInput!) {
     createSubmission(input: $input) {
         id
-        googleMapsUrl
-        healthcareProfessionalName
-        spokenLanguages
-        isApproved
-        isRejected
-        isUnderReview
-        createdDate
-        updatedDate
     }
 }`


### PR DESCRIPTION
Part of #502 

## 🔧 What changed

Small PR that wraps the Submit request in a try/catch. Further changes are currently being made in #494 to add Cypress testing for the page. Validation will also be added in a separate PR.
