### PR TITLE
refactor: remove isInViewport and isNotInViewport

### DIFF
--- a/cypress/e2e/about.cy.ts
+++ b/cypress/e2e/about.cy.ts
@@ -53,7 +53,7 @@ describe('About page', () => {
         })
 
         it('shows the footer without scrolling', () => {
-            cy.isInViewport('[data-testid="footer"]')
+            cy.get('[data-testid="footer"]').should('be.visible')
         })
 
     })

--- a/cypress/e2e/privacy.cy.ts
+++ b/cypress/e2e/privacy.cy.ts
@@ -22,7 +22,7 @@ describe('Privacy Policy page', () => {
         })
 
         it('shows the footer without scrolling', () => {
-            cy.isInViewport('[data-testid="footer"]')
+            cy.get('[data-testid="footer"]').should('be.visible')
         })
 
 

--- a/cypress/e2e/submit.cy.ts
+++ b/cypress/e2e/submit.cy.ts
@@ -61,7 +61,7 @@ describe('Submit page', () => {
         })
 
         it('shows the footer without scrolling', () => {
-            cy.isInViewport('[data-testid="footer"]')
+            cy.get('[data-testid="footer"]').should('be.visible')
         })
 
         it('does not submit an incomplete form', () => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,29 +23,3 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-/* global cy */
-/* global Cypress */
-/* global expect */
-Cypress.Commands.add('isNotInViewport', element => {
-    cy.get(element).then($el => {
-      const bottom = Cypress.$(cy.state('window')).height()
-      const rect = $el[0].getBoundingClientRect()
-
-      expect(rect.top).to.be.greaterThan(bottom)
-      expect(rect.bottom).to.be.greaterThan(bottom)
-      expect(rect.top).to.be.greaterThan(bottom)
-      expect(rect.bottom).to.be.greaterThan(bottom)
-    })
-  })
-
-  Cypress.Commands.add('isInViewport', element => {
-    cy.get(element).then($el => {
-      const bottom = Cypress.$(cy.state('window')).height()
-      const rect = $el[0].getBoundingClientRect()
-
-      expect(rect.top).not.to.be.greaterThan(bottom)
-      expect(rect.bottom).not.to.be.greaterThan(bottom)
-      expect(rect.top).not.to.be.greaterThan(bottom)
-      expect(rect.bottom).not.to.be.greaterThan(bottom)
-    })
-  })


### PR DESCRIPTION
## 🔧 What changed
This change removes the custom `isInViewport` and `isNotInViewport` commands. They were introduced as a way to ensure that the top navigation and footer were always visible without scrolling. However, they are conflicting somehow (possibly with webpack) when CI is ran through the Github Actions.

## 🧪 Testing instructions
1. Run `yarn dev`
2. Run `yarn cypress run` and confirm the tests _pass_

## 📸 Screenshots
<img width="778" alt="Screenshot 2024-06-18 at 4 09 26 PM" src="https://github.com/ourjapanlife/findadoc-web/assets/31802656/f6a5daaf-938f-4390-aeda-9dc4bfc6678c">

