### PR TITLE
fix: add id missing in update submission

### DIFF
--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -662,10 +662,14 @@ async function submitForm(e: Event) {
             updateFacilitySubmissionGqlMutation,
             submissionInputVariables
         )
-        router.push('/moderation')
+        if (moderationSubmissionStore.updatingMutationFromTopBar) {
+            moderationSubmissionStore.setUpdatingMutationFromTopBar(false)
+            router.push('/moderation')
+        }
     } catch (error) {
         console.error('Failed to update submission:', error)
         moderationSubmissionStore.setDidMutationFail(true)
+        moderationSubmissionStore.setUpdatingMutationFromTopBar(false)
     }
 }
 

--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -709,8 +709,8 @@ onMounted(() => {
 })
 
 const updateFacilitySubmissionGqlMutation = gql`
-mutation Mutation($updateSubmissionId: ID!, $input: UpdateSubmissionInput!) {
-  updateSubmission(id: $updateSubmissionId, input: $input) {
+mutation Mutation($id: ID!, $input: UpdateSubmissionInput!) {
+  updateSubmission(id: $id, input: $input) {
     isUnderReview
     facility {
       id

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -33,7 +33,7 @@ export const useModerationSubmissionsStore = defineStore(
         const selectedSubmissionData: Ref<Submission | undefined> = ref()
         const filteredSubmissionDataForListComponent: Ref<Submission[]> = ref([])
         const didMutationFail: Ref<boolean> = ref(false)
-        const updatingMutationFromTopBar = ref(false)
+        const updatingMutationFromTopBar: Ref<boolean> = ref(false)
 
         function setUpdatingMutationFromTopBar(newValue: boolean) {
             updatingMutationFromTopBar.value = newValue


### PR DESCRIPTION
Resolves #701

## 🔧 What changed
Before the `ModEditSubmissionTopBar` was not working for Save & Exit. As well as this the submission itself wasn't working due to the variable name not matching what was expected. Now it is updated to Save and Exit successfully from the Top Bar. Otherwise if you press enter or just submit it doesn't automatically exit so you can keep working on the form.

## 🧪 Testing instructions
Go to the backend and start the localdb with
```
yarn dev:startlocaldb
```
and start the backend with
```
yarn dev
```

Then start the frontend with 
``` 
yarn dev:localserver
```

## 📸 Screenshots

-   ### Before
N/A
-   ### After

https://github.com/user-attachments/assets/f5124c5a-7554-4a7a-aa70-d6c7f2449978


