### PR TITLE
refactor: update problematic tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -15,11 +15,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             # Install yarn dependencies, cache them correctly
             # and run all Cypress tests
             - name: Cypress run
-              uses: cypress-io/github-action@v5.6.1
+              uses: cypress-io/github-action@v6
               with:
                   build: yarn prod:build
                   start: yarn prod:start

--- a/cypress/e2e/moderationDashboard.cy.ts
+++ b/cypress/e2e/moderationDashboard.cy.ts
@@ -66,7 +66,7 @@ describe('Moderation Facility Submission Form', () => {
         beforeEach(() => {
             cy.viewport(1920, 1080)
             cy.visit('/moderation')
-            cy.wait(500)
+            cy.wait(700)
             cy.get('[data-testid="mod-submission-list-item-1"]').click()
         })
 

--- a/cypress/e2e/moderationDashboard.cy.ts
+++ b/cypress/e2e/moderationDashboard.cy.ts
@@ -1,4 +1,5 @@
 import "cypress-real-events";
+import "cypress-plugin-tab"
 import enUS from "../../i18n/locales/en.json";
 
 describe(
@@ -9,44 +10,44 @@ describe(
         },
     },
     () => {
-        beforeEach(() => {}),
-        context("Landscape mode", () => {
-            before(() => {
-                cy.viewport(1920, 1080);
-                cy.visit("/moderation");
-            })
+        beforeEach(() => { }),
+            context("Landscape mode", () => {
+                before(() => {
+                    cy.viewport(1920, 1080);
+                    cy.visit("/moderation");
+                })
 
-            it("shows mod dashboard left navbar buttons", () => {
-                cy.wait(500);
+                it("shows mod dashboard left navbar buttons", () => {
+                    cy.wait(500);
 
-                cy.get("[data-testid=mod-dashboard-leftnav-for-review]")
-                    .should("exist")
-                    .should(
-                        "include.text",
-                        enUS.modDashboardLeftNav.forReview
-                    );
+                    cy.get("[data-testid=mod-dashboard-leftnav-for-review]")
+                        .should("exist")
+                        .should(
+                            "include.text",
+                            enUS.modDashboardLeftNav.forReview
+                        );
 
-                cy.get("[data-testid=mod-dashboard-leftnav-approved]")
-                    .should("exist")
-                    .should(
-                        "include.text",
-                        enUS.modDashboardLeftNav.approved
-                    );
+                    cy.get("[data-testid=mod-dashboard-leftnav-approved]")
+                        .should("exist")
+                        .should(
+                            "include.text",
+                            enUS.modDashboardLeftNav.approved
+                        );
 
-                cy.get("[data-testid=mod-dashboard-leftnav-rejected]")
-                    .should("exist")
-                    .should(
-                        "include.text",
-                        enUS.modDashboardLeftNav.rejected
-                    )
-            });
+                    cy.get("[data-testid=mod-dashboard-leftnav-rejected]")
+                        .should("exist")
+                        .should(
+                            "include.text",
+                            enUS.modDashboardLeftNav.rejected
+                        )
+                });
 
-            it.skip("it shows the moderation top nav", () => {
-                // wait for the vue components to actually load
-                cy.wait(1000)
+                it.skip("it shows the moderation top nav", () => {
+                    // wait for the vue components to actually load
+                    cy.wait(1000)
 
-                cy.get('[data-testid="mod-submission-list-item-1"]').click()
-                cy.get('[data-testid="mod-edit-submission-copy-submission-id"]').click()
+                    cy.get('[data-testid="mod-submission-list-item-1"]').click()
+                    cy.get('[data-testid="mod-edit-submission-copy-submission-id"]').click()
 
                     // check that the value copied to the clipboard is the same that's displayed
                     const clipboardResult = cy.window().then((win) => {
@@ -77,7 +78,7 @@ describe('Moderation Facility Submission Form', () => {
             cy.get('[data-testid="submission-form-email"]').should('exist')
             cy.get('[data-testid="submission-form-website"]').should('exist')
             cy.get('[data-testid="submission-form-postalCode"]').should('exist')
-            cy.get( '[data-testid="submission-form-cityEn"]').should('exist')
+            cy.get('[data-testid="submission-form-cityEn"]').should('exist')
             cy.get('[data-testid="submission-form-addressLine1En"]').should('exist')
             cy.get('[data-testid="submission-form-addressLine2En"]').should('exist')
             cy.get('[data-testid=submission-form-cityJp]').should('exist')
@@ -102,7 +103,7 @@ describe('Moderation Facility Submission Form', () => {
             cy.get('[data-testid="submission-form-email"]').find('input').type('example@mail.com')
             cy.get('[data-testid="submission-form-website"]').find('input').type('http://example.com')
             cy.get('[data-testid="submission-form-postalCode"]').find('input').type('180-0000')
-            cy.get( '[data-testid="submission-form-cityEn"]').find('input').type('Shibuya')
+            cy.get('[data-testid="submission-form-cityEn"]').find('input').type('Shibuya')
             cy.get('[data-testid="submission-form-addressLine1En"]').find('input').type('some address line 1')
             cy.get('[data-testid="submission-form-addressLine2En"]').find('input').type('some address line 2')
             cy.get('[data-testid=submission-form-cityJp]').find('input').type('渋谷区')
@@ -121,47 +122,47 @@ describe('Moderation Facility Submission Form', () => {
 
         it('should be display error messages', () => {
 
-            cy.get('[data-testid="submission-form-nameEn"]').find('input').type('立川中央病院').blur()
+            cy.get('[data-testid="submission-form-nameEn"]').find('input').type('立川中央病院').tab()
             cy.get('[data-testid="submission-form-nameEn"]').find('p').should('exist').contains('Invalid English Name')
 
-            cy.get('[data-testid="submission-form-nameJp"]').find('input').type('Tachikawa Hospital').blur()
+            cy.get('[data-testid="submission-form-nameJp"]').find('input').type('Tachikawa Hospital').tab()
             cy.get('[data-testid="submission-form-nameJp"]').find('p').should('exist').contains('Invalid Japanese Name')
 
-            cy.get('[data-testid="submission-form-phone"]').find('input').type('Hello').blur()
+            cy.get('[data-testid="submission-form-phone"]').find('input').type('Hello').tab()
             cy.get('[data-testid="submission-form-phone"]').find('p').should('exist').contains('Invalid Phone Number')
 
-            cy.get('[data-testid="submission-form-email"]').find('input').type('example').blur()
+            cy.get('[data-testid="submission-form-email"]').find('input').type('example').tab()
             cy.get('[data-testid="submission-form-email"]').find('p').should('exist').contains('Invalid Email Address')
 
-            cy.get('[data-testid="submission-form-website"]').find('input').type('example').blur()
+            cy.get('[data-testid="submission-form-website"]').find('input').type('example').tab()
             cy.get('[data-testid="submission-form-website"]').find('p').should('exist').contains('Invalid Website URL')
 
-            cy.get('[data-testid="submission-form-postalCode"]').find('input').type('180-0').blur()
+            cy.get('[data-testid="submission-form-postalCode"]').find('input').type('180-0').tab()
             cy.get('[data-testid="submission-form-postalCode"]').find('p').should('exist').contains('Invalid Zip Code')
 
-            cy.get('[data-testid="submission-form-cityEn"]').find('input').type('渋谷区').blur()
+            cy.get('[data-testid="submission-form-cityEn"]').find('input').type('渋谷区').tab()
             cy.get('[data-testid="submission-form-cityEn"]').find('p').should('exist').contains('Invalid English City Name')
 
-            cy.get('[data-testid="submission-form-addressLine1En"]').find('input').type('道の駅').blur()
+            cy.get('[data-testid="submission-form-addressLine1En"]').find('input').type('道の駅').tab()
             cy.get('[data-testid="submission-form-addressLine1En"]').find('p').should('exist').contains('Invalid English Address')
 
-            cy.get('[data-testid="submission-form-addressLine2En"]').find('input').type('道の駅').blur()
+            cy.get('[data-testid="submission-form-addressLine2En"]').find('input').type('道の駅').tab()
             cy.get('[data-testid="submission-form-addressLine2En"]').find('p').should('exist').contains('Invalid English Address')
 
-            cy.get('[data-testid=submission-form-cityJp]').find('input').type('Shibuya').blur()
+            cy.get('[data-testid=submission-form-cityJp]').find('input').type('Shibuya').tab()
             cy.get('[data-testid=submission-form-cityJp]').find('p').should('exist').contains('Invalid Japanese City Name')
 
 
-            cy.get('[data-testid="submission-form-addressLine1Jp"]').find('input').type('Peanutbutter street').blur()
+            cy.get('[data-testid="submission-form-addressLine1Jp"]').find('input').type('Peanutbutter street').tab()
             cy.get('[data-testid="submission-form-addressLine1Jp"]').should('exist').contains('Invalid Japanese Address')
 
-            cy.get('[data-testid="submission-form-addressLine2Jp"]').find('input').type('Jelly street').blur()
+            cy.get('[data-testid="submission-form-addressLine2Jp"]').find('input').type('Jelly street').tab()
             cy.get('[data-testid="submission-form-addressLine2Jp"]').should('exist').contains('Invalid Japanese Address')
 
-            cy.get('[data-testid="submission-form-mapLatitude"]').find('input').type('Not Number Latitude').blur()
-             cy.get('[data-testid="submission-form-mapLatitude"]').find('p').should('exist').contains('Invalid Latitude')
+            cy.get('[data-testid="submission-form-mapLatitude"]').find('input').type('Not Number Latitude').tab()
+            cy.get('[data-testid="submission-form-mapLatitude"]').find('p').should('exist').contains('Invalid Latitude')
 
-            cy.get('[data-testid="submission-form-mapLongitude"]').find('input').type('Not Number Longitude').blur()
+            cy.get('[data-testid="submission-form-mapLongitude"]').find('input').type('Not Number Longitude').tab()
             cy.get('[data-testid="submission-form-mapLongitude"]').find('p').should('exist').contains('Invalid Longitude')
         })
     })

--- a/cypress/e2e/submit.cy.ts
+++ b/cypress/e2e/submit.cy.ts
@@ -93,7 +93,7 @@ describe('Submit page', () => {
             cy.get('[data-testid="submit-completed"]').should('not.be.visible')
         });
 
-        it('submits a complete form', () => {
+        it.skip('submits a complete form', () => {
             cy.get('[data-testid="submit-input-googlemaps"]').type('https://example.com')
             cy.get('[data-testid="submit-input-lastname"]').type('some last name')
             cy.get('[data-testid="submit-select-language1"]').select('日本語 (Japan)')

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "all-contributors-cli": "^6.26.1",
         "autoprefixer": "^10.4.18",
         "cypress": "^13.10.0",
+        "cypress-plugin-tab": "^1.0.5",
         "eslint": "^9.3.0",
         "eslint-plugin-cypress": "^3.2.0",
         "eslint-plugin-json": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5244,6 +5244,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ally.js@npm:^1.4.1":
+  version: 1.4.1
+  resolution: "ally.js@npm:1.4.1"
+  dependencies:
+    css.escape: "npm:^1.5.0"
+    platform: "npm:1.3.3"
+  checksum: 10/91ce8ecea5bd62f45889aa84f25041760a4627d0bb73b285dab9056bca96a91fc9fd30d95c2d80a58c9f2afffc18d3bb972ff84b4376f18d14f561804b265616
+  languageName: node
+  linkType: hard
+
 "ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
@@ -6680,6 +6690,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css.escape@npm:^1.5.0":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10/f6d38088d870a961794a2580b2b2af1027731bb43261cfdce14f19238a88664b351cc8978abc20f06cc6bbde725699dec8deb6fe9816b139fc3f2af28719e774
+  languageName: node
+  linkType: hard
+
 "cssesc@npm:^3.0.0":
   version: 3.0.0
   resolution: "cssesc@npm:3.0.0"
@@ -6772,6 +6789,15 @@ __metadata:
   version: 3.1.3
   resolution: "csstype@npm:3.1.3"
   checksum: 10/f593cce41ff5ade23f44e77521e3a1bcc2c64107041e1bf6c3c32adc5187d0d60983292fda326154d20b01079e24931aa5b08e4467cc488b60bb1e7f6d478ade
+  languageName: node
+  linkType: hard
+
+"cypress-plugin-tab@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "cypress-plugin-tab@npm:1.0.5"
+  dependencies:
+    ally.js: "npm:^1.4.1"
+  checksum: 10/87d68c8caf03bb8d330901c68caa4253442d7c5364dae92899c744286a459dd16fd47c3633288eb35940655b3079502d425c83fbb489841722c7f4d7c77dd212
   languageName: node
   linkType: hard
 
@@ -8338,6 +8364,7 @@ __metadata:
     all-contributors-cli: "npm:^6.26.1"
     autoprefixer: "npm:^10.4.18"
     cypress: "npm:^13.10.0"
+    cypress-plugin-tab: "npm:^1.0.5"
     cypress-real-events: "npm:^1.12.0"
     eslint: "npm:^9.3.0"
     eslint-plugin-cypress: "npm:^3.2.0"
@@ -12391,6 +12418,13 @@ __metadata:
     mlly: "npm:^1.7.0"
     pathe: "npm:^1.1.2"
   checksum: 10/225eaf7c0339027e176dd0d34a6d9a1384c21e0aab295e57dfbef1f1b7fc132f008671da7e67553e352b80b17ba38c531c720c914061d277410eef1bdd9d9608
+  languageName: node
+  linkType: hard
+
+"platform@npm:1.3.3":
+  version: 1.3.3
+  resolution: "platform@npm:1.3.3"
+  checksum: 10/3abaa62cf5c7cf549d0a7564ce97caa32615d9dbbc1c19a83ed95dfa2749d0dc68d13cb704e1858022ac5f18de412aa6878cc2521df524cfe9764f9fd51e6802
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of #540 

## 🔧 What changed

1. This PR adds `.skip` to the test that is making fake submissions to the prod database. We'll re-enable this once we figure out mocking. 

2. This PR also changes `.blur()` in tests to `.tab()` because the command was causing Cypress to fail consistently. The purpose of the blur was to make the error messages appear, but it also had the effect of changing the DOM. The [cypress-plugin-tab](https://github.com/Bkucera/cypress-plugin-tab) allows us to use tabs in our tests, which is helpful for triggering the input validations.

![Screenshot 2024-06-07 at 8 14 20 PM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/8965ad52-3cde-48f1-9f08-d90e7361564b)

3. Increases the wait time between moderation tests that were failing due to the elements not having enough time to load.
4. Upgrades the [Cypress Github Action](https://github.com/cypress-io/github-action) to (hopefully) fix the "server not running" errors that sometimes pop up in CI.

## How to test
1. Run `yarn dev`
2. Run `yarn cypress run`