### PR TITLE
refactor: improve visibility of search results

### DIFF
--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -17,10 +17,10 @@ import SearchResultDetails from './SearchResultDetails.vue';
             <Modal v-show="store.$state.isOpen" class="min-h-1/2 ml-8 mt-12">
                 <SearchResultDetails />
             </Modal>
-            <div class="h-1/2">
+            <div class="h-1/4">
                 <MapContainer />
             </div>
-            <div class="h-1/2 overflow-y-auto">
+            <div class="h-3/4">
                 <SearchResultsList />
             </div>
         </div>

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="h-full flex flex-col">
+    <div class="h-full flex flex-col overflow-y-auto">
         <div class="results-header flex flex-row ml-9 mr-5 mb-6 pt-5">
             <span class="flex-1 w-1/2 font-bold self-center">
                 {{ $t('searchResultsList.doctorsNearby') }}
@@ -22,29 +22,28 @@
                 </div>
             </div>
         </div>
-        <div v-else-if="hasResults">
-            <div id="searchResults" class="flex flex-col landscape:overflow-y-scroll h-full">
-                <div @click="resultsStore.setActiveSearchResult(searchResult.professional.id)" :key="index"
-                    v-for="(searchResult, index) in resultsStore.searchResultsList" class="results-list flex flex-col">
-                    <div class="flex-1 h-24 w-6/8 border-b-2 border-primary/20 p-3
-                        hover:border-transparent hover:bg-primary/5 transition-all hover:cursor-pointer">
-                        <SearchResultsListItem
-                            :name="`${searchResult.professional.names[0].firstName} ${searchResult.professional.names[0].lastName}`"
-                            :degrees="searchResult.professional.degrees"
-                            :facility-name="localeStore.locale.code == Locale.JaJp ? searchResult.facilities[0]?.nameJa : searchResult.facilities[0]?.nameEn"
-                            :specialties="searchResult.professional.specialties"
-                            :spoken-languages="searchResult.professional.spokenLanguages" />
+            <div v-else-if="hasResults">
+                <div id="searchResults" class="flex flex-col landscape:overflow-y-scroll h-full mb-40 landscape:mb-0">
+                    <div @click="resultsStore.setActiveSearchResult(searchResult.professional.id)" :key="index"
+                        v-for="(searchResult, index) in resultsStore.searchResultsList" class="results-list flex flex-col">
+                        <div class="flex-1 h-24 w-6/8 border-b-2 border-primary/20 p-3
+                            hover:border-transparent hover:bg-primary/5 transition-all hover:cursor-pointer">
+                            <SearchResultsListItem
+                                :name="`${searchResult.professional.names[0].firstName} ${searchResult.professional.names[0].lastName}`"
+                                :degrees="searchResult.professional.degrees"
+                                :facility-name="localeStore.locale.code == Locale.JaJp ? searchResult.facilities[0]?.nameJa : searchResult.facilities[0]?.nameEn"
+                                :specialties="searchResult.professional.specialties"
+                                :spoken-languages="searchResult.professional.spokenLanguages" />
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-
         <div v-else>
