### PR TITLE
refactor: adjust screen resolutions and wait times for submit tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -7,6 +7,4 @@ export default defineConfig({
         baseUrl: 'http://localhost:3000',
         testIsolation: false
     },
-    viewportHeight: 927,
-    viewportWidth: 1600
 })

--- a/cypress/e2e/about.cy.ts
+++ b/cypress/e2e/about.cy.ts
@@ -2,9 +2,17 @@ import enUS from '../../i18n/locales/en.json'
 
 describe('About page', () => {
     context('Desktop resolution', () => {
+        before(() => {
+            cy.visit("/about")
+            // This wait time is to give the page time to load from Prod when ran in CI.
+            cy.wait(3000)
+        })
+
         beforeEach(() => {
+            // The resolution is in the beforeEach() instead of before() to
+            // prevent Cypress from defaulting to other screen sizes between tests.
             cy.viewport(1920, 1080)
-            cy.visit('/about')
+            cy.wait(500)
         })
 
         it('shows the desktop top nav', () => {
@@ -51,9 +59,19 @@ describe('About page', () => {
     })
 
     context('Portrait mode', () => {
-        beforeEach(() => {
-            cy.viewport('iphone-5')
+        before(() => {
             cy.visit('/about')
+            // This wait time is to give the page time to load from Prod when ran in CI.
+            cy.wait(3000)
+        })
+
+        beforeEach(() => {
+            // The resolution is in the beforeEach() instead of before() to
+            // prevent Cypress from defaulting to other screen sizes between tests.
+
+            // An iPhone 5 screen resolution is used to test portrait mode.
+            cy.viewport(640, 1136)
+            cy.wait(500)
         })
 
         it('shows the hamburger component', () => {
@@ -74,6 +92,17 @@ describe('About page', () => {
             cy.get('[data-testid="member-title"]').should('exist')
             cy.get('[data-testid="member-linkedin"]').should('exist')
             cy.get('[data-testid="member-github"').should('exist')
+        })
+
+        it("Allows navigating to external links", () => {
+            cy.get('[data-testid="member-linkedin"]')
+                .first()
+                .should("have.attr", "href")
+                .and("include", "linkedin.com")
+            cy.get('[data-testid="member-github"]')
+                .first()
+                .should("have.attr", "href")
+                .and("include", "github.com")
         })
     })
 })

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -132,6 +132,8 @@ describe("Visits the home page", () => {
         beforeEach(() => {
             // The resolution is in the beforeEach() instead of before() to
             // prevent Cypress from defaulting to other screen sizes between tests.
+
+            // An iPhone 5 screen resolution is used to test portrait mode.
             cy.viewport(640, 1136)
             cy.wait(500)
         })

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -4,19 +4,22 @@ describe("Visits the home page", () => {
 
     context('Landscape mode', () => {
         before(() => {
-            cy.viewport(1920, 1080)
             cy.visit("/")
+            // This wait time is to give the page time to load from Prod when ran in CI.
+            cy.wait(3000)
+        })
+
+        beforeEach(() => {
+            // The resolution is in the beforeEach() instead of before() to
+            // prevent Cypress from defaulting to other screen sizes between tests.
+            cy.viewport(1920, 1080)
+            cy.wait(500)
         })
 
         it("Displays the Logo", () => {
             cy.get('[data-testid="landscape-logo"]')
                 .should("be.visible")
                 .contains("Find a Doc Japan")
-            // TODO: clicking it should take us to '/'
-        })
-
-        it("Displays loading SVG on visit", () => {
-            cy.get('[data-testid="svg-loading-icon"]').should("be.visible")
         })
 
         it("renders the map", () => {
@@ -73,10 +76,8 @@ describe("Visits the home page", () => {
         })
 
         describe("Checks footer links", () => {
+            // verify link to GitHub
             it("navigates to github", () => {
-                // TODO
-
-                // verify link to GitHub
                 cy.get('[data-testid="github-link"]').should("be.visible")
                 cy.get('[data-testid="github-link"]').should(
                     "have.attr",
@@ -119,43 +120,19 @@ describe("Visits the home page", () => {
                 cy.url().should("include", "/terms")
             })
         })
-
-
-        describe("Visits the about page", () => {
-            before(() => {
-                cy.visit("/about")
-            })
-
-            it("Displays the main content", () => {
-                cy.get('[data-testid="about-heading"]').should("be.visible")
-                cy.get('[data-testid="about-subheading"]').should("be.visible")
-            })
-
-            it("Displays the members section", () => {
-                cy.get('[data-testid="members-header"]').should("be.visible")
-                cy.get('[data-testid="member"]').should("have.length.gte", 5)
-            })
-
-            it("Allows navigating to external links", () => {
-                cy.get('[data-testid="member-linkedin"]')
-                    .first()
-                    .should("have.attr", "href")
-                    .and("include", "linkedin.com")
-                cy.get('[data-testid="member-github"]')
-                    .first()
-                    .should("have.attr", "href")
-                    .and("include", "github.com")
-            })
-        })
     })
-
     // Portrait mode tests - usually for mobile and tablet
     context('Portrait mode', () => {
-        beforeEach(() => {
-            cy.viewport('iphone-5')
+        before(() => {
             cy.visit('/')
+            // This wait time is to give the page time to load from Prod when ran in CI.
+            cy.wait(3000)
+        })
 
-            //need to wait for the page+data to load so the menu will open properly
+        beforeEach(() => {
+            // The resolution is in the beforeEach() instead of before() to
+            // prevent Cypress from defaulting to other screen sizes between tests.
+            cy.viewport(640, 1136)
             cy.wait(500)
         })
 
@@ -177,59 +154,56 @@ describe("Visits the home page", () => {
 
         describe("Hamburger Menu tests", () => {
             it('shows the hamburger icon', () => {
-                //this conditionally renders based on screen orientation
+                // The hamburger menu conditionally renders based on screen orientation
                 cy.get('[data-testid="hamburger-menu-icon"]').should('exist').should('be.visible')
             })
 
-            it('can open the hamburger component', () => {
+            it('can open and close the hamburger component', () => {
                 cy.get('[data-testid="hamburger-menu-icon"]').should('exist').click()
                 cy.get('[data-testid="hamburger-menu"]').should('exist').should('be.visible')
+                cy.get('[data-testid="hamburger-menu-close-button"]').should('exist').click()
             })
 
-            // netlify link
             it("navigates to netlify", () => {
-                // This link is required by netlify for our open source license. make sure it shows
-
-                //open the hamburger menu
+                // This link is required by Netlify for our open source license.
                 cy.get('[data-testid="hamburger-menu-icon"]').click()
 
-                // verify link shows and has the right url generated
+                // Verify that the link shows and has the right url generated.
                 cy.get('[data-testid="hamburger-menu-footer-dev-links-netlify"]').should("be.visible")
                 cy.get('[data-testid="hamburger-menu-footer-dev-links-netlify"]').should(
                     "have.attr",
                     "href",
                     "https://www.netlify.com"
                 )
+                cy.get('[data-testid="hamburger-menu-close-button"]').should('exist').click()
             })
 
             // privacy
             it("navigates to privacy policy", () => {
-                //open the hamburger menu
+                // Open the hamburger menu
                 cy.get('[data-testid="hamburger-menu-icon"]').click()
-
                 cy.get('[data-testid="hamburger-menu-footer-legal-privacy"]').should("be.visible")
                 cy.get('[data-testid="hamburger-menu-footer-legal-privacy').click()
-                // verify navigation
+                // Verify navigation
                 cy.url().should("include", "/privacypolicy")
             })
 
             // terms
             it("navigates to the terms page", () => {
-                //open the hamburger menu
+                // Open the hamburger menu
                 cy.get('[data-testid="hamburger-menu-icon"]').click()
-
                 cy.get('[data-testid="hamburger-menu-footer-legal-terms"]').should("be.visible")
                 cy.get('[data-testid="hamburger-menu-footer-legal-terms').click()
-                // verify navigation
+                // Verify navigation
                 cy.url().should("include", "/terms")
             })
 
             // copyright
             it('copyright is visible', () => {
-                //open the hamburger menu
+                // Open the hamburger menu
                 cy.get('[data-testid="hamburger-menu-icon"]').click()
-
                 cy.get('[data-testid="hamburger-menu-footer-copyright"]').should('exist').should('be.visible')
+                cy.get('[data-testid="hamburger-menu-close-button"]').should('exist').click()
             })
         })
     })

--- a/cypress/e2e/moderationDashboard.cy.ts
+++ b/cypress/e2e/moderationDashboard.cy.ts
@@ -4,122 +4,109 @@ import enUS from "../../i18n/locales/en.json"
 
 describe(
     "Moderation dashboard",
-    {
-        env: {
-            ENABLE_MODERATION_PANEL: true,
-        },
-    },
     () => {
-        beforeEach(() => { }),
-            context("Landscape mode", () => {
-                before(() => {
-                    cy.viewport(1920, 1080)
-                    cy.visit("/moderation")
-
-                })
-
-                it("shows mod dashboard left navbar buttons", () => {
-                    cy.wait(500)
-
-                    cy.get("[data-testid=mod-dashboard-leftnav-for-review]")
-                        .should("exist")
-                        .should(
-                            "include.text",
-                            enUS.modDashboardLeftNav.forReview
-                        )
-
-                    cy.get("[data-testid=mod-dashboard-leftnav-approved]")
-                        .should("exist")
-                        .should(
-                            "include.text",
-                            enUS.modDashboardLeftNav.approved
-                        )
-
-                    cy.get("[data-testid=mod-dashboard-leftnav-rejected]")
-                        .should("exist")
-                        .should(
-                            "include.text",
-                            enUS.modDashboardLeftNav.rejected
-                        )
-                })
-
-                it.skip("it shows the moderation top nav", () => {
-                    // wait for the vue components to actually load
-                    cy.wait(1000)
-
-                    cy.get('[data-testid="mod-submission-list-item-1"]').click()
-                    cy.get('[data-testid="mod-edit-submission-copy-submission-id"]').click()
-
-                    // check that the value copied to the clipboard is the same that's displayed
-                    const clipboardResult = cy.window().then((win) => {
-                        return win.navigator.clipboard.readText()
-                    })
-
-                    // the timeout is to give time for the clipboard to be read
-                    clipboardResult.should("exist", 10000)
-                })
+        context("Landscape mode", () => {
+            before(() => {
+                cy.visit('/moderation')
+                // This wait time is to give the page time to load from Prod when ran in CI.
+                cy.wait(3000)
             })
+            beforeEach(() => {
+                // The resolution is in the beforeEach() instead of before() to
+                // prevent Cypress from defaulting to other screen sizes between tests.
+                cy.viewport(1920, 1080)
+                cy.wait(500)
+            })
+
+            it("shows mod dashboard left navbar buttons", () => {
+                cy.get("[data-testid=mod-dashboard-leftnav-for-review]")
+                    .should("exist")
+                    .should(
+                        "include.text",
+                        enUS.modDashboardLeftNav.forReview
+                    )
+
+                cy.get("[data-testid=mod-dashboard-leftnav-approved]")
+                    .should("exist")
+                    .should(
+                        "include.text",
+                        enUS.modDashboardLeftNav.approved
+                    )
+
+                cy.get("[data-testid=mod-dashboard-leftnav-rejected]")
+                    .should("exist")
+                    .should(
+                        "include.text",
+                        enUS.modDashboardLeftNav.rejected
+                    )
+            })
+
+            it.skip("it shows the moderation top nav", () => {
+                cy.get('[data-testid="mod-submission-list-item-1"]').click()
+                cy.get('[data-testid="mod-edit-submission-copy-submission-id"]').click()
+
+                // check that the value copied to the clipboard is the same that's displayed
+                const clipboardResult = cy.window().then((win) => {
+                    return win.navigator.clipboard.readText()
+                })
+
+                // the timeout is to give time for the clipboard to be read
+                clipboardResult.should("exist", 10000)
+            })
+        })
     }
 )
 
 describe('Moderation Facility Submission Form', () => {
-    context('Landscape mode', () => {
-        beforeEach(() => {
-            cy.viewport(1920, 1080)
-            cy.visit('/moderation')
-           
-            
-            const findADocJapanAPIEndpoint = 'https://api.findadoc.jp/'
-
-                   
-            const mockedSubmissionResponse = {
-              data: {
-                submissions: [
-                  {
+    const findADocJapanAPIEndpoint = 'https://api.findadoc.jp/'
+    const mockedSubmissionResponse = {
+        data: {
+            submissions: [
+                {
                     id: '1',
                     googleMapsUrl: 'https://maps.google.com/?q=custom1',
                     healthcareProfessionalName: 'Dr. John Doe',
                     spokenLanguages: ['English', 'Japanese'],
                     facility: {
-                      id: '1',
-                      nameEn: 'Custom Facility EN',
-                      nameJa: 'カスタム施設 JA',
-                      contact: {
-                        googleMapsUrl: 'https://maps.google.com/?q=facility1',
-                        email: 'contact@facility.com',
-                        phone: '123-456-7890',
-                        website: 'https://facility.com',
-                        address: {
-                          postalCode: '123-4567',
-                          prefectureEn: 'Tokyo',
-                          cityEn: 'Shibuya',
-                          addressLine1En: '1-2-3 Custom St',
-                          addressLine2En: 'Apt 456',
-                          prefectureJa: '東京都',
-                          cityJa: '渋谷区',
-                          addressLine1Ja: 'カスタム通り1-2-3',
-                          addressLine2Ja: '456号室'
-                        }
-                      },
-                      healthcareProfessionalIds: ['1']
+                        id: '1',
+                        nameEn: 'Custom Facility EN',
+                        nameJa: 'カスタム施設 JA',
+                        contact: {
+                            googleMapsUrl: 'https://maps.google.com/?q=facility1',
+                            email: 'contact@facility.com',
+                            phone: '123-456-7890',
+                            website: 'https://facility.com',
+                            address: {
+                                postalCode: '123-4567',
+                                prefectureEn: 'Tokyo',
+                                cityEn: 'Shibuya',
+                                addressLine1En: '1-2-3 Custom St',
+                                addressLine2En: 'Apt 456',
+                                prefectureJa: '東京都',
+                                cityJa: '渋谷区',
+                                addressLine1Ja: 'カスタム通り1-2-3',
+                                addressLine2Ja: '456号室'
+                            }
+                        },
+                        healthcareProfessionalIds: ['1']
                     },
                     healthcareProfessionals: [
-                      {
-                        id: '1',
-                        names: [
-                          {
-                            firstName: 'John',
-                            middleName: '',
-                            lastName: 'Doe',
-                            locale: 'en'
-                          }
-                        ],
-                        spokenLanguages: ['English'],
-                        degrees: ['MD'],
-                        specialties: ['General Practice'],
-                        acceptedInsurance: ['Insurance1'],
-                        facilityIds: ['1']
-                      }
+                        {
+                            id: '1',
+                            names: [
+                                {
+                                    firstName: 'John',
+                                    middleName: '',
+                                    lastName: 'Doe',
+                                    locale: 'en'
+                                }
+                            ],
+                            spokenLanguages: ['English'],
+                            degrees: ['MD'],
+                            specialties: ['General Practice'],
+                            acceptedInsurance: ['Insurance1'],
+                            facilityIds: ['1']
+                        }
                     ],
                     isUnderReview: false,
                     isApproved: true,
@@ -127,28 +114,32 @@ describe('Moderation Facility Submission Form', () => {
                     createdDate: '2023-01-01T00:00:00Z',
                     updatedDate: '2023-01-02T00:00:00Z',
                     notes: 'This is a custom note.'
-                  }
-                ]
-              }
-            }
-
+                }
+            ]
+        }
+    }
+    context('Landscape mode', () => {
+        beforeEach(() => {
+            // The resolution is in the beforeEach() instead of before() to
+            // prevent Cypress from defaulting to other screen sizes between tests.
+            cy.viewport(1920, 1080)
+            cy.visit('/moderation')
             cy.intercept('POST', findADocJapanAPIEndpoint, (req) => {
                 if (req.body.query && req.body.query.includes('query Submissions')) {
-                  req.reply({
-                    statusCode: 200,
-                    body: mockedSubmissionResponse
-                  });
+                    req.reply({
+                        statusCode: 200,
+                        body: mockedSubmissionResponse
+                    });
                 }
-              }).as('getSubmissions');
-
-              cy.wait('@getSubmissions')
-
-              cy.wait(700)
-              cy.get('[data-testid="mod-submission-list-item-1"]').click()
+            }).as('getSubmissions');
+            cy.wait('@getSubmissions')
+            // This wait time is to give the page elements time to load.
+            cy.wait(2000)
+            cy.get('[data-testid="mod-submission-list-item-1"]').click()
+            cy.wait(2000)
         })
 
         it('contains the following input fields', () => {
-
             cy.get('[data-testid="submission-form-nameEn"]').should('exist')
             cy.get('[data-testid="submission-form-nameJp"]').should('exist')
             cy.get('[data-testid="submission-form-phone"]').should('exist')
@@ -173,7 +164,6 @@ describe('Moderation Facility Submission Form', () => {
         })
 
         it('should be able to type in all input fields', () => {
-
             cy.get('[data-testid="submission-form-nameEn"]').find('input').type('Hospital')
             cy.get('[data-testid="submission-form-nameJp"]').find('input').type('立川中央病院')
             cy.get('[data-testid="submission-form-phone"]').find('input').type('08080939393')
@@ -198,7 +188,6 @@ describe('Moderation Facility Submission Form', () => {
         })
 
         it('should be display error messages', () => {
-
             cy.get('[data-testid="submission-form-nameEn"]').find('input').type('立川中央病院').tab()
             cy.get('[data-testid="submission-form-nameEn"]').find('p').should('exist').contains('Invalid English Name')
 
@@ -228,7 +217,6 @@ describe('Moderation Facility Submission Form', () => {
 
             cy.get('[data-testid=submission-form-cityJp]').find('input').type('Shibuya').tab()
             cy.get('[data-testid=submission-form-cityJp]').find('p').should('exist').contains('Invalid Japanese City Name')
-
 
             cy.get('[data-testid="submission-form-addressLine1Jp"]').find('input').type('Peanutbutter street').tab()
             cy.get('[data-testid="submission-form-addressLine1Jp"]').should('exist').contains('Invalid Japanese Address')

--- a/cypress/e2e/submit.cy.ts
+++ b/cypress/e2e/submit.cy.ts
@@ -2,9 +2,18 @@ import enUS from '../../i18n/locales/en.json'
 
 describe('Submit page', () => {
     context('Desktop resolution', () => {
-        beforeEach(() => {
-            cy.viewport(1920, 1080)
+        before(() => {
             cy.visit('/submit')
+            // This wait time is to give the page time to load from Prod when ran in CI.
+            cy.wait(3000)
+        })
+
+        beforeEach(() => {
+            // The resolution is in the beforeEach() instead of before() to
+            // prevent Cypress from defaulting to other screen sizes between tests.
+            cy.viewport(1920, 1080)
+            cy.wait(500)
+
         })
 
         it('shows the desktop top nav', () => {
@@ -55,39 +64,6 @@ describe('Submit page', () => {
             cy.isInViewport('[data-testid="footer"]')
         })
 
-        it('shows the footer without scrolling', () => {
-            cy.isInViewport('[data-testid="footer"]')
-        });
-
-
-    })
-
-    context('Portrait mode', () => {
-        beforeEach(() => {
-            cy.viewport('iphone-5')
-            cy.visit('/submit')
-        })
-
-        it('shows the hamburger component', () => {
-            cy.get('[data-testid="hamburger-menu-icon"]').should('exist').should('be.visible')
-        })
-
-        it('does not show the landscape searchbar', () => {
-            cy.get('[data-testid="landscape-searchbar"]').should("not.be.visible")
-        })
-
-        it('does not show the footer', () => {
-            cy.get('[data-testid="footer"]').should('not.exist')
-        })
-
-    })
-
-    context('form validation', () => {
-        beforeEach(() => {
-            cy.visit('/submit')
-            cy.wait(1000) // wait for the vue components to actually load
-        })
-
         it('does not submit an incomplete form', () => {
             cy.get('[data-testid="submit-submitbutton"]').click()
             cy.get('[data-testid="submit-completed"]').should('not.be.visible')
@@ -119,6 +95,33 @@ describe('Submit page', () => {
             cy.get('[data-testid="submit-select-language1"]').select('日本語 (Japan)')
             cy.contains(enUS.submitPage.spokenLanguageValidation).should('not.be.visible')
         });
+
+    })
+
+    context('Portrait mode', () => {
+        before(() => {
+            cy.visit('/submit')
+            // This wait time is to give the page time to load from Prod when ran in CI.
+            cy.wait(3000)
+        })
+
+        beforeEach(() => {
+            // The resolution is in the beforeEach() instead of before() to
+            // prevent Cypress from defaulting to other screen sizes between tests.
+            cy.viewport(640, 1136)
+        })
+
+        it('shows the hamburger component', () => {
+            cy.get('[data-testid="hamburger-menu-icon"]').should('exist').should('be.visible')
+        })
+
+        it('does not show the landscape searchbar', () => {
+            cy.get('[data-testid="landscape-searchbar"]').should("not.be.visible")
+        })
+
+        it('does not show the footer', () => {
+            cy.get('[data-testid="footer"]').should('not.exist')
+        })
 
     })
 })

--- a/cypress/e2e/submit.cy.ts
+++ b/cypress/e2e/submit.cy.ts
@@ -108,6 +108,8 @@ describe('Submit page', () => {
         beforeEach(() => {
             // The resolution is in the beforeEach() instead of before() to
             // prevent Cypress from defaulting to other screen sizes between tests.
+
+            // An iPhone 5 screen resolution is used to test portrait mode.
             cy.viewport(640, 1136)
         })
 


### PR DESCRIPTION
## 🔧 What changed
Currently, tests are failing assertions for certain elements—some that are not rendering, and some that are offscreen. I discovered that the screen size can change between tests if it's only specified in the `before()` and not the `beforeEach()`. This was causing failures when looking for specific elements in either portrait or landscape mode.

## 🧪 Testing instructions

### Test with local dev server
1. Run `yarn dev`
2. Run `yarn cypress run`
3. Confirm that the tests are passing

Additionally:
1. Run `yarn cypress open`
2. Run each e2e test and confirm that the tests are running against the proper screen resolutions

### Test with prod server
1. Run `yarn prod:build`
2. Run `yarn prod:start`
3. Run `yarn cypress run` to confirm that the tests pass.
4. Follow the Additional steps above
