### PR TITLE
fix: change handling of mod store visibility to use path

### DIFF
--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -2,16 +2,21 @@
     <div v-if="store.enableModerationPanel" class="flex flex-row min-h-screen">
         <!-- This button exists solely for testing that the states work and how you can implement it on other components. -->
         <!-- <button @click="store.setActiveScreen(ModerationScreen.editSubmission)">Change state!</button> -->
-       <ModLeftNavbar />
-       <div class="w-full flex flex-col items-stretch">
+        <ModLeftNavbar />
+        <div class="w-full flex flex-col items-stretch">
             <ModTopbar />
             <ModMainContent />
-       </div>
+        </div>
     </div>
 </template>
 
 <script setup lang="ts">
 import { useModerationScreenStore, ModerationScreen } from "~/stores/moderationScreenStore"
+import { useRoute } from 'vue-router'
 
 const store = useModerationScreenStore()
+const route = useRoute()
+const currentPath = route.path.replace("/", "")
+
+store.setEnableModerationPanelToTrue(currentPath)
 </script>

--- a/stores/moderationScreenStore.ts
+++ b/stores/moderationScreenStore.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { Ref, ref } from 'vue'
-import { useRuntimeConfig } from "#imports"
 
 export enum ModerationScreen {
     'dashboard',
@@ -8,13 +7,16 @@ export enum ModerationScreen {
 }
 
 export const useModerationScreenStore = defineStore('moderationScreenStore', () => {
-    const runtimeConfig = useRuntimeConfig();
     const activeScreen: Ref<ModerationScreen> = ref(ModerationScreen.dashboard)
-    const enableModerationPanel: Ref<boolean> = ref(runtimeConfig.public.ENABLE_MODERATION_PANEL || false)
+    const enableModerationPanel: Ref<boolean> = ref(false)
 
     function setActiveScreen(newValue: ModerationScreen) {
         activeScreen.value = newValue
     }
 
-    return { activeScreen, enableModerationPanel, setActiveScreen }
+    function setEnableModerationPanelToTrue ( currentPath:string){  
+        process.env.ENABLE_MODERATION_PANEL && currentPath.includes("moderation") ? enableModerationPanel.value = true : null
+    }
+
+    return { activeScreen, enableModerationPanel, setActiveScreen, setEnableModerationPanelToTrue }
 })


### PR DESCRIPTION
## 🔧 What changed
Before we were handling the visibility of the route for  `/moderation` with only and environmental variable which is mocking the feature flag variable for now. This now conditionally handles the variable and the visibility of the route with not only the `env` variable being set to true, but if the `pathname` includes `moderation`. I implemented it this way in case we have nested routes later.

## 🧪 Testing instructions
-This will allow for successful testing of moderation panel testing in the future since it will not change the layout of the other pages, which would cause all those cypress tests to fail

## 📸 Screenshots

-   ### Before
-This is how the layout was being affected before.
![WhatsApp Image 2024-05-30 at 13 19 48_609f8283](https://github.com/ourjapanlife/findadoc-web/assets/124335161/089ac1fd-bc64-4698-a3f7-d12a28c10ac2)


-   ### After
This is what it looks like with new implementaiton
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/041ce57d-3a1f-42af-a147-2ca147808b78)

-Moderation panel still displays

![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/47a40b3a-d530-4249-8418-98a0a18a96ec)

