### PR TITLE
fix: style overflow y to auto on search results list

### DIFF
--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -1,5 +1,7 @@
 <template>
-    <div class="h-full flex flex-col">
+    <div
+        class="h-full flex flex-col"
+    >
         <div class="results-header flex flex-row ml-9 mr-5 mb-6 pt-5">
             <span class="flex-1 w-1/2 font-bold self-center">
                 {{ $t('searchResultsList.doctorsNearby') }}
@@ -36,7 +38,8 @@
         </div>
         <div
             v-else-if="hasResults"
-            class="landscape:overflow-y-scroll"
+            class="overflow-y-auto"
+            data-testid="search-results-list-container"
         >
             <div
                 id="searchResults"
@@ -46,6 +49,7 @@
                     v-for="(searchResult, index) in resultsStore.searchResultsList"
                     :key="index"
                     class="results-list flex flex-col"
+                    data-testid="search-results-list"
                     @click="resultsStore.setActiveSearchResult(searchResult.professional.id)"
                 >
                     <div
@@ -61,6 +65,7 @@
                                 : searchResult.facilities[0]?.nameEn"
                             :specialties="searchResult.professional.specialties"
                             :spoken-languages="searchResult.professional.spokenLanguages"
+                            :data-testid="`search-result-list-item-${index}`"
                         />
                     </div>
                 </div>

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -71,6 +71,7 @@ describe('Visits the home page', () => {
         })
 
         it('shows the last doctor of the search results', () => {
+            // ensure scrollable is set to false in case the list isn't long enough where the container needs to scroll
             cy.get('[data-testid="search-results-list-container"]').scrollTo('bottom', { ensureScrollable: false })
             //This finds the lenght of the div so that we know it is showing the final doctor in the search
             cy.get('[data-testid="search-results-list"]').its('length').then(length => {
@@ -154,6 +155,7 @@ describe('Visits the home page', () => {
         })
 
         it('shows the last doctor of the search results', () => {
+            // ensure scrollable is set to false in case the list isn't long enough where the container needs to scroll
             cy.get('[data-testid="search-results-list-container"]').scrollTo('bottom', { ensureScrollable: false })
             //This finds the lenght of the div so that we know it is showing the final doctor in the search
             cy.get('[data-testid="search-results-list"]').its('length').then(length => {

--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -70,6 +70,14 @@ describe('Visits the home page', () => {
             cy.contains('Doctors Nearby').should('be.visible')
         })
 
+        it('shows the last doctor of the search results', () => {
+            cy.get('[data-testid="search-results-list-container"]').scrollTo('bottom', { ensureScrollable: false })
+            //This finds the lenght of the div so that we know it is showing the final doctor in the search
+            cy.get('[data-testid="search-results-list"]').its('length').then(length => {
+                cy.get(`[data-testid='search-result-list-item-${length - 1}']`).should('be.visible')
+            })
+        })
+
         describe('Checks footer links', () => {
             // verify link to GitHub
             it('navigates to github', () => {
@@ -143,6 +151,14 @@ describe('Visits the home page', () => {
 
         it('shows doctors nearby', () => {
             cy.contains('Doctors Nearby').should('be.visible')
+        })
+
+        it('shows the last doctor of the search results', () => {
+            cy.get('[data-testid="search-results-list-container"]').scrollTo('bottom', { ensureScrollable: false })
+            //This finds the lenght of the div so that we know it is showing the final doctor in the search
+            cy.get('[data-testid="search-results-list"]').its('length').then(length => {
+                cy.get(`[data-testid='search-result-list-item-${length - 1}']`).should('be.visible')
+            })
         })
 
         describe('Hamburger Menu tests', () => {


### PR DESCRIPTION
Resolves #716 

## 🔧 What changed
The `SearchResultsList.vue` container wasn't scrollable on auto! Our users could not see all the doctors.

## 🧪 Testing instructions
Tests were added to the home page to ensure that in portrait and landscape you can scroll to the bottom of the search list container and see the last item.

## 📸 Screenshots

-   ### Before

https://github.com/user-attachments/assets/074713ea-10ec-40e3-a004-26fc5e04970c

-   ### After

https://github.com/user-attachments/assets/b149c2a5-6044-4357-b3a6-c1d3dc6b4c49


