### PR TITLE
feat: implement mutation rejection for facility submission

### DIFF
--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -32,6 +32,11 @@ export const useModerationSubmissionsStore = defineStore(
         const selectedHealthcareProfessionalId: Ref<string> = ref('')
         const selectedSubmissionData: Ref<Submission | undefined> = ref()
         const filteredSubmissionDataForListComponent: Ref<Submission[]> = ref([])
+        const didMutationFail: Ref<boolean> = ref(false)
+
+        function setDidMutationFail(newValue: boolean) {
+            didMutationFail.value = newValue
+        }
 
         async function getSubmissions() {
             const submissionsSearchResults = await querySubmissions()
@@ -72,6 +77,8 @@ export const useModerationSubmissionsStore = defineStore(
             selectedSubmissionId,
             filterSelectedSubmission,
             selectedSubmissionData,
+            didMutationFail,
+            setDidMutationFail,
             selectedModerationListViewChosen,
             setSelectedModerationListViewChosen,
             selectedFacilityId,


### PR DESCRIPTION
Resolves #639 
Related to #636

## 🔧 What changed
This implements the functionality of the reject button to reject a facility submission. Before it just logged. Now if I click, the facility will be rejected and moved in tabs.

It also contains a custom function that will allow us to pass `GQL requests` and retry recursively.


## 🧪 Testing instructions

1.  Run the local backend 

```
yarn dev:startlocaldb
```
```
yarn dev
```

2. Then start the frontend 
```
yarn dev:localserver
```

3. Reject a submission and you can see how it changes as shown in the After screenshot

## 📸 Screenshots

-   ### Before

-   ### After

This is the submission list before I reject Stephanie Mills

![image](https://github.com/user-attachments/assets/d35c2e73-5f87-4814-a414-a733c68130b8)

and after with the rejection seen in the separate tab
![image](https://github.com/user-attachments/assets/ef6e81f2-4968-4d1a-9b31-0af86521cbb5)

![image](https://github.com/user-attachments/assets/6abb2f04-b8ee-45fa-92af-d20f5366725c)
