### PR TITLE
implement fade in photo component

### DIFF
--- a/components/MemberComponent.vue
+++ b/components/MemberComponent.vue
@@ -54,7 +54,6 @@
 import SVGLinkedinIcon from '~/assets/icons/social-linkedin.svg'
 import SVGGithubIcon from '~/assets/icons/social-github.svg'
 import type { PropType } from "vue"
-import SmoothLoadingImage from './SmoothLoadingImage.vue';
 
 defineProps({
     avatarImg: {

--- a/components/MemberComponent.vue
+++ b/components/MemberComponent.vue
@@ -1,9 +1,13 @@
 <template>
     <div class="member flex flex-col items-center text-center">
-        <img
-            data-testid="member-avatar"
-            :src="avatarImg"
-            class="member-image object-cover rounded-full w-32 h-32"
+        <SmoothLoadingImage
+            :imgSrc="avatarImg"
+            :testId="`member-avatar-${index}`"
+            :alt="name"
+            object-styling="cover"
+            height="32"
+            width="32"
+            borderRadius="full"
         />
         <div
             data-testid="member-name"
@@ -50,11 +54,16 @@
 import SVGLinkedinIcon from '~/assets/icons/social-linkedin.svg'
 import SVGGithubIcon from '~/assets/icons/social-github.svg'
 import type { PropType } from "vue"
+import SmoothLoadingImage from './SmoothLoadingImage.vue';
 
 defineProps({
     avatarImg: {
         type: String,
         required: true,
+    },
+    index: {
+        type: Number,
+        require: true
     },
     name: {
         type: String,
@@ -71,6 +80,6 @@ defineProps({
     githubUrl: {
         type: [String, null] as PropType<string | null>,
         required: false,
-    },
+    }
 })
 </script>

--- a/components/SmoothLoadingImage.vue
+++ b/components/SmoothLoadingImage.vue
@@ -1,7 +1,7 @@
 <template>
   
-    <SmoothLoadingImageFadeTransition><div v-show="!show.showing"><SVGLoadingIcon /></div></SmoothLoadingImageFadeTransition>
-   <SmoothLoadingImageFadeTransition><img v-show="show.showing" :data-testid=testId :class="`object-${objectStyling} rounded-${borderRadius} w-${width} h-${height}`" :src="src" @load="showImg()"/></SmoothLoadingImageFadeTransition>
+    <SmoothLoadingImageFadeTransition><div v-show="!isVisible"><SVGLoadingIcon /></div></SmoothLoadingImageFadeTransition>
+   <SmoothLoadingImageFadeTransition><img v-show="isVisible" :data-testid=testId :class="`object-${objectStyling} rounded-${borderRadius} w-${width} h-${height}`" :src="src" @load="showImg()"/></SmoothLoadingImageFadeTransition>
 
 </template>
 
@@ -41,16 +41,16 @@
   })
   
   const src:Ref<string | undefined> = ref()
-  const show = reactive({showing: false});
+  const isVisible:Ref<boolean> = ref(false)
   const showImg = function () {
-    show.showing = true
+    isVisible.value = true
   }
   
   watch(
     () => props.imgSrc,
     () => {
     src.value = props.imgSrc
-    show.showing = false
+    isVisible.value = false
   }, {immediate: true})
   
 

--- a/components/SmoothLoadingImage.vue
+++ b/components/SmoothLoadingImage.vue
@@ -1,7 +1,7 @@
 <template>
   
     <SmoothLoadingImageFadeTransition><div v-show="!show.showing"><SVGLoadingIcon /></div></SmoothLoadingImageFadeTransition>
-   <SmoothLoadingImageFadeTransition><img v-show="show.showing" :class="`object-${objectStyling} rounded-${borderRadius} w-${width} h-${height}`" :src="src" @load="showImg()"/></SmoothLoadingImageFadeTransition>
+   <SmoothLoadingImageFadeTransition><img v-show="show.showing" :data-testid=testId :class="`object-${objectStyling} rounded-${borderRadius} w-${width} h-${height}`" :src="src" @load="showImg()"/></SmoothLoadingImageFadeTransition>
 
 </template>
 

--- a/components/SmoothLoadingImage.vue
+++ b/components/SmoothLoadingImage.vue
@@ -1,0 +1,77 @@
+<template>
+  
+    <SmoothLoadingImageFadeTransition><div v-show="!show.showing"><SVGLoadingIcon /></div></SmoothLoadingImageFadeTransition>
+   <SmoothLoadingImageFadeTransition><img v-show="show.showing" :class="`object-${objectStyling} rounded-${borderRadius} w-${width} h-${height}`" :src="src" @load="showImg()"/></SmoothLoadingImageFadeTransition>
+
+</template>
+
+<script lang='ts' setup>
+  import { reactive, ref, watch, type Ref } from 'vue'
+  import SVGLoadingIcon from '~/assets/icons/loading.svg'
+
+  const props = defineProps({
+    imgSrc: {
+        type: String,
+        required: true,
+    },
+    testId: {
+        type: String,
+        required: true,
+    },
+    alt: {
+        type: String,
+        required: true,
+    },
+    objectStyling:{
+        type: String,
+        required: true,
+    },
+    height:{
+        type: String,
+        required: true,
+    },
+    width:{
+        type: String,
+        required: true,
+    },
+    borderRadius:{
+        type: String,
+        required: true,
+    },
+  })
+  
+  const src:Ref<string | undefined> = ref()
+  const show = reactive({showing: false});
+  const showImg = function () {
+    show.showing = true
+  }
+  
+  watch(
+    () => props.imgSrc,
+    () => {
+    src.value = props.imgSrc
+    show.showing = false
+  }, {immediate: true})
+  
+
+</script>
+
+
+<style scoped>
+  .loader {
+    border: 4px solid grey;
+    border-top: 4px solid darkGrey;
+    border-radius: 50%;
+    width: 30px;
+    height: 30px;
+    animation: spin 5s linear infinite;
+    position: absolute;
+    left: calc(50% - 15px);
+    top: calc(50% - 15px);
+  }
+
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+</style>

--- a/components/SmoothLoadingImageFadeTransition.vue
+++ b/components/SmoothLoadingImageFadeTransition.vue
@@ -1,0 +1,20 @@
+<script>
+</script>
+
+<template>
+  <Transition name="fade">
+    <slot></slot> 
+  </Transition>
+</template>
+
+<style>
+  .fade-enter-active, 
+  .fade-leave-active {
+    transition: opacity 1s ease;
+  }
+
+  .fade-enter-from, 
+  .fade-leave-to {
+    opacity: 0;
+  }
+</style>

--- a/cypress/e2e/about.cy.ts
+++ b/cypress/e2e/about.cy.ts
@@ -45,7 +45,7 @@ describe('About page', () => {
         })
 
         it('shows member details', () => {
-            cy.get('[data-testid="member-avatar"]').should('exist')
+            cy.get('[data-testid="member-avatar-0"]').should('exist')
             cy.get('[data-testid="member-name"]').should('exist')
             cy.get('[data-testid="member-title"]').should('exist')
             cy.get('[data-testid="member-linkedin"]').should('exist')
@@ -87,7 +87,7 @@ describe('About page', () => {
         })
 
         it('shows member details', () => {
-            cy.get('[data-testid="member-avatar"]').should('exist')
+            cy.get('[data-testid="member-avatar-0"]').should('exist')
             cy.get('[data-testid="member-name"]').should('exist')
             cy.get('[data-testid="member-title"]').should('exist')
             cy.get('[data-testid="member-linkedin"]').should('exist')

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="overflow-y-auto w-full">
+    <div class="w-full">
         <div class="flex flex-col items-center px-10 md:px-32">
             <SvgHeartPlus role="img" alt="pink heart with a white plus in the middle to symbolize health" title="heart icon"
                 class="my-4 h-32" />
@@ -32,7 +32,7 @@
                 <div data-testid="member" class="members-list grid"
                     :key="index" v-for="(member, index) in data.members">
                     <MemberComponent :avatarImg="member.avatarImg" :name="member.name" :title="member.title"
-                        :linkedInUrl="member.linkedInUrl" :githubUrl="member.githubUrl" />
+                        :index=index :linkedInUrl="member.linkedInUrl" :githubUrl="member.githubUrl" />
                 </div>
             </div>
         </div>
@@ -41,6 +41,5 @@
 
 <script setup lang="ts">
 import data from "../member_directory/members.json"
-import MemberComponent from "~/components/MemberComponent.vue"
 import SvgHeartPlus from '~/assets/icons/heart-plus.svg'
 </script>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="w-full">
+    <div class="overflow-y-auto w-full">
         <div class="flex flex-col items-center px-10 md:px-32">
             <SvgHeartPlus role="img" alt="pink heart with a white plus in the middle to symbolize health" title="heart icon"
                 class="my-4 h-32" />
@@ -30,9 +30,9 @@
             <div data-testid="members" id="members"
                 class="grid grid-cols-2 md:grid-cols-3 mx-4 gap-8 pb-12 md:pb-32">
                 <div data-testid="member" class="members-list grid"
-                    :key="index" v-for="(member, index) in data.members">
+                    :key="member.avatarImg" v-for="(member, index) in data.members">
                     <MemberComponent :avatarImg="member.avatarImg" :name="member.name" :title="member.title"
-                        :index=index :linkedInUrl="member.linkedInUrl" :githubUrl="member.githubUrl" />
+                        :indexForTests=index :linkedInUrl="member.linkedInUrl" :githubUrl="member.githubUrl" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This component can be used anywhere in the app. It allows for a smoother load of images no matter the size. Even after compressing the about us files they would sometimes load in a manner that was less than ideal. Now it loads with a fade in effect. Tests were refactored to be updated for the component.

## 🔧 What changed
Before the loading image on the about us page was a bit choppy

## 🧪 Testing instructions
Go to the branch and run: 
```
yarn dev
yarn cypress open
```
Run the about specs

## 📸 Screenshots

-   ### Before
https://www.loom.com/share/d1249542d49c4113934080f20ef8ffd2

-   ### After
https://www.loom.com/share/5dd53ead6c424cf2b51ebb518feaff68