### PR TITLE
chore: increase wait between submit tests

### DIFF
--- a/cypress/e2e/submit.cy.ts
+++ b/cypress/e2e/submit.cy.ts
@@ -85,7 +85,7 @@ describe('Submit page', () => {
     context('form validation', () => {
         beforeEach(() => {
             cy.visit('/submit')
-            cy.wait(500) // wait for the vue components to actually load
+            cy.wait(1000) // wait for the vue components to actually load
         })
 
         it('does not submit an incomplete form', () => {


### PR DESCRIPTION
## 🔧 What changed
Increases the wait time before each Submit validation test, because sometimes the elements are slow to load. This was failing on `main` for #534, but passed after re-running it.

![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/414d802a-2ec4-41e6-9185-f0e9b57ec490)