-            <div class="h-full flex flex-col">
-                <SVGNoSearchResults class="p-12" />
-                <span class="text-primary-text pl-1 font-bold self-center group-hover:text-primary-text-inverted/50">{{
+            <div class="flex flex-col">
+                <SVGNoSearchResults class="portrait:px-4 h-12" />
+                <span class="text-primary-text px-1 font-bold self-center group-hover:text-primary-text-inverted/50">{{
                     $t('searchResultsList.noResults') }}</span>
-                <span class="text-primary-text self-center">{{
+                <span class="text-primary-text self-center text-center">{{
                     $t('searchResultsList.noResultsSubtext') }}</span>
             </div>
         </div>

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -22,22 +22,22 @@
                 </div>
             </div>
         </div>
-            <div v-else-if="hasResults">
-                <div id="searchResults" class="flex flex-col landscape:overflow-y-scroll h-full mb-40 landscape:mb-0">
-                    <div @click="resultsStore.setActiveSearchResult(searchResult.professional.id)" :key="index"
-                        v-for="(searchResult, index) in resultsStore.searchResultsList" class="results-list flex flex-col">
-                        <div class="flex-1 h-24 w-6/8 border-b-2 border-primary/20 p-3
-                            hover:border-transparent hover:bg-primary/5 transition-all hover:cursor-pointer">
-                            <SearchResultsListItem
-                                :name="`${searchResult.professional.names[0].firstName} ${searchResult.professional.names[0].lastName}`"
-                                :degrees="searchResult.professional.degrees"
-                                :facility-name="localeStore.locale.code == Locale.JaJp ? searchResult.facilities[0]?.nameJa : searchResult.facilities[0]?.nameEn"
-                                :specialties="searchResult.professional.specialties"
-                                :spoken-languages="searchResult.professional.spokenLanguages" />
-                        </div>
+        <div v-else-if="hasResults">
+            <div id="searchResults" class="flex flex-col landscape:overflow-y-scroll h-full mb-40 landscape:mb-0">
+                <div @click="resultsStore.setActiveSearchResult(searchResult.professional.id)" :key="index"
+                    v-for="(searchResult, index) in resultsStore.searchResultsList" class="results-list flex flex-col">
+                    <div class="flex-1 h-24 w-6/8 border-b-2 border-primary/20 p-3
+                        hover:border-transparent hover:bg-primary/5 transition-all hover:cursor-pointer">
+                        <SearchResultsListItem
+                            :name="`${searchResult.professional.names[0].firstName} ${searchResult.professional.names[0].lastName}`"
+                            :degrees="searchResult.professional.degrees"
+                            :facility-name="localeStore.locale.code == Locale.JaJp ? searchResult.facilities[0]?.nameJa : searchResult.facilities[0]?.nameEn"
+                            :specialties="searchResult.professional.specialties"
+                            :spoken-languages="searchResult.professional.spokenLanguages" />
                     </div>
                 </div>
             </div>
+        </div>
         <div v-else>
             <div class="flex flex-col">
                 <SVGNoSearchResults class="portrait:px-4 h-12" />


### PR DESCRIPTION
## 🔧 What changed
Currently, it's difficult for users to understand when there are no search results. The information is rendered off screen on mobile in both portrait and landscape mode. This PR improves the visibility of the "No Results Found" message on mobile, so most users will be aware that it's there without having to scroll. 

It also improves the visibility of the Search Results List, by enabling users to scroll to the bottom of the last result. For iPhone users, this information is currently blocked by the toolbar.

## 🧪 Testing instructions
1. Test the preview on an iPhone in portrait and landscape mode.
2. Test the preview on a desktop browser and drag the size.

## 📸 Screenshots
Desktop before
![Screenshot 2024-06-08 at 12 27 55 AM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/e688cb8f-2daa-4e09-a2a6-e9764ddde372)

Desktop after**
![Screenshot 2024-06-08 at 12 35 19 AM](https://github.com/ourjapanlife/findadoc-web/assets/31802656/6f65736f-0c50-42aa-b189-7a7845f35586)


Mobile landscape before:
![IMG_5247](https://github.com/ourjapanlife/findadoc-web/assets/31802656/86914fa2-b771-4af3-a7ef-fa5d73caf377)

Mobile landscape after:
![IMG_5242](https://github.com/ourjapanlife/findadoc-web/assets/31802656/9ad02cc7-db67-4ffc-8646-96d33dd2efd8)

Mobile portrait before:
![IMG_5248](https://github.com/ourjapanlife/findadoc-web/assets/31802656/057537b0-bcaf-477c-9614-31ac5e15e4fb)

Mobile portrait after:
![IMG_5241](https://github.com/ourjapanlife/findadoc-web/assets/31802656/395ba35c-ced2-461c-b5d9-3a26dddb5336)
