### PR TITLE
refactor: implement new error logic in submission form

### DIFF
--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -16,7 +16,7 @@
             class="mb-2 text-neutral-600 text-sm font-normal font-['Noto Sans JP']"
         >{{ $t('submitPage.googleMaps') }}</span>
         <p
-            v-show="!isValidGoogleMapsUrl"
+            v-show="!isValidInput.googleMapsUrl.value"
             class="text-currentColor text-xs font-['Noto Sans JP']"
         >
             {{ $t('submitPage.googleMapsValidation') }}
@@ -27,17 +27,31 @@
             type="text"
             required
             class="mb-5 px-3 py-3.5 w-[350px] h-[50px] bg-white rounded-lg border border-zinc-400
-          text-neutral-600 text-sm font-normal font-['Noto Sans JP']"
+            text-neutral-600 text-sm font-normal font-['Noto Sans JP']"
             :placeholder="$t('submitPage.location')"
+            @blur="initialValidationCheck(submissionStore.location, 'googleMaps')"
         >
         <span
             class="mb-2 text-neutral-600 text-sm font-normal font-['Noto Sans JP']"
         >{{ $t('submitPage.healthcareProfessionalName') }}</span>
-        <p
-            v-show="!isValidLastName || !isValidFirstName"
-            class="text-currentColor text-xs font-['Noto Sans JP']"
-        >
-            {{ $t('submitPage.lastNameValidation') }}
+        <p class="flex text-currentColor text-xs font-['Noto Sans JP']">
+            <span
+                :class="[
+                    !isValidInput.lastName.value ? 'visible' : 'invisible',
+                    'w-44',
+                    'mr-1',
+                ]"
+            >
+                {{ $t('submitPage.lastNameValidation') }}
+            </span>
+            <span
+                :class="[
+                    !isValidInput.firstName.value ? 'visible' : 'invisible',
+                    'w-44',
+                ]"
+            >
+                {{ $t('submitPage.firstNameValidation') }}
+            </span>
         </p>
         <div>
             <input
@@ -49,6 +63,7 @@
                 required
                 maxlength="30"
                 :placeholder="$t('submitPage.lastName')"
+                @blur="initialValidationCheck(submissionStore.lastName, 'lastName')"
             >
             <input
                 v-model="submissionStore.firstName"
@@ -58,13 +73,14 @@
                 type="text"
                 maxlength="30"
                 :placeholder="$t('submitPage.firstName')"
+                @blur="initialValidationCheck(submissionStore.firstName, 'firstName')"
             >
         </div>
         <span
             class="mb-2 text-neutral-600 text-sm font-normal font-['Noto Sans JP']"
         >{{ $t('submitPage.spokenLanguage1') }}</span>
         <p
-            v-show="!isValidPrimarySpokenLanguage"
+            v-show="!isValidInput.primarySpokenLangauge.value"
             class="text-currentColor text-xs font-['Noto Sans JP']"
         >
             {{ $t('submitPage.spokenLanguageValidation') }}
@@ -74,6 +90,7 @@
             data-testid="submit-select-language1"
             class="mb-5 px-3 py-3.5 w-[350px] h-[50px] bg-white rounded-lg border border-zinc-400 text-primary-text"
             :placeholder="$t('submitPage.selectLanguage1')"
+            @change="initialValidationCheck(submissionStore.selectLanguage1, 'primaryLanguage')"
         >
             <option
                 v-for="(locale, index) in localeStore.localeDisplayOptions"
@@ -88,7 +105,7 @@
             class="mb-2 text-neutral-600 text-sm font-normal font-['Noto Sans JP']"
         >{{ $t('submitPage.spokenLanguage2') }}</span>
         <p
-            v-show="!isValidSecondarySpokenLanguage"
+            v-show="!isValidInput.secondarySpokenLanguage.value"
             class="text-currentColor text-xs font-['Noto Sans JP']"
         >
             {{ $t('submitPage.invalidOption') }}
@@ -98,6 +115,7 @@
             data-testid="submit-select-language2"
             class="mb-5 px-3 py-3.5 w-[350px] h-[50px] bg-white rounded-lg border border-zinc-400 text-primary-text"
             :placeholder="$t('submitPage.selectLanguage2')"
+            @change="initialValidationCheck(submissionStore.selectLanguage1, 'secondaryLanguage')"
         >
             <option
                 v-for="(locale, index) in localeStore.localeDisplayOptions"
@@ -130,7 +148,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, type ComputedRef } from 'vue'
+import { ref, watch, nextTick } from 'vue'
 import * as validations from '../utils/formValidations'
 import { useSubmissionStore } from '~/stores/submissionStore'
 import { useLocaleStore } from '~/stores/localeStore'
@@ -138,34 +156,103 @@ import { useLocaleStore } from '~/stores/localeStore'
 const submissionStore = useSubmissionStore()
 const localeStore = useLocaleStore()
 
-const isValidGoogleMapsUrl: ComputedRef<boolean> = computed(() =>
-    validations.validateGoogleMapsUrlInput(submissionStore.location))
+const validationCheckedPreviously = {
+    googleMapsUrl: ref(false),
+    lastName: ref(false),
+    firstName: ref(false),
+    primarySpokenLangauge: ref(false),
+    secondarySpokenLanguage: ref(false)
+}
 
-const isValidLastName: ComputedRef<boolean> = computed(() =>
-    validations.validateUserSubmittedLastName(submissionStore.lastName))
-
-const isValidFirstName: ComputedRef<boolean> = computed(() =>
-    validations.validateUserSubmittedFirstName(submissionStore.firstName))
-
-const isValidPrimarySpokenLanguage: ComputedRef<boolean> = computed(() =>
-    validations.validateFirstSpokenLanguage(submissionStore.selectLanguage1))
-
-const isValidSecondarySpokenLanguage: ComputedRef<boolean> = computed(() =>
-    validations.validateSecondSpokenLanguage(submissionStore.selectLanguage2))
+const isValidInput = {
+    googleMapsUrl: ref(true),
+    lastName: ref(true),
+    firstName: ref(true),
+    primarySpokenLangauge: ref(true),
+    secondarySpokenLanguage: ref(true)
+}
 
 const validateFields = (e: Event) => {
     e.preventDefault()
+    validationCheckedPreviously.googleMapsUrl.value = true
+    isValidInput.googleMapsUrl.value = validations.validateGoogleMapsUrlInput(submissionStore.location)
+    validationCheckedPreviously.lastName.value = true
+    isValidInput.lastName.value = validations.validateUserSubmittedLastName(submissionStore.lastName)
+    validationCheckedPreviously.firstName.value = true
+    isValidInput.firstName.value = validations.validateUserSubmittedFirstName(submissionStore.firstName)
+    validationCheckedPreviously.primarySpokenLangauge.value = true
+    isValidInput.primarySpokenLangauge.value = validations.validateFirstSpokenLanguage(submissionStore.selectLanguage1)
+    validationCheckedPreviously.secondarySpokenLanguage.value = true
+    isValidInput.secondarySpokenLanguage.value
+        = validations.validateUserSubmittedLastName(submissionStore.selectLanguage2)
 
     if (
-        !isValidGoogleMapsUrl.value
-        || !isValidLastName.value
-        || !isValidFirstName.value
-        || !isValidPrimarySpokenLanguage.value
-        || !isValidSecondarySpokenLanguage.value
+        !isValidInput.googleMapsUrl.value
+        || !isValidInput.lastName.value
+        || !isValidInput.firstName.value
+        || !isValidInput.primarySpokenLangauge.value
+        || !isValidInput.secondarySpokenLanguage.value
     ) {
         e.preventDefault()
         return
     }
     submissionStore.submit()
 }
+
+// nextTick is used to ensure that the model value is updated before doing the validation check
+const initialValidationCheck = async (inputValue: string, field: string) => {
+    switch (field) {
+        case 'googleMaps':
+            validationCheckedPreviously.googleMapsUrl.value = true
+            await nextTick()
+            isValidInput.googleMapsUrl.value = validations.validateGoogleMapsUrlInput(inputValue)
+            break
+        case 'lastName':
+            validationCheckedPreviously.lastName.value = true
+            await nextTick()
+            isValidInput.lastName.value = validations.validateUserSubmittedLastName(inputValue)
+            break
+        case 'firstName':
+            validationCheckedPreviously.firstName.value = true
+            await nextTick()
+            isValidInput.firstName.value = validations.validateUserSubmittedFirstName(inputValue)
+            break
+        case 'primaryLanguage':
+            validationCheckedPreviously.primarySpokenLangauge.value = true
+            await nextTick()
+            isValidInput.primarySpokenLangauge.value = validations.validateFirstSpokenLanguage(inputValue)
+            break
+        case 'secondaryLanguage':
+            validationCheckedPreviously.secondarySpokenLanguage.value = true
+            await nextTick()
+            isValidInput.secondarySpokenLanguage.value = validations.validateSecondSpokenLanguage(inputValue)
+            break
+    }
+}
+
+watch(() => submissionStore.location, newValue => {
+    if (validationCheckedPreviously.googleMapsUrl.value) {
+        isValidInput.googleMapsUrl.value = validations.validateGoogleMapsUrlInput(newValue)
+    }
+})
+watch(() => submissionStore.lastName, newValue => {
+    if (validationCheckedPreviously.lastName.value) {
+        isValidInput.lastName.value = validations.validateUserSubmittedLastName(newValue)
+    }
+})
+watch(() => submissionStore.firstName, newValue => {
+    if (validationCheckedPreviously.firstName.value) {
+        isValidInput.firstName.value = validations.validateUserSubmittedFirstName(newValue)
+    }
+})
+watch(() => submissionStore.selectLanguage1, newValue => {
+    if (validationCheckedPreviously.primarySpokenLangauge.value) {
+        isValidInput.primarySpokenLangauge.value = validations.validateFirstSpokenLanguage(newValue)
+    }
+})
+watch(() => submissionStore.selectLanguage2, newValue => {
+    if (validationCheckedPreviously.secondarySpokenLanguage.value) {
+        isValidInput.secondarySpokenLanguage.value = validations.validateSecondSpokenLanguage(newValue)
+    }
+})
 </script>

--- a/cypress/e2e/submit.cy.ts
+++ b/cypress/e2e/submit.cy.ts
@@ -84,7 +84,8 @@ describe('Submit page', () => {
         it('requires a last name of 30 characters or less', () => {
             cy.get('[data-testid="submit-input-lastname"]').type(' ')
             cy.contains(enUS.submitPage.lastNameValidation).should('be.visible')
-            cy.get('[data-testid="submit-input-lastname"]').type('some last name under 30 characters')
+            cy.get('[data-testid="submit-input-lastname"]').type('The Frog')
+            cy.get('[data-testid="submit-input-firstname"]').type('Kermy')
             cy.contains(enUS.submitPage.lastNameValidation).should('not.be.visible')
             cy.get('[data-testid="submit-input-lastname"]').type('a'.repeat(80), { delay: 0 }).invoke('val').should('have.length', 30)
         })

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -53,6 +53,7 @@
     },
     "submitPage": {
         "firstName": "First Name",
+        "firstNameValidation": "Enter a first name",
         "googleMaps": "Google Maps URL",
         "googleMapsValidation": "Enter a URL starting with https://",
         "heading": "Add a Doctor",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -52,6 +52,7 @@
     },
     "submitPage": {
         "firstName": "名",
+        "firstNameValidation": "Enter a first name",
         "googleMaps": "Google MapsのURL",
         "googleMapsValidation": "https://を含む、アドレスを入れてください",
         "heading": "医師情報の追加",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -50,6 +50,7 @@
     },
     "submitPage": {
         "firstName": "Nome",
+        "firstNameValidation": "Enter a first name",
         "googleMaps": "Endereço no Google Maps",
         "googleMapsValidation": "Insira uma endereço começando com https://",
         "heading": "Adicionar um profissional de saúde",

--- a/utils/formValidations.ts
+++ b/utils/formValidations.ts
@@ -206,7 +206,7 @@ export function validateUserSubmittedLastName(name: string): boolean {
 export function validateUserSubmittedFirstName(name: string): boolean {
     // The first name is optional and may be an empty string.
     name = name.trim()
-    if (name.length > 30) {
+    if (name.length > 30 || !name.length) {
         return false
     }
     return true


### PR DESCRIPTION
Resolves #623 

## 🔧 What changed
Before error messages were displayed before the user left the field and only showed when correct. The logic is now changed to reflect the same way we used in the Moderation Panel Form. We validate on blur for the first entry. Then we validate on change until it is correct. We also have an extra check on submit to validate.

## 🧪 Testing instructions
The tests should not have changed. They are the same as before with the submissions. Only error showing logic has changed.

## 📸 Screenshots

-   ### Before
![image](https://github.com/ourjapanlife/findadoc-web/assets/124335161/2676ae2d-689f-4568-b9e0-8f49c0189820)

-   ### After
https://www.loom.com/share/2d1500f2fb9b4f0b801911c389c41a06
