### PR TITLE
feat: show filtered data in ModSubmissionList

### DIFF
--- a/components/ModDashboardLeftNavbar.vue
+++ b/components/ModDashboardLeftNavbar.vue
@@ -17,7 +17,7 @@
                 <button
                     data-testid="mod-dashboard-leftnav-for-review"
                     class="flex flex-row items-center text-start p-1"
-                    @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.forReview)"
+                    @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.ForReview)"
                 >
                     {{ $t("modDashboardLeftNav.forReview") }} ({{ autofillStatusCount.forReviewCount }})
                 </button>
@@ -27,7 +27,7 @@
                 <button
                     data-testid="mod-dashboard-leftnav-approved"
                     class="flex flex-row items-center text-start p-1 "
-                    @click=" updateSubmissionListViewState(SelectedSubmissionListViewTab.approved)"
+                    @click=" updateSubmissionListViewState(SelectedSubmissionListViewTab.Approved)"
                 >
                     {{ $t("modDashboardLeftNav.approved") }} ({{ autofillStatusCount.approvedCount }})
                 </button>
@@ -37,7 +37,7 @@
                 <button
                     data-testid="mod-dashboard-leftnav-rejected"
                     class="flex flex-row items-center text-start p-1"
-                    @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.rejected)"
+                    @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.Rejected)"
                 >
                     {{ $t("modDashboardLeftNav.rejected") }} ({{ autofillStatusCount.rejectedCount }})
                 </button>
