### PR TITLE
refactor: implement format function in store for locales

### DIFF
--- a/components/SearchResultsListItem.vue
+++ b/components/SearchResultsListItem.vue
@@ -53,8 +53,9 @@ import SVGProfileIcon from '~/assets/icons/profile-icon.svg'
 import SVGChatBubblesIcon from '~/assets/icons/chat-bubbles.svg'
 import { useLocaleStore } from '~/stores/localeStore.js'
 import { useSpecialtiesStore } from '~/stores/specialtiesStore.js'
+import type { Locale } from '~/typedefs/gqlTypes'
 
-const localStore = useLocaleStore()
+const localeStore = useLocaleStore()
 const specialtiesStore = useSpecialtiesStore()
 
 const props = defineProps({
@@ -75,7 +76,7 @@ const props = defineProps({
         required: true
     },
     spokenLanguages: {
-        type: Array,
+        type: Array<Locale>,
         required: true
     }
 })
@@ -92,14 +93,5 @@ const formattedSpecialties = computed(() => {
     return specialtiesDisplayText
 })
 
-const formattedLanguages = computed(() => {
-    const languagesDisplayText = props.spokenLanguages?.map(s => {
-        const languageDisplayText = localStore.localeDisplayOptions.find(
-            l => l.code === s
-        )?.simpleText
-        return languageDisplayText
-    })
-
-    return languagesDisplayText
-})
+const formattedLanguages = computed(() => localeStore.formatLanguages(props.spokenLanguages, localeStore.localeDisplayOptions))
 </script>

--- a/stores/localeStore.ts
+++ b/stores/localeStore.ts
@@ -16,7 +16,14 @@ export const useLocaleStore = defineStore('locale', () => {
         locale.value = localeDisplayOptions.find(l => l.code == selectedLocale) as LocaleDisplay
     }
 
-    return { locale, localeDisplayOptions, mvpLocaleDisplayOptions, setLocale }
+    function formatLanguages(
+        spokenLanguages: Locale[], localeDisplayOptions: { code: string, simpleText: string }[]
+    ) {
+        return spokenLanguages?.map(languageCode => localeDisplayOptions.find(option => option.code === languageCode)?.simpleText || 'Not Specified')
+          ?? []
+    }
+
+    return { locale, localeDisplayOptions, mvpLocaleDisplayOptions, setLocale, formatLanguages }
 })
 
 export const localeDisplayOptions = [

--- a/test/functional/localeStore.spec.ts
+++ b/test/functional/localeStore.spec.ts
@@ -9,19 +9,58 @@ describe('LocalStore', () => {
     })
 
     it('should initialize with default values', () => {
-        const localStore = useLocaleStore()
+        const localeStore = useLocaleStore()
 
-        expect(localStore.locale.code).to.equal(Locale.EnUs)
-        expect(localStore.locale.simpleText).to.equal('English')
-        expect(localStore.locale.displayText).to.equal('English (US)')
+        expect(localeStore.locale.code).to.equal(Locale.EnUs)
+        expect(localeStore.locale.simpleText).to.equal('English')
+        expect(localeStore.locale.displayText).to.equal('English (US)')
     })
 
     it('should update locale when new locale is passed in setLocale', () => {
-        const localStore = useLocaleStore()
-        localStore.setLocale(Locale.JaJp)
+        const localeStore = useLocaleStore()
+        localeStore.setLocale(Locale.JaJp)
 
-        expect(localStore.locale.code).to.equal(Locale.JaJp)
-        expect(localStore.locale.simpleText).to.equal('日本語')
-        expect(localStore.locale.displayText).to.equal('日本語 (Japan)')
+        expect(localeStore.locale.code).to.equal(Locale.JaJp)
+        expect(localeStore.locale.simpleText).to.equal('日本語')
+        expect(localeStore.locale.displayText).to.equal('日本語 (Japan)')
+    })
+
+    it('should return formatted language text when spokenLanguages are provided', () => {
+        const localeStore = useLocaleStore()
+        const spokenLanguages = [Locale.EnUs, Locale.JaJp]
+        const localeDisplayOptions = [
+            { code: Locale.EnUs, simpleText: 'English' },
+            { code: Locale.JaJp, simpleText: '日本語' }
+        ]
+
+        const result = localeStore.formatLanguages(spokenLanguages, localeDisplayOptions)
+
+        expect(result).to.deep.equal(['English', '日本語'])
+    })
+
+    it('should return an empty array when no spokenLanguages are provided', () => {
+        const localeStore = useLocaleStore()
+        const spokenLanguages: Locale[] = []
+        const localeDisplayOptions = [
+            { code: Locale.EnUs, simpleText: 'English' },
+            { code: Locale.JaJp, simpleText: '日本語' }
+        ]
+
+        const result = localeStore.formatLanguages(spokenLanguages, localeDisplayOptions)
+
+        expect(result).to.deep.equal([])
+    })
+
+    it('should return "Not Specified" for unrecognized language codes', () => {
+        const localeStore = useLocaleStore()
+        const spokenLanguages = ['unrecognized' as Locale]
+        const localeDisplayOptions = [
+            { code: Locale.EnUs, simpleText: 'English' },
+            { code: Locale.JaJp, simpleText: '日本語' }
+        ]
+
+        const result = localeStore.formatLanguages(spokenLanguages, localeDisplayOptions)
+
+        expect(result).to.deep.equal(['Not Specified'])
     })
 })


### PR DESCRIPTION
Resolves #723 

## 🔧 What changed
The function that made the locales more readable was written within the file. But I already found a use case in the mod panel where we would want to make it more readable. So it was moved out to the `localeStore` where localization is handled and made reusable.

## 🧪 Testing instructions
Tests were written for the Pinia tests in `localeStore.spec.ts` so you can run the tests in this file
## 📸 Screenshots
N/A as there is no change to the actual design of the website