### PR TITLE
chore: add margin to bottom of submit component

### DIFF
--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -76,14 +76,14 @@
     >{{ $t('submitPage.otherNotes')}}({{ $t('submitPage.optional')}})</span>
     <textarea
     data-testid="submit-input-notes"
-      class="mb-5 md:mb-[71px] px-3 py-3.5 w-[350px] h-[100px] bg-white rounded-lg border border-zinc-400"
+      class="mb-5 landscape:mb-[71px] px-3 py-3.5 w-[350px] h-[100px] bg-white rounded-lg border border-zinc-400"
       v-model="submissionStore.otherNotes"
       maxlength="300"
     />
     <button
     data-testid="submit-submitbutton"
     type="submit"
-      class="px-20 py-3 mb-40 md:mb-0 rounded-full bg-currentColor w-[350px] text-center text-white text-base font-medium font-['Noto Sans JP']"
+      class="px-20 py-3 mb-40 landscape:mb-0 rounded-full bg-currentColor w-[350px] text-center text-white text-base font-medium font-['Noto Sans JP']"
       @click="validateFields"
     >{{ $t('submitPage.submitButton')}}</button>
 </form>

--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -76,14 +76,14 @@
     >{{ $t('submitPage.otherNotes')}}({{ $t('submitPage.optional')}})</span>
     <textarea
     data-testid="submit-input-notes"
-      class="mb-[71px] px-3 py-3.5 w-[350px] h-[100px] bg-white rounded-lg border border-zinc-400"
+      class="mb-5 md:mb-[71px] px-3 py-3.5 w-[350px] h-[100px] bg-white rounded-lg border border-zinc-400"
       v-model="submissionStore.otherNotes"
       maxlength="300"
     />
     <button
     data-testid="submit-submitbutton"
     type="submit"
-      class="px-20 py-3 rounded-full bg-currentColor w-[350px] text-center text-white text-base font-medium font-['Noto Sans JP']"
+      class="px-20 py-3 mb-40 md:mb-0 rounded-full bg-currentColor w-[350px] text-center text-white text-base font-medium font-['Noto Sans JP']"
       @click="validateFields"
     >{{ $t('submitPage.submitButton')}}</button>
 </form>


### PR DESCRIPTION
Resolves #543 

## 🔧 What changed
This PR makes it possible to scroll to the Submit button at the bottom of the Submit page without affecting the visibility of the sticky menu.

## 🧪 Testing instructions
1. Open the preview on an iPhone (must be an actual phone).
2. Scroll to the bottom and confirm that both the sticky menu and Submit button are visible at the same time.

## 📸 Demo Videos
### Before
https://github.com/ourjapanlife/findadoc-web/assets/31802656/213c19ff-923f-4d45-a09c-337abcd55b9c

### After
https://github.com/ourjapanlife/findadoc-web/assets/31802656/e49466ef-3074-4fff-bb69-591304d287fe



