### PR TITLE
feat: create logic for fetching healthcare professionals

### DIFF
--- a/components/ModHealthcareProfessionalSearchbar.vue
+++ b/components/ModHealthcareProfessionalSearchbar.vue
@@ -6,10 +6,12 @@
         <div class="flex flex-col mt-4">
             <div class="justify-start items-start flex">
                 <input
+                    v-model="requestedHealthcareProfessionalId"
                     type="text"
                     :placeholder="$t('modSubmissionForm.placeholderTextHealthcareProfessionalSearchbar')"
                     class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                     text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
+                    @input="searchHealthcareProfessionalById"
                 >
                 <SVGLookingGlass
                     role="img"
@@ -22,5 +24,19 @@
 </template>
 
 <script lang="ts" setup>
+import { ref, type Ref } from 'vue'
 import SVGLookingGlass from '~/assets/icons/looking-glass.svg'
+import type { HealthcareProfessional } from '~/typedefs/gqlTypes'
+import { getHealthcareProfessionalById } from '~/stores/healthcareProfessionalsStore'
+
+const requestedHealthcareProfessionalId: Ref<string> = ref('')
+// `healthcareProfessionalById` will be used in the UI component in an upcoming PR
+const healthcareProfessionalById: Ref<HealthcareProfessional[] | []> = ref([])
+
+async function searchHealthcareProfessionalById() {
+    if (!requestedHealthcareProfessionalId.value || requestedHealthcareProfessionalId.value.trim().length < 1) {
+        return
+    }
+    healthcareProfessionalById.value = await getHealthcareProfessionalById(requestedHealthcareProfessionalId.value)
+}
 </script>

--- a/stores/healthcareProfessionalsStore.ts
+++ b/stores/healthcareProfessionalsStore.ts
@@ -52,6 +52,26 @@ async function queryHealthcareProfessionals() {
     }
 }
 
+export async function getHealthcareProfessionalById(id: string) {
+    try {
+        const queryData = {
+            healthcareProfessionalId: id
+        }
+        const result = await gqlClient.request<{ healthcareProfessional: HealthcareProfessional[] }>(
+            getHealthcareProfessionalByIdGqlQuery,
+            queryData
+        )
+
+        if (!result.healthcareProfessional) {
+            throw new Error(`The Healthcare Professional ID doesn't exist`)
+        }
+        return result.healthcareProfessional
+    } catch (error: unknown) {
+        console.log(`Error retrieving healthcare professional by id: ${id}: ${JSON.stringify(error)}`)
+        return []
+    }
+}
+
 const getAllHealthcareProfessionalsData = gql`
 query Query($filters: HealthcareProfessionalSearchFilters!) {
   healthcareProfessionals(filters: $filters) {
@@ -71,6 +91,19 @@ query Query($filters: HealthcareProfessionalSearchFilters!) {
     updatedDate
   }
 }`
+
+const getHealthcareProfessionalByIdGqlQuery = gql`
+    query HealthcareProfessionals($healthcareProfessionalId: ID!) {
+        healthcareProfessional(id: $healthcareProfessionalId) {
+        names {
+            firstName
+            lastName
+        }
+        id
+        specialties
+    }
+}`
+
 
 const updateHealthcareProfessionalGqlMutation = gql`
 mutation Mutation($updateHealthcareProfessionalId: ID!, $input: UpdateHealthcareProfessionalInput!) {

--- a/stores/healthcareProfessionalsStore.ts
+++ b/stores/healthcareProfessionalsStore.ts
@@ -104,7 +104,6 @@ const getHealthcareProfessionalByIdGqlQuery = gql`
     }
 }`
 
-
 const updateHealthcareProfessionalGqlMutation = gql`
 mutation Mutation($updateHealthcareProfessionalId: ID!, $input: UpdateHealthcareProfessionalInput!) {
   updateHealthcareProfessional(id: $updateHealthcareProfessionalId, input: $input) {


### PR DESCRIPTION
Resolves #530 

## 🔧 What changed

**❗Changes Made Against Design ❗**

I have decided to only implement search a healthcare professional by id only, this is why;

At the moment we don't have a fuzzy search in the backend. This means that we need to search by exact name type like following: 
```
type LocalizedName {
  firstName: String!
  middleName: String
  lastName: String!
  locale: Locale!
}
```
So if you would make a request it should exactly match those fields. In my opinion I think it's better to just use the id for now. If we have a fuzzy search in the future we can implement searching by name.

- Fetch the healthcare professionals for the ModSearchHealthcareProfessional component
- Create graphQl query
- Create a moderationSearchHealthcareProfessionalStore

## To do
- Implement the UI for this part
