### PR TITLE
FIX(UI): overlapping modal with footer for desktop users

### DIFF
--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -3,12 +3,12 @@
         <div
             v-if="$viewport.isGreaterThan('tablet')"
             id="landscape-content"
-            class="bg-secondary-bg/20 hover:shadow-inner hover:shadow-secondary-bg/90 h-full w-full"
+            class="bg-secondary-bg/20 hover:shadow-inner hover:shadow-secondary-bg/90 h-full w-full relative"
         >
             <Loader />
             <Modal
                 v-show="store.$state.isOpen"
-                class="min-h-1/2 ml-8 mt-12"
+                class="max-h-[calc(100vh-12rem)] ml-8 mt-12 overflow-y-auto"
             >
                 <SearchResultDetails />
             </Modal>


### PR DESCRIPTION
Resolves #213 

## 🔧 What changed
The Modal (bigger than tablet mode)
a)is not overlapping with the footer and 
b)scrollable IF the winodw height is too narrow

## 🧪 Testing instructions
1. Open browser
2. open dev tools
3. set the website to a screensize bigger than tablet
4. narrow the height 

## 📸 Screenshots

-   ### Before
<img width="1273" alt="スクリーンショット 2024-07-11 14 57 19" src="https://github.com/user-attachments/assets/458359cd-fa6e-4115-b313-9a71759ef033">

-   ### After

https://github.com/user-attachments/assets/600e7745-d98a-44b9-b414-f301c97f7b3c


