### PR TITLE
style: match styling of language select to searchbar

### DIFF
--- a/components/LocaleSelector.vue
+++ b/components/LocaleSelector.vue
@@ -2,7 +2,7 @@
   <div class="w-24">
     <select
       v-model="selectedLocale"
-      class="rounded-full  w-full px-1 border-2 border-primary/60 py-1.5 drop-shadow-md text-primary-text bg-primary-bg hover:bg-primary-hover/10 transition-all"
+      class="rounded-full md:w-full px-2 py-1 md:px-1 md:py-1.5 border-2 border-primary/80 md:border-primary/60  drop-shadow-md text-primary-text bg-secondary-bg/5 md:bg-primary-bg hover:bg-primary-hover/10 transition-colors"
     >
       <option
         v-for="(localeOption) in localeStore.mvpLocaleDisplayOptions"
@@ -28,3 +28,6 @@ watch(selectedLocale, (newLocale: any) => {
   locale.value = newLocale;
 });
 </script>
+
+
+rounded-full px-2 py-1 border-2 border-primary/80 drop-shadow-md text-primary-text bg-secondary-bg/5 hover:text-primary-hover transition-colors

--- a/components/LocaleSelector.vue
+++ b/components/LocaleSelector.vue
@@ -2,7 +2,7 @@
   <div class="w-24">
     <select
       v-model="selectedLocale"
-      class="rounded-full md:w-full px-2 py-1 md:px-1 md:py-1.5 border-2 border-primary/80 md:border-primary/60  drop-shadow-md text-primary-text bg-secondary-bg/5 md:bg-primary-bg hover:bg-primary-hover/10 transition-colors"
+      class="rounded-full landscape:w-full px-2 py-1 landscape:px-1 landscape:py-1.5 border-2 border-primary/80 landscape:border-primary/60  drop-shadow-md text-primary-text bg-secondary-bg/5 landscape:bg-primary-bg hover:bg-primary-hover/10 transition-colors"
     >
       <option
         v-for="(localeOption) in localeStore.mvpLocaleDisplayOptions"
@@ -28,6 +28,3 @@ watch(selectedLocale, (newLocale: any) => {
   locale.value = newLocale;
 });
 </script>
-
-
-rounded-full px-2 py-1 border-2 border-primary/80 drop-shadow-md text-primary-text bg-secondary-bg/5 hover:text-primary-hover transition-colors

--- a/components/LocaleSelector.vue
+++ b/components/LocaleSelector.vue
@@ -2,7 +2,7 @@
   <div class="w-24">
     <select
       v-model="selectedLocale"
-      class="rounded-full px-2 py-1 border-2 border-primary/80 drop-shadow-md text-primary-text bg-secondary-bg/5 hover:text-primary-hover transition-colors"
+      class="rounded-full  w-full px-1 border-2 border-primary/60 py-1.5 drop-shadow-md text-primary-text bg-primary-bg hover:bg-primary-hover/10 transition-all"
     >
       <option
         v-for="(localeOption) in localeStore.mvpLocaleDisplayOptions"


### PR DESCRIPTION
## 🔧 What changed
This was mentioned a while back by @Ntlja. She noticed that our selects were not consistent in styling. So this updates the `LocaleSelector` to use the same styling as the `SearchBar` in terms of padding. I kept the styling in the hamburger menu the same due to it being styled in a way that fits into the hamburger menu text sizing.

## 🧪 Testing instructions
Run `yarn dev` and confirm it matches the screenshots

## 📸 Screenshots

-   ### Before
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/a0c0dd1e-8579-4187-a8df-97d3be5b8460)

Mobile:
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/d7618634-f0f0-4aba-b13b-d1883b8ccf44)


-   ### After
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/1f7d27c4-3c20-404f-898f-50935367d5c4)

Mobile:
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/c46f670b-af30-471b-9b5f-4e72cb98eea9)
