### PR TITLE
feat: auth - add support for moderator and admin roles in the moderation dashboard

### DIFF
--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -12,6 +12,7 @@
                 >
                     {{ $t('login.checkingauth') }}
                 </div>
+
                 <div
                     v-if="!authStore.isLoadingAuth && !authStore.isAdmin && !authStore.isModerator"
                     data-testid="unauthorized-message"
@@ -58,7 +59,7 @@
 
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router'
-import { watch } from 'vue'
+import { onMounted, watch } from 'vue'
 import { useAuthStore } from '~/stores/authStore'
 import { definePageMeta } from '#imports'
 
@@ -76,12 +77,16 @@ const checkIfUserIsLoggedIn = async () => {
     // It doesn't do anything, but <Suspense> requires an awaited setup method
     await authStore.refreshUserCredentials()
 
+    const doesTheUserHaveAccess = route.path.startsWith('/moderation')
+      && !authStore.isLoggedIn
+      && !authStore.isLoadingAuth
+
     //ignore if route change is unrelated to moderation
-    if (route.path === "/moderation" && !authStore.isLoggedIn && !authStore.isLoadingAuth) {
+    if (doesTheUserHaveAccess) {
         // give the user a bit of time to read the message before redirecting
         setTimeout(() => {
             // Redirect to login page if user is not logged in
-            router.push("/")
+            router.push('/')
         }, 10000)
     }
 }
@@ -90,5 +95,7 @@ watch(route, async () => {
     await checkIfUserIsLoggedIn()
 })
 
-await checkIfUserIsLoggedIn()
+onMounted(async () => {
+    await checkIfUserIsLoggedIn()
+})
 </script>

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -74,18 +74,16 @@ const router = useRouter()
 const checkIfUserIsLoggedIn = async () => {
     // This promise is here to make the Suspense component work.
     // It doesn't do anything, but <Suspense> requires an awaited setup method
-    await new Promise(resolve => {
-        //ignore if route change is unrelated to moderation
-        if (route.path === '/moderation' && !authStore.isLoggedIn && !authStore.isLoadingAuth) {
-            // give the user a bit of time to read the message before redirecting
-            setTimeout(() => {
-                // Redirect to login page if user is not logged in
-                router.push('/')
-            }, 10000)
-        }
+    await authStore.refreshUserCredentials()
 
-        resolve(true)
-    })
+    //ignore if route change is unrelated to moderation
+    if (route.path === "/moderation" && !authStore.isLoggedIn && !authStore.isLoadingAuth) {
+        // give the user a bit of time to read the message before redirecting
+        setTimeout(() => {
+            // Redirect to login page if user is not logged in
+            router.push("/")
+        }, 10000)
+    }
 }
 
 watch(route, async () => {

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
-import { type Ref, ref, computed } from 'vue'
+import { type Ref, ref, computed, watch } from 'vue'
+import { useLoadingStore } from './loadingStore.js'
 import { auth0 } from '../utils/auth0.js'
 import { useLoadingStore } from './loadingStore.js'
 
@@ -7,8 +8,20 @@ export const useAuthStore = defineStore('authStore', () => {
     const userId = computed(() => auth0?.user.value?.nickname ?? 'unknown user')
     const isLoadingAuth = computed(() => auth0?.isLoading.value)
     const isLoggedIn = computed(() => !auth0?.isLoading.value && auth0?.isAuthenticated.value)
-    const isAdmin = computed(() => !auth0?.isLoading.value && auth0?.isAuthenticated.value)
+    // const isAdmin = computed(() => !auth0?.isLoading.value && auth0?.isAuthenticated.value)
+    const isAdmin: Ref<boolean> = ref(false)
     const isModerator: Ref<boolean> = ref(false)
+    const authToken: Ref<string | null> = ref(null)
+
+    watch(auth0.isAuthenticated, async (isLoggedIn) => {
+        if (isLoggedIn) {
+            await refreshUserCredentials()
+        } else {
+            isAdmin.value = false
+            isModerator.value = false
+            authToken.value = null
+        }
+    }, { deep: true })
 
     async function login() {
         //set the loading visual state
@@ -20,6 +33,7 @@ export const useAuthStore = defineStore('authStore', () => {
             isModerator.value = false
 
             if (!auth0.isAuthenticated.value) {
+                //login with auth0. this redirects the user to the auth0 login page, then returns to the home page after login
                 await auth0.loginWithRedirect()
             }
 
@@ -39,5 +53,32 @@ export const useAuthStore = defineStore('authStore', () => {
         await auth0.logout({ logoutParams: { returnTo: window.location.origin } })
     }
 
-    return { userId, isLoggedIn, isLoadingAuth, isAdmin, isModerator, login, logout }
+
+    async function refreshUserCredentials() {
+        //if the user is not logged in, we don't need to do anything
+        if (!auth0.isAuthenticated.value)
+            return
+
+        //get the access token after login. We'll send this with our requests to our API
+        const newToken = await auth0.getAccessTokenSilently()
+        authToken.value = newToken
+
+        //fetch the user's permissions from the auth0 management API
+        const userId = auth0.user.value?.sub
+        const response = await fetch(`https://findadoc.jp.auth0.com/api/v2/users/${userId}/permissions`, {
+            headers: {
+                Authorization: 'Bearer ' + newToken
+            }
+        })
+
+        const userPermissionsData = await response.json()
+
+        if (!userPermissionsData || !userPermissionsData.permissions)
+            throw new Error('Error retrieving user permissions: No permissions data found')
+
+        isAdmin.value = userPermissionsData.permissions.includes('admin')
+        isModerator.value = userPermissionsData.permissions.includes('moderator')
+    }
+
+    return { userId, isLoggedIn, isLoadingAuth, isAdmin, isModerator, login, logout, refreshUserCredentials }
 })

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { type Ref, ref, computed, watch } from 'vue'
-import { useLoadingStore } from './loadingStore.js'
 import { auth0 } from '../utils/auth0.js'
 import { useLoadingStore } from './loadingStore.js'
 
@@ -10,10 +9,11 @@ export const useAuthStore = defineStore('authStore', () => {
     const isLoggedIn = computed(() => !auth0?.isLoading.value && auth0?.isAuthenticated.value)
     // const isAdmin = computed(() => !auth0?.isLoading.value && auth0?.isAuthenticated.value)
     const isAdmin: Ref<boolean> = ref(false)
+
     const isModerator: Ref<boolean> = ref(false)
     const authToken: Ref<string | null> = ref(null)
 
-    watch(auth0.isAuthenticated, async (isLoggedIn) => {
+    watch(() => auth0.isAuthenticated, async isLoggedIn => {
         if (isLoggedIn) {
             await refreshUserCredentials()
         } else {
@@ -53,7 +53,6 @@ export const useAuthStore = defineStore('authStore', () => {
         await auth0.logout({ logoutParams: { returnTo: window.location.origin } })
     }
 
-
     async function refreshUserCredentials() {
         //if the user is not logged in, we don't need to do anything
         if (!auth0.isAuthenticated.value)
@@ -64,7 +63,7 @@ export const useAuthStore = defineStore('authStore', () => {
         authToken.value = newToken
 
         //fetch the user's permissions from the auth0 management API
-        const userId = auth0.user.value?.sub
+        const userId = auth0.user.value?.name
         const response = await fetch(`https://findadoc.jp.auth0.com/api/v2/users/${userId}/permissions`, {
             headers: {
                 Authorization: 'Bearer ' + newToken

--- a/utils/auth0.ts
+++ b/utils/auth0.ts
@@ -24,6 +24,7 @@ export const initializeAuth0 = () => {
                 },
                 //eslint-disable-next-line
                 redirect_uri: isProduction ? 'https://www.findadoc.jp' : 'http://localhost:3000'
+                audience: 'https://findadoc.jp.auth0.com/api/v2/'
             }
         })
 

--- a/utils/auth0.ts
+++ b/utils/auth0.ts
@@ -23,7 +23,7 @@ export const initializeAuth0 = () => {
                     target: useRoute().path
                 },
                 //eslint-disable-next-line
-                redirect_uri: isProduction ? 'https://www.findadoc.jp' : 'http://localhost:3000'
+                redirect_uri: isProduction ? 'https://www.findadoc.jp' : 'http://localhost:3000',
                 audience: 'https://findadoc.jp.auth0.com/api/v2/'
             }
         })


### PR DESCRIPTION
Dependent on #549 
Resolves #571 

## 🔧 What changed
- added support for  user roles!

## 🧪 Testing instructions

## 📸 Screenshots

-   ### Before

-   ### After
