### PR TITLE
fix/show loading leftnav

### DIFF
--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -13,7 +13,20 @@
                 </span>
             </button>
         </div>
-        <div v-if="hasResults">
+        <div v-if="loadingStore.isLoading">
+            <div class="h-full flex flex-col justify-center items-center w-full">
+<<<<<<< HEAD
+                <SVGLoading class="w-4/5 p-12" />
+=======
+                <div class="flex justify-center align-middle">
+                    <div class="flex text-primary self-center text-4xl">Loading</div>
+                    <SVGLoadingIcon data-testid='svg-loading-icon' role="img" alt="loading animation"
+                        title="loading animation" class="flex h-28" />
+                </div>
+>>>>>>> 9052b2b (fixup! fix: implement loading animation when looking for results)
+            </div>
+        </div>
+        <div v-else-if="hasResults">
             <div id="searchResults" class="flex flex-col landscape:overflow-y-scroll h-full">
                 <div @click="resultsStore.setActiveSearchResult(searchResult.professional.id)" :key="index"
                     v-for="(searchResult, index) in resultsStore.searchResultsList" class="results-list flex flex-col">
@@ -29,9 +42,10 @@
                 </div>
             </div>
         </div>
+
         <div v-else>
-            <div class="h-full flex flex-col w-[358px]">
-                <img :src='noSearchResultsGraphic' class="p-12" />
+            <div class="h-full flex flex-col">
+                <SVGNoSearchResults class="p-12" />
                 <span class="text-primary-text pl-1 font-bold self-center group-hover:text-primary-text-inverted/50">{{
                     $t('searchResultsList.noResults') }}</span>
                 <span class="text-primary-text self-center">{{
@@ -43,15 +57,22 @@
 
 <script setup lang="ts">
 import SVGHamburgerListIcon from '~/assets/icons/hamburger-list-icon.svg'
-import { computed } from 'vue';
+import SVGLoadingIcon from '~/assets/icons/loading.svg'
+import SVGNoSearchResults from '~/assets/icons/no-search-results-graphic.svg'
+import { computed, onMounted } from 'vue';
 import { useSearchResultsStore } from '../stores/searchResultsStore'
 import { useLocaleStore } from '../stores/localeStore'
+import { useLoadingStore } from '../stores/loadingStore'
 import { Locale } from '~/typedefs/gqlTypes.js';
 import noSearchResultsGraphic from '@/assets/icons/no-search-results-graphic.svg'
 const resultsStore = useSearchResultsStore()
 const localeStore = useLocaleStore()
-//let's start with some initial data
-resultsStore.search()
+const loadingStore = useLoadingStore()
+
+onMounted(() => {
+    resultsStore.search()
+})
+
 const hasResults = computed(() => resultsStore.searchResultsList.length > 0)
 
 </script>

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -15,15 +15,11 @@
         </div>
         <div v-if="loadingStore.isLoading">
             <div class="h-full flex flex-col justify-center items-center w-full">
-<<<<<<< HEAD
-                <SVGLoading class="w-4/5 p-12" />
-=======
                 <div class="flex justify-center align-middle">
                     <div class="flex text-primary self-center text-4xl">Loading</div>
                     <SVGLoadingIcon data-testid='svg-loading-icon' role="img" alt="loading animation"
                         title="loading animation" class="flex h-28" />
                 </div>
->>>>>>> 9052b2b (fixup! fix: implement loading animation when looking for results)
             </div>
         </div>
         <div v-else-if="hasResults">

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -13,6 +13,11 @@ describe("Visits the home page", () => {
         // TODO: clicking it should take us to '/'
     });
 
+
+    it("Displays loading SVG on visit", () => {
+        cy.get('[data-testid="svg-loading-icon"]').should("be.visible");
+    })
+
     it.skip("renders the map", () => {
         // TODO
         cy.get('[data-testid="map-of-japan"]').should("be.visible");


### PR DESCRIPTION
## 🔧 What changed
Before it was showing no results instead of loading while fetching results from the store. Now it displays no results found if there are only no results and shows the loading svg when first fetching from backend

## 🧪 Testing instructions
Run `yarn cypress open` and run the home tests. Since it is now using the dev database instead of production one test will fail but maybe we can address this in a different PR.

## 📸 Screenshots

-   ### Before
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/9950bbef-4e67-40a2-afe3-a36105c8c915)

-   ### After

![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/06760963-ec51-4951-996c-dc1d1c807aee)

If No search results after selecting urology from local db

![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/af7438b6-6b2c-4029-9fa2-f1b8370c177d)

