### PR TITLE
fix: change the old import to new style

### DIFF
--- a/components/ModDashboardLeftNavbar.vue
+++ b/components/ModDashboardLeftNavbar.vue
@@ -12,7 +12,7 @@
                 :class="{ 'border-b border-gray-300': index !== submissionListViewOptions.length - 1 }"
                 v-for="(submissionListEntry, index) in submissionListViewOptions ">
                 <div class="flex items-center justify-center w-1/5">
-                    <img :src="submissionListEntry.svgIcon" />
+                    <component :is="submissionListEntry.svgIcon" class="h-5" />
                 </div>
                 {{ $t(submissionListEntry.displayText) }} ({{ submissionListEntry.count }})
             </button>
@@ -22,9 +22,9 @@
 
 <script setup lang="ts">
 import { ref, Ref } from 'vue'
-import noteStackAddSvg from "../assets/icons/note-stack-add.svg"
-import checkBoxSvg from "../assets/icons/check-box.svg"
-import disabledByDefault from "../assets/icons/disabled-by-default.svg"
+import NoteStackAddSvg from "../assets/icons/note-stack-add.svg"
+import CheckBoxSvg from "../assets/icons/check-box.svg"
+import DisabledByDefault from "../assets/icons/disabled-by-default.svg"
 
 const modDashboardViewOptions = [{
     displayText: "Facilities",
@@ -38,19 +38,19 @@ const modDashboardViewOptions = [{
 const submissionListViewOptions = [{
     displayText: "For Review",
     value: "forReview",
-    svgIcon: noteStackAddSvg,
+    svgIcon: NoteStackAddSvg,
     count: 0,
 },
 {
     displayText: "Approved",
     value: "approved",
-    svgIcon: checkBoxSvg,
+    svgIcon: CheckBoxSvg,
     count: 0,
 },
 {
     displayText: "Rejected",
     value: "rejected",
-    svgIcon: disabledByDefault,
+    svgIcon: DisabledByDefault,
     count: 0,
 }]
 


### PR DESCRIPTION
## 🔧 What changed
The images were not appearing properly due to the change of the `svg` from img to component style. Updated to be the way we import the `svg` now

## 📸 Screenshots

-   ### Before
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/766d1c70-5792-4f47-aec3-eb06824082ce)


-   ### After
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/d4bc0cce-fe49-4646-8237-557e00ea556b)
