### PR TITLE
fix: fix syntax for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 
 # review when someone opens a pull request.
 
--   @theyokohamalife @ermish
+*  @theyokohamalife @ermish


### PR DESCRIPTION
[Documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax)

## 🔧 What changed
Currently, developers are able to merge PRs that are approved by any contributor on the repository. This is due to changes that were made in #240 with improper syntax. This changes it to (hopefully) require code owner approval as intended.

