### PR TITLE
chore: change modalStore into Vue setup store

### DIFF
--- a/stores/modalStore.ts
+++ b/stores/modalStore.ts
@@ -1,16 +1,16 @@
 import { defineStore } from 'pinia'
+import { ref, type Ref } from 'vue'
 
-export const useModalStore = defineStore({
-    id: 'modal-store',
-    state: () => ({
-        isOpen: false
-    }),
-    actions: {
-        showModal(): void {
-            this.isOpen = true
-        },
-        hideModal(): void {
-            this.isOpen = false
-        }
+export const useModalStore = defineStore('modal-store', () => {
+    const isOpen: Ref<boolean> = ref(false)
+
+    function showModal(newValue: boolean) {
+        isOpen.value = newValue === true ? true : false
     }
+
+    function hideModal(newValue: boolean) {
+        isOpen.value = newValue === false ? false : true
+    }
+
+    return { isOpen, showModal, hideModal }
 })

--- a/stores/modalStore.ts
+++ b/stores/modalStore.ts
@@ -4,12 +4,12 @@ import { ref, type Ref } from 'vue'
 export const useModalStore = defineStore('modal-store', () => {
     const isOpen: Ref<boolean> = ref(false)
 
-    function showModal(newValue: boolean) {
-        isOpen.value = newValue === true ? true : false
+    function showModal() {
+        isOpen.value = true
     }
 
-    function hideModal(newValue: boolean) {
-        isOpen.value = newValue === false ? false : true
+    function hideModal() {
+        isOpen.value = false
     }
 
     return { isOpen, showModal, hideModal }


### PR DESCRIPTION
Resolves #733 

## 🔧 What changed 

We refactored the modalStore from option store to setup store using loadingStore as an example to follow. 

