### PR TITLE
fix: change intercept order to confirm route registration

### DIFF
--- a/cypress/e2e/moderationDashboard.cy.ts
+++ b/cypress/e2e/moderationDashboard.cy.ts
@@ -133,6 +133,8 @@ describe(
                     cy.get('[data-action-button-primary]').should('be.visible').click()
                 })
 
+                cy.url({ timeout: 10000 }).should('equal', 'http://localhost:3000/')
+
                 cy.intercept('POST', '**/', req => {
                     req.continue(res => {
                         if (req.body.query && req.body.query.includes('query Submissions')) {
@@ -240,6 +242,8 @@ describe('Moderation Facility Submission Form', () => {
                 cy.get('input#password').should('be.visible').type('vCnL5J8agHg6m2f')
                 cy.get('[data-action-button-primary]').should('be.visible').click()
             })
+
+            cy.url({ timeout: 10000 }).should('equal', 'http://localhost:3000/')
 
             cy.intercept('POST', '**/', req => {
                 req.continue(res => {


### PR DESCRIPTION
Resolves #664

## 🔧 What changed
In the tests the intercept was being registered on the return from the auth login. But this could possible happen before or after the website in production had return to `localhost:3000`. Now the url is checked with a timeout to ensure that the intercept can register properly on the frontend.

## 🧪 Testing instructions
Tests run successfully

## 📸 Screenshots
N/A
