### PR TITLE
feat: implement transition for fade-in images

### DIFF
--- a/components/FadeInTransitionImage.vue
+++ b/components/FadeInTransitionImage.vue
@@ -1,0 +1,80 @@
+<template>
+    <Transition
+        enter-active-class="transition-opacity duration-1000 ease"
+        enter-from-class="opacity-0"
+        leave-active-class="transition-opacity duration-1000 ease"
+        leave-to-class="opacity-0"
+    >
+        <div v-show="!isVisible">
+            <SVGLoadingIcon />
+        </div>
+    </Transition>
+    <Transition
+        enter-active-class="transition-opacity duration-1000 ease"
+        enter-from-class="opacity-0"
+        leave-active-class="transition-opacity duration-1000 ease"
+        leave-to-class="opacity-0"
+    >
+        <img
+            v-show="isVisible"
+            :data-testid="dataTestId"
+            :class="`${objectStyling} ${borderRadius} ${width} ${height}`"
+            :src="src"
+            :alt="alt"
+            @load="showImg"
+            @error="handleError"
+        >
+    </Transition>
+</template>
+
+<script setup lang='ts'>
+import { onMounted, ref, type Ref } from 'vue'
+import SVGLoadingIcon from '~/assets/icons/loading.svg'
+
+const props = defineProps({
+    imgSrc: {
+        type: String,
+        required: true
+    },
+    dataTestId: {
+        type: String,
+        required: true
+    },
+    alt: {
+        type: String,
+        required: true
+    },
+    objectStyling: {
+        type: String,
+        required: true
+    },
+    height: {
+        type: String,
+        required: true
+    },
+    width: {
+        type: String,
+        required: true
+    },
+    borderRadius: {
+        type: String,
+        required: true
+    }
+})
+
+const src: Ref<string | undefined> = ref<string>()
+const isVisible: Ref<boolean> = ref(false)
+
+const showImg = () => {
+    isVisible.value = true
+}
+
+const handleError = () => {
+    isVisible.value = false
+}
+
+onMounted(() => {
+    src.value = props.imgSrc
+    isVisible.value = false
+})
+</script>

--- a/components/MemberComponent.vue
+++ b/components/MemberComponent.vue
@@ -1,10 +1,14 @@
 <template>
     <div class="member flex flex-col items-center text-center">
-        <img
-            data-testid="member-avatar"
-            :src="avatarImg"
-            class="member-image object-cover rounded-full w-32 h-32"
-        >
+        <FadeInTransitionImage
+            :data-test-id="`member-avatar-${dataTestId}`"
+            :alt="name"
+            border-radius="rounded-full"
+            height="h-32"
+            :img-src="avatarImg"
+            object-styling="object-cover"
+            width="w-32"
+        />
         <div
             data-testid="member-name"
             class="member-name mt-1 text-xl font-bold"
@@ -62,21 +66,25 @@ defineProps({
         type: String,
         required: true
     },
-    name: {
-        type: String,
-        required: true
-    },
-    title: {
-        type: String,
-        required: true
+    githubUrl: {
+        type: [String, null] as PropType<string | null>,
+        required: false
     },
     linkedInUrl: {
         type: [String, null] as PropType<string | null>,
         required: false
     },
-    githubUrl: {
-        type: [String, null] as PropType<string | null>,
-        required: false
+    name: {
+        type: String,
+        required: true
+    },
+    dataTestId: {
+        type: Number,
+        required: true
+    },
+    title: {
+        type: String,
+        required: true
     }
 })
 </script>

--- a/cypress/e2e/about.cy.ts
+++ b/cypress/e2e/about.cy.ts
@@ -44,7 +44,7 @@ describe('About page', () => {
         })
 
         it('shows member details', () => {
-            cy.get('[data-testid="member-avatar"]').should('exist')
+            cy.get('[data-testid="member-avatar-0"]').should('exist')
             cy.get('[data-testid="member-name"]').should('exist')
             cy.get('[data-testid="member-title"]').should('exist')
             cy.get('[data-testid="member-linkedin"]').should('exist')
@@ -85,7 +85,7 @@ describe('About page', () => {
         })
 
         it('shows member details', () => {
-            cy.get('[data-testid="member-avatar"]').should('exist')
+            cy.get('[data-testid="member-avatar-0"]').should('exist')
             cy.get('[data-testid="member-name"]').should('exist')
             cy.get('[data-testid="member-title"]').should('exist')
             cy.get('[data-testid="member-linkedin"]').should('exist')

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -61,16 +61,17 @@
             >
                 <div
                     v-for="(member, index) in data.members"
-                    :key="index"
+                    :key="member.avatarImg"
                     data-testid="member"
                     class="members-list grid"
                 >
                     <MemberComponent
                         :avatar-img="member.avatarImg"
-                        :name="member.name"
-                        :title="member.title"
-                        :linked-in-url="member.linkedInUrl"
                         :github-url="member.githubUrl"
+                        :linked-in-url="member.linkedInUrl"
+                        :name="member.name"
+                        :data-test-id="index"
+                        :title="member.title"
                     />
                 </div>
             </div>


### PR DESCRIPTION
## 🔧 What changed
This component can be used anywhere in the app. It allows for a smoother load of images no matter the size. Even after compressing the about us files they would sometimes load in a manner that was less than ideal. Now it should load with a fade in effect if there is a delay or load the whole image at once.

## 🧪 Testing instructions
Go to the branch and run:

```
yarn dev
yarn cypress open
```

## 📸 Screenshots

-   ### Before
https://www.loom.com/share/28505cfdc1d44891993686e793a64c29
-   ### After
https://www.loom.com/share/9fc53ffec9aa4122a7bf8f933379f096