### PR TITLE
chore: change modal to type button

### DIFF
--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -5,6 +5,7 @@
     >
         <div class="modal">
             <button
+                type="button"
                 class="close-button absolute right-6 top-5 bg-primary-inverted rounded-lg px-2 py-.5
                 group hover:bg-primary-hover transition-all duration-200"
                 @click="store.hideModal()"


### PR DESCRIPTION
## 🔧 What changed
In the modal changed the attribute of the type to `button`
