### PR TITLE
feat: create composable to check viewport

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,7 +4,7 @@
         class="h-full w-full overflow-hidden"
     >
         <div
-            v-if="$viewport.isGreaterThan('tablet')"
+            v-if="!isPortrait"
             class="flex h-full overflow-clip"
         >
             <LeftNavbar class="bg-primary-bg w-96 overflow-y-auto" />
@@ -20,9 +20,10 @@
 </template>
 
 <script setup lang="ts">
-import { useNuxtApp } from '#app'
+import { useScreenOrientation } from '~/utils/useScreenOrientation'
 import { useModalStore } from '~/stores/modalStore'
 
-const { $viewport } = useNuxtApp()
 useModalStore()
+
+const { isPortrait } = useScreenOrientation()
 </script>

--- a/utils/useScreenOrientation.ts
+++ b/utils/useScreenOrientation.ts
@@ -1,0 +1,17 @@
+import { ref, onMounted } from 'vue'
+
+export const useScreenOrientation = () => {
+    const isPortrait = ref(true)
+
+    const checkViewport = () => {
+        isPortrait.value = window.innerWidth <= 768
+    }
+
+    onMounted(() => {
+        checkViewport()
+    })
+
+    return {
+        isPortrait
+    }
+}


### PR DESCRIPTION
Resolves issue #640

## 🔧 What changed
I made a composable. This can use screen orientation to set variables and then improve the responsiveness of the app on mobile.

##Details
As you can see I used my phone to record the video of the deployed preview from a ticket without this change and with this change and the layout is correct instantly on the after video

## 🧪 Testing instructions
The tests should still pass since it didn't change functionality.

## 📸 Screenshots

-   ### Before

https://github.com/ourjapanlife/findadoc-web/assets/124335161/b1a664bc-9203-400a-a6ed-5018bf76db4e


-   ### After

https://github.com/ourjapanlife/findadoc-web/assets/124335161/9af45665-a7e0-4927-8ab5-0c7f19011b82

