### PR TITLE
CHORE: adding nuxt support to typescript compiler and intellisense

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -83,6 +83,8 @@ export default defineNuxtConfig({
         ],
         link: [{ rel: 'icon', type: 'image/x-icon', href: '/assets/favicon.ico' }]
     },
+    // this helps the aliases like ~ or @ to start at '/' instead of '/src'.
+    srcDir: '',
 
     // Global CSS: https://go.nuxtjs.dev/config-css
     css: ['~/assets/css/tailwind.css'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+    "extends": "./.nuxt/tsconfig.json",
     "compilerOptions": {
         "target": "ESNext",
         "module": "ESNext",
@@ -7,10 +8,6 @@
             "esnext",
             "DOM"
         ],
-        "paths": {
-            "~/*": ["./*"],
-            "@/*": ["./*"]
-        },
         "strict": true,
         "outDir": "dist",
         "sourceMap": true,


### PR DESCRIPTION
## 🔧 What changed
- Adding support for nuxt variables and plugins into typescript compiler. 
  - We should not have any more `$t()` errors!
  - import from `'#app'` should work now. We can get `vueApp` variable
 
## 🧪 Testing instructions
- app should still work! 
- you shouldn't see any more $t() errors
