### PR TITLE
test: improve test speed for ci/cd pipeline

### DIFF
--- a/cypress/e2e/about.cy.ts
+++ b/cypress/e2e/about.cy.ts
@@ -3,16 +3,13 @@ import enUS from '../../i18n/locales/en.json'
 describe('About page', () => {
     context('Desktop resolution', () => {
         before(() => {
-            cy.visit('/about')
-            // This wait time is to give the page time to load from Prod when ran in CI.
-            cy.wait(3000)
+            cy.visit('/about', { timeout: 10000 })
         })
 
         beforeEach(() => {
             // The resolution is in the beforeEach() instead of before() to
             // prevent Cypress from defaulting to other screen sizes between tests.
-            cy.viewport(1920, 1080)
-            cy.wait(500)
+            cy.viewport('macbook-16')
         })
 
         it('shows the desktop top nav', () => {
@@ -58,9 +55,7 @@ describe('About page', () => {
 
     context('Portrait mode', () => {
         before(() => {
-            cy.visit('/about')
-            // This wait time is to give the page time to load from Prod when ran in CI.
-            cy.wait(3000)
+            cy.visit('/about', { timeout: 10000 })
         })
 
         beforeEach(() => {
@@ -68,8 +63,7 @@ describe('About page', () => {
             // prevent Cypress from defaulting to other screen sizes between tests.
 
             // An iPhone 5 screen resolution is used to test portrait mode.
-            cy.viewport(640, 1136)
-            cy.wait(500)
+            cy.viewport('iphone-5')
         })
 
         it('shows the hamburger component', () => {

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -4,16 +4,13 @@ describe('Visits the home page', () => {
 
     context('Landscape mode', () => {
         before(() => {
-            cy.visit('/')
-            // This wait time is to give the page time to load from Prod when ran in CI.
-            cy.wait(3000)
+            cy.visit('/', { timeout: 10000 })
         })
 
         beforeEach(() => {
             // The resolution is in the beforeEach() instead of before() to
             // prevent Cypress from defaulting to other screen sizes between tests.
-            cy.viewport(1920, 1080)
-            cy.wait(500)
+            cy.viewport('macbook-16')
         })
 
         it('Displays the Logo', () => {
@@ -27,8 +24,7 @@ describe('Visits the home page', () => {
         })
 
         it('allows setting search fields', () => {
-            cy.wait(5000)
-            cy.get('[data-testid="search-button"]').should('be.visible')
+            cy.get('[data-testid="search-button"]', { timeout: 10000 }).should('be.visible')
 
             cy.get('.search-specialty select').select('Dermatology')
             cy.get('.search-specialty select').should('be.visible', 'Dermatology')
@@ -123,18 +119,14 @@ describe('Visits the home page', () => {
     // Portrait mode tests - usually for mobile and tablet
     context('Portrait mode', () => {
         before(() => {
-            cy.visit('/')
-            // This wait time is to give the page time to load from Prod when ran in CI.
-            cy.wait(3000)
+            cy.visit('/', { timeout: 10000 })
         })
 
         beforeEach(() => {
             // The resolution is in the beforeEach() instead of before() to
             // prevent Cypress from defaulting to other screen sizes between tests.
 
-            // An iPhone 5 screen resolution is used to test portrait mode.
-            cy.viewport(640, 1136)
-            cy.wait(500)
+            cy.viewport('iphone-5')
         })
 
         it('shows the logo', () => {

--- a/cypress/e2e/moderationDashboard.cy.ts
+++ b/cypress/e2e/moderationDashboard.cy.ts
@@ -119,21 +119,12 @@ describe(
     'Moderation dashboard',
     () => {
         context('Landscape mode', () => {
-            before(() => {
-                cy.visit('/moderation')
-                // This wait time is to give the page time to load from Prod when ran in CI.
-                cy.wait(3000)
-            })
             beforeEach(() => {
                 // The resolution is in the beforeEach() instead of before() to
                 // prevent Cypress from defaulting to other screen sizes between tests.
-                cy.viewport(1920, 1080)
-                cy.wait(500)
-                cy.visit('/login')
+                cy.viewport('macbook-16')
+                cy.visit('/login', { timeout: 10000 })
                 Cypress.session.clearCurrentSessionData()
-
-                // Wait for redirect to login form
-                cy.wait(3000)
 
                 cy.origin('https://findadoc.jp.auth0.com/', () => {
                     cy.get('input#username').should('be.visible').type('findadoctest@proton.me')
@@ -153,18 +144,18 @@ describe(
                     })
                 }).as('getSubmissions')
 
-                cy.wait(3000)
+                cy.url().as('initialUrl')
 
-                cy.url().should('include', '')
+                cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click()
 
-                cy.get('[data-testid=top-nav-mod-link]').click()
+                cy.url().should('not.eq', '@initialUrl')
 
                 cy.wait('@getSubmissions', { timeout: 10000 })
             })
 
-            it('shows mod dashboard left navbar buttons with correct counts', () => {
+            it('shows mod dashboard left navbar buttons with correct counts and functionality', () => {
                 //The number for include text is for the status in the mock data
-                cy.get('[data-testid=mod-dashboard-leftnav-for-review]')
+                cy.get('[data-testid=mod-dashboard-leftnav-for-review]', { timeout: 10000 })
                     .should('exist')
                     .should(
                         'include.text',
@@ -196,25 +187,23 @@ describe(
                         'include.text',
                         '0'
                     )
-            })
 
-            it('updates the submission list based on selected tab', () => {
-                cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
+                cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).should('exist')
 
                 cy.get('[data-testid=mod-dashboard-leftnav-approved]')
                     .click()
 
-                cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
+                cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).should('exist')
 
                 cy.get('[data-testid=mod-dashboard-leftnav-rejected]')
                     .click()
 
-                cy.get('[data-testid="mod-submission-list-item-1"]').should('not.exist')
+                cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).should('not.exist')
 
                 cy.get('[data-testid=mod-dashboard-leftnav-for-review]')
                     .click()
 
-                cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
+                cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).should('exist')
             })
 
             it.skip('it shows the moderation top nav', () => {
@@ -228,7 +217,7 @@ describe(
                 clipboardResult.should('exist', 10000)
             })
 
-            after(() => {
+            afterEach(() => {
                 Cypress.session.clearCurrentSessionData()
             })
         })
@@ -240,13 +229,10 @@ describe('Moderation Facility Submission Form', () => {
         before(() => {
             // The resolution is in the beforeEach() instead of before() to
             // prevent Cypress from defaulting to other screen sizes between tests.
-            cy.viewport(1920, 1080)
+            cy.viewport('macbook-16')
 
-            cy.visit('/login')
+            cy.visit('/login', { timeout: 10000 })
             Cypress.session.clearCurrentSessionData()
-
-            // Wait for redirect to login form
-            cy.wait(3000)
 
             cy.origin('https://findadoc.jp.auth0.com/', () => {
                 cy.get('input#username').should('be.visible').type('findadoctest@proton.me')
@@ -254,7 +240,6 @@ describe('Moderation Facility Submission Form', () => {
                 cy.get('input#password').should('be.visible').type('vCnL5J8agHg6m2f')
                 cy.get('[data-action-button-primary]').should('be.visible').click()
             })
-            cy.wait(3000)
 
             cy.intercept('POST', '**/', req => {
                 req.continue(res => {
@@ -268,15 +253,15 @@ describe('Moderation Facility Submission Form', () => {
                 })
             }).as('getSubmissions')
 
-            cy.url().should('include', '')
+            cy.url().as('initialUrl')
 
-            cy.get('[data-testid=top-nav-mod-link]').click()
+            cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click()
+
+            cy.url().should('not.eq', '@initialUrl')
 
             cy.wait('@getSubmissions', { timeout: 10000 })
-            // This wait time is to give the page elements time to load.
-            cy.wait(2000)
-            cy.get('[data-testid="mod-submission-list-item-1"]').click()
-            cy.wait(2000)
+
+            cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).click()
         })
 
         after(() => {

--- a/cypress/e2e/privacy.cy.ts
+++ b/cypress/e2e/privacy.cy.ts
@@ -1,7 +1,7 @@
 describe('Privacy Policy page', () => {
     context('Landscape resolution', () => {
         beforeEach(() => {
-            cy.viewport(1920, 1080)
+            cy.viewport('macbook-16')
             cy.visit('/privacypolicy')
         })
 

--- a/cypress/e2e/submit.cy.ts
+++ b/cypress/e2e/submit.cy.ts
@@ -3,16 +3,14 @@ import enUS from '../../i18n/locales/en.json'
 describe('Submit page', () => {
     context('Desktop resolution', () => {
         before(() => {
-            cy.visit('/submit')
-            // This wait time is to give the page time to load from Prod when ran in CI.
-            cy.wait(3000)
+            cy.visit('/submit', { timeout: 10000 })
         })
 
         beforeEach(() => {
             // The resolution is in the beforeEach() instead of before() to
             // prevent Cypress from defaulting to other screen sizes between tests.
-            cy.viewport(1920, 1080)
-            cy.wait(500)
+
+            cy.viewport('macbook-16')
         })
 
         it('shows the desktop top nav', () => {
@@ -86,7 +84,7 @@ describe('Submit page', () => {
             cy.contains(enUS.submitPage.lastNameValidation).should('be.visible')
             cy.get('[data-testid="submit-input-lastname"]').type('The Frog')
             cy.get('[data-testid="submit-input-firstname"]').type('Kermy')
-            cy.contains(enUS.submitPage.lastNameValidation).should('not.be.visible')
+            cy.contains(enUS.submitPage.lastNameValidation, { timeout: 10000 }).should('not.be.visible')
             cy.get('[data-testid="submit-input-lastname"]').type('a'.repeat(80), { delay: 0 }).invoke('val').should('have.length', 30)
         })
 
@@ -99,17 +97,11 @@ describe('Submit page', () => {
 
     context('Portrait mode', () => {
         before(() => {
-            cy.visit('/submit')
-            // This wait time is to give the page time to load from Prod when ran in CI.
-            cy.wait(3000)
+            cy.visit('/submit', { timeout: 10000 })
         })
 
         beforeEach(() => {
-            // The resolution is in the beforeEach() instead of before() to
-            // prevent Cypress from defaulting to other screen sizes between tests.
-
-            // An iPhone 5 screen resolution is used to test portrait mode.
-            cy.viewport(640, 1136)
+            cy.viewport('iphone-5')
         })
 
         it('shows the hamburger component', () => {


### PR DESCRIPTION
Resolves #662 

## 🔧 What changed
The tests were using `cy.wait` to make sure pages were visited and components had time to render. Now the build in timeout method is used. This is designed by Cypress in order to move on right when the test passes. `cy.wait` Takes the whole time.

## 🧪 Testing instructions
Build the production locally and run the tests on this branch. Check the timing. Check that also on another branch and compare the times.

## 📸 Screenshots

-   ### Before
This is from another branch I recently re-ran
![image](https://github.com/user-attachments/assets/cc6c0471-1e7d-4f2e-9207-4136cc847b9b)


-   ### After
This if from the new CI/CD

![image](https://github.com/user-attachments/assets/863f958b-0d6d-4592-b367-86e3e6287f48)
