### PR TITLE
chore: update submission query to match schema

### DIFF
--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -46,6 +46,8 @@ const getSubmissionsGqlQuery = gql`
     spokenLanguages
     facility {
       id
+      mapLatitude
+      mapLongitude
       nameEn
       nameJa
       contact {


### PR DESCRIPTION
Resolves #578

## 🔧 What changed
The query before did not include the `mapLatitude` or `mapLongitude` as part of the graphQl query since it was just added to the backend. This needs to be added in order to autofill forms once they have been updated.

## 🧪 Testing instructions

Start your backend with 
```
npm run dev:startlocaldb
npm run dev
```

Then run 
```
yarn dev:localserver
```

You should be able to successfully query the db and get the mapLatitude and mapLongitude