@@ -69,6 +69,7 @@ const updateSelectedDashboardView = (event: Event) => {
 
 function createCountsForSubmissionListView(submissions: Submission[]) {
     return submissions.reduce((statusCountObject, submission) => {
+        const isNewSubmission = !submission.isRejected && !submission.isApproved && !submission.isUnderReview
         if (submission.isUnderReview) {
             statusCountObject.forReviewCount += 1
         }
@@ -78,7 +79,7 @@ function createCountsForSubmissionListView(submissions: Submission[]) {
         if (submission.isRejected) {
             statusCountObject.rejectedCount += 1
         }
-        if (!submission.isRejected && !submission.isApproved && !submission.isUnderReview) {
+        if (isNewSubmission) {
             statusCountObject.forReviewCount += 1
         }
         return statusCountObject
@@ -92,8 +93,8 @@ function createCountsForSubmissionListView(submissions: Submission[]) {
 const autofillStatusCount = computed(() => createCountsForSubmissionListView(moderationSubmissionsStore.submissionsData))
 
 watchEffect(() => {
-    if (moderationSubmissionsStore.submissionsData.length > 0) {
-        moderationSubmissionsStore.filterSubmissionsBySelectedTab(SelectedSubmissionListViewTab.forReview)
+    if (moderationSubmissionsStore.submissionsData.length) {
+        moderationSubmissionsStore.filterSubmissionsBySelectedTab(SelectedSubmissionListViewTab.ForReview)
     }
 })
 </script>

--- a/components/ModSubmissionListContainer.vue
+++ b/components/ModSubmissionListContainer.vue
@@ -23,7 +23,7 @@
             class="grid grid-cols-subgrid col-span-5"
         >
             <div
-                v-for="(submission, index) in modSubmissionsStore.submissionsData"
+                v-for="(submission, index) in modSubmissionsStore.filteredSubmissionDataForListComponent"
                 :key="index"
                 class="grid grid-cols-subgrid col-span-5 bg-gray-200"
             >

--- a/cypress/e2e/moderationDashboard.cy.ts
+++ b/cypress/e2e/moderationDashboard.cy.ts
@@ -144,7 +144,6 @@ describe(
 
                 cy.intercept('POST', '**/', req => {
                     req.continue(res => {
-                        console.log(req.body.query)
                         if (req.body.query && req.body.query.includes('query Submissions')) {
                             res.send({
                                 statusCode: 200,
@@ -197,6 +196,25 @@ describe(
                         'include.text',
                         '0'
                     )
+            })
+
+            it('updates the submission list based on selected tab', () => {
+                cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
+
+                cy.get('[data-testid=mod-dashboard-leftnav-approved]')
+                    .click()
+
+                cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
+
+                cy.get('[data-testid=mod-dashboard-leftnav-rejected]')
+                    .click()
+
+                cy.get('[data-testid="mod-submission-list-item-1"]').should('not.exist')
+
+                cy.get('[data-testid=mod-dashboard-leftnav-for-review]')
+                    .click()
+
+                cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
             })
 
             it.skip('it shows the moderation top nav', () => {
@@ -290,7 +308,7 @@ describe('Moderation Facility Submission Form', () => {
         })
 
         it('should autofill the form', () => {
-            const submission = mockedSubmissionResponse.data.submissions[0].facility
+            const submission = mockedSubmissionResponse.data.submissions[1].facility
 
             cy.get('[data-testid="submission-form-nameEn"]').find('input', { timeout: 10000 })
                 .should('have.value', submission.nameEn)

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -5,9 +5,9 @@ import { gqlClient } from '../utils/graphql.js'
 import { type Submission } from '~/typedefs/gqlTypes.js'
 
 export enum SelectedSubmissionListViewTab {
-    forReview = 'forReview',
-    approved = 'approved',
-    rejected = 'rejected'
+    ForReview = 'FOR_REVIEW',
+    Approved = 'APPROVED',
+    Rejected = 'REJECTED'
 }
 
 export const useModerationSubmissionsStore = defineStore(
@@ -29,22 +29,30 @@ export const useModerationSubmissionsStore = defineStore(
 
         function filterSubmissionsBySelectedTab(tabValue: SelectedSubmissionListViewTab) {
             switch (tabValue) {
-                case 'forReview':
+                case SelectedSubmissionListViewTab.ForReview:
                     filteredSubmissionDataForListComponent.value = submissionsData.value
-                        .filter((submission: Submission) => submission.isUnderReview ||
-                        (!submission.isApproved && !submission.isRejected && !submission.isUnderReview))
+                        .filter((submission: Submission) => {
+                            const isNewSubmission = !submission.isRejected && !submission.isApproved && !submission.isUnderReview
+                            return submission.isUnderReview || isNewSubmission
+                        })
                     break
-                case 'approved':
+                case SelectedSubmissionListViewTab.Approved:
                     filteredSubmissionDataForListComponent.value = submissionsData.value
                         .filter((submission: Submission) => submission.isApproved)
                     break
-                case 'rejected':
+                case SelectedSubmissionListViewTab.Rejected:
                     filteredSubmissionDataForListComponent.value = submissionsData.value
                         .filter((submission: Submission) => submission.isRejected)
                     break
             }
         }
-        return { getSubmissions, submissionsData, filterSubmissionsBySelectedTab, filteredSubmissionDataForListComponent, selectedSubmissionId, filterSelectedSubmission, selectedSubmissionData }
+        return { getSubmissions,
+            submissionsData,
+            filterSubmissionsBySelectedTab,
+            filteredSubmissionDataForListComponent,
+            selectedSubmissionId,
+            filterSelectedSubmission,
+            selectedSubmissionData }
     }
 )
 


### PR DESCRIPTION
Resolves #508 

## 🔧 What changed
Before we would show all the different types of submissions in the `SubmissionListComponent`. Now it is filtered based on which tab is selected.

## 🧪 Testing instructions
There are tests added so you can go to the branch and run
```
yarn dev
yarn cypress open
```
and then run the `moderationDashboard.cy.ts` spec

## 📸 Screenshots

-   ### Before
https://www.loom.com/share/cec042893b6c476881e3b398f76f6fc4
-   ### After
https://www.loom.com/share/6f2c0e990acc403fae1203b38e061e6e
