### PR TITLE
chore: move env to dev local server script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
     "private": true,
     "scripts": {
         "prepare": "husky",
-        "dev": "NODE_ENV=development yarn && nuxi dev",
+        "dev": "yarn && nuxi dev",
+        "dev:localserver": "NODE_ENV=development yarn && nuxi dev",
         "generate": "graphql-codegen --config ./typesgeneratorconfig.ts",
         "lint": "ESLINT_USE_FLAT_CONFIG=true eslint . -c eslint.config.js && stylelint **/*.{vue,css,scss} --ignore-path .gitignore",
         "lint:ci": "eslint . --config eslint.config.js --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",


### PR DESCRIPTION
## 🔧 What changed
Creates a `yarn dev:localserver` script that passes `NODE_ENV=development`. This will allow `yarn dev` to connect to the prod API as it did before.

## 🧪 Testing instructions
1. Start the backend database and server.
2. Start the frontend server.
3. Confirm that the frontend connects to the local server and renders data from the local database.