### PR TITLE
feat: implement fake pagination for mod panel

### DIFF
--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -58,18 +58,22 @@
 
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router'
-import { watch } from 'vue'
+import { onMounted, watch } from 'vue'
 import { useAuthStore } from '~/stores/authStore'
 import { definePageMeta } from '#imports'
+import { ModerationScreen, useModerationScreenStore } from '~/stores/moderationScreenStore'
 
 // tell nuxt to our moderation layout
 definePageMeta({
     layout: 'moderationlayout'
 })
 
+const moderationScreenStore = useModerationScreenStore()
 const authStore = useAuthStore()
 const route = useRoute()
 const router = useRouter()
+
+// const idForTheForwardButton: Ref<string> = ref(moderationSubmissionsStore.selectedSubmissionId)
 
 const checkIfUserIsLoggedIn = async () => {
     // This promise is here to make the Suspense component work.
@@ -93,4 +97,30 @@ watch(route, async () => {
 })
 
 await checkIfUserIsLoggedIn()
+
+function disableBackButton() {
+    if (typeof window !== 'undefined' && typeof window.history.pushState === 'function') {
+        if (moderationScreenStore.activeScreen === ModerationScreen.editSubmission) {
+            window.history.pushState({ path: '/moderation' }, '', window.location.href)
+        } else {
+            window.history.pushState({ path: '/' }, '', window.location.href)
+        }
+
+        window.onpopstate = function() {
+            if (moderationScreenStore.activeScreen === ModerationScreen.editSubmission) {
+                moderationScreenStore.setActiveScreen(ModerationScreen.dashboard)
+            }
+        }
+    } else {
+        console.error('window.history.pushState is not a function')
+    }
+}
+
+onMounted (() => {
+    disableBackButton()
+})
+
+watch(() => moderationScreenStore.activeScreen, () => {
+    disableBackButton()
+})
 </script>


### PR DESCRIPTION
## 🔧 What changed
This only works when the path is `'/moderation'`. This is a hot fix for now to toggle back to the dashboard by commandeering the browser's back button and setting the state of the `ModerationScreen` to   `ModerationScreen.dashboard`. It has two checks. One is the push the state of the href in the window object of the most previous one when a form is clicked to the path `'/moderation'`. Then when the back button pops that ref it will set the active screen back to dashboard. This does only work in terms of the flow of the moderation panel, but does not affect the flow of the user facing site. 
## 🧪 Testing instructions
Go to the branch. Click on a form while running on the backend 
```
yarn dev:startlocaldb
yarn dev:startserver
```
On the frontend run
```
yarn dev:localserver
```
## 📸 Screenshots

-   ### Before
https://www.loom.com/share/175a357db33046d0884b27a796c7870e
-   ### After
https://www.loom.com/share/f177c04f300d4ca88eb4fbac2670ecb8