### PR TITLE
fix: add timeout to cypress config for ci timeout

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
         setupNodeEvents() { },
         baseUrl: 'http://localhost:3000',
         testIsolation: false,
-        experimentalRunAllSpecs: true
+        experimentalRunAllSpecs: true,
+        requestTimeout: 10000,
+        responseTimeout: 30000,
+        pageLoadTimeout: 60000
     }
 })

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -37,15 +37,15 @@ describe('Visits the home page', () => {
         })
 
         it('can select "select a language"', () => {
-            cy.get('[data-testid="search-bar-language"]').trigger('click')
+            cy.get('[data-testid="search-bar-language"]', { timeout: 10000 }).trigger('click')
         })
 
         it('can select "English" from the language bar', () => {
-            cy.get('[data-testid="search-bar-language"]').should('be.visible')
+            cy.get('[data-testid="search-bar-language"]', { timeout: 10000 }).should('be.visible')
 
-            cy.get('[data-testid="search-bar-language"]').select('English')
+            cy.get('[data-testid="search-bar-language"]', { timeout: 10000 }).select('English')
 
-            cy.get('[data-testid="search-bar-language"]').should(
+            cy.get('[data-testid="search-bar-language"]', { timeout: 10000 }).should(
                 'have.value',
                 'en_US'
             )

--- a/cypress/e2e/moderationDashboard.cy.ts
+++ b/cypress/e2e/moderationDashboard.cy.ts
@@ -144,11 +144,11 @@ describe(
                     })
                 }).as('getSubmissions')
 
-                cy.url().as('initialUrl')
+                cy.url({ timeout: 10000 }).should('equal', 'http://localhost:3000/')
 
-                cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click()
-
-                cy.url().should('not.eq', '@initialUrl')
+                /* chaining of visit was used here to make sure the user was logged in and that it would
+                 100 percent visit moderation */
+                cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click().visit('/moderation')
 
                 cy.wait('@getSubmissions', { timeout: 10000 })
             })
@@ -253,11 +253,11 @@ describe('Moderation Facility Submission Form', () => {
                 })
             }).as('getSubmissions')
 
-            cy.url().as('initialUrl')
+            cy.url({ timeout: 10000 }).should('equal', 'http://localhost:3000/')
 
-            cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click()
-
-            cy.url().should('not.eq', '@initialUrl')
+            /* chaining of visit was used here to make sure the user was logged in and that it would
+                 100 percent visit moderation */
+            cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click().visit('/moderation')
 
             cy.wait('@getSubmissions', { timeout: 10000 })
 

--- a/cypress/e2e/submit.cy.ts
+++ b/cypress/e2e/submit.cy.ts
@@ -82,8 +82,8 @@ describe('Submit page', () => {
         it('requires a last name of 30 characters or less', () => {
             cy.get('[data-testid="submit-input-lastname"]').type(' ')
             cy.contains(enUS.submitPage.lastNameValidation).should('be.visible')
-            cy.get('[data-testid="submit-input-lastname"]').type('The Frog')
-            cy.get('[data-testid="submit-input-firstname"]').type('Kermy')
+            cy.get('[data-testid="submit-input-lastname"]', { timeout: 10000 }).type('The Frog')
+            cy.get('[data-testid="submit-input-firstname"]', { timeout: 10000 }).type('Kermy')
             cy.contains(enUS.submitPage.lastNameValidation, { timeout: 10000 }).should('not.be.visible')
             cy.get('[data-testid="submit-input-lastname"]').type('a'.repeat(80), { delay: 0 }).invoke('val').should('have.length', 30)
         })


### PR DESCRIPTION
Resolves #660 

## 🔧 What changed
A timeout was added to the `cypress.config.ts` in order to avoid CI/CD failures in the pipeline of Cypress e2e tests just due to a timeout of finding the localhost

## 🧪 Testing instructions
No tests were fundamentally changed

## 📸 Screenshots

-   ### Before
N/A
-   ### After
N/A