### PR TITLE
fix: improve variable names in submission store

### DIFF
--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -686,20 +686,20 @@ async function submitForm(e: Event) {
             updateFacilitySubmissionGqlMutation,
             submissionInputVariables
         )
-        if (moderationSubmissionStore.updatingMutationFromTopBar) {
+        if (moderationSubmissionStore.updatingSubmissionFromTopBar) {
             router.push('/moderation')
         }
     } catch (error) {
         console.error('Failed to update submission:', error)
         moderationSubmissionStore.setDidMutationFail(true)
-        moderationSubmissionStore.setUpdatingMutationFromTopBar(false)
+        moderationSubmissionStore.setUpdatingSubmissionFromTopBar(false)
     }
 }
 
 const syntheticEvent = new Event('submit', { bubbles: true, cancelable: true })
 
 watch(moderationSubmissionStore, newValue => {
-    if (newValue.updatingMutationFromTopBar) {
+    if (newValue.updatingSubmissionFromTopBar) {
         submitForm(syntheticEvent)
     }
 })
@@ -743,12 +743,12 @@ const handleConfirmationOfBack = () => {
 }
 // Checks to see whether the save and exit button is clicked, if it has not been clicked the second if block runs and opens the modal.
 onBeforeRouteLeave(async (to, _, next) => {
-    if (moderationSubmissionStore.updatingMutationFromTopBar) {
-        moderationSubmissionStore.setUpdatingMutationFromTopBar(false)
+    if (moderationSubmissionStore.updatingSubmissionFromTopBar) {
+        moderationSubmissionStore.setUpdatingSubmissionFromTopBar(false)
         next()
         return
     }
-    if (to.path === '/moderation' && !moderationSubmissionStore.updatingMutationFromTopBar) {
+    if (to.path === '/moderation' && !moderationSubmissionStore.updatingSubmissionFromTopBar) {
         modalStore.showModal()
         next(false)
         return

--- a/components/ModEditSubmissionTopbar.vue
+++ b/components/ModEditSubmissionTopbar.vue
@@ -76,11 +76,11 @@ const copySubmissionId = async () => {
 }
 
 const saveAndExit = () => {
-    moderationSubmissionStore.setUpdatingMutationFromTopBar(true)
+    moderationSubmissionStore.setUpdatingSubmissionFromTopBar(true)
 }
 
 const acceptSubmission = () => {
-    console.log('You are accepted')
+    moderationSubmissionStore.setApprovingSubmissionFromTopBar(true)
 }
 
 const rejectSubmission = async () => {

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -33,12 +33,17 @@ export const useModerationSubmissionsStore = defineStore(
         const selectedSubmissionData: Ref<Submission | undefined> = ref()
         const filteredSubmissionDataForListComponent: Ref<Submission[]> = ref([])
         const didMutationFail: Ref<boolean> = ref(false)
-        const updatingMutationFromTopBar: Ref<boolean> = ref(false)
+        const updatingSubmissionFromTopBar: Ref<boolean> = ref(false)
+        const approvingSubmissionFromTopBar: Ref<boolean> = ref(false)
         const selectedModerationListViewTabChosen: Ref<SelectedSubmissionListViewTab>
         = ref(SelectedSubmissionListViewTab.ForReview)
 
-        function setUpdatingMutationFromTopBar(newValue: boolean) {
-            updatingMutationFromTopBar.value = newValue
+        function setUpdatingSubmissionFromTopBar(newValue: boolean) {
+            updatingSubmissionFromTopBar.value = newValue
+        }
+
+        function setApprovingSubmissionFromTopBar(newValue: boolean) {
+            approvingSubmissionFromTopBar.value = newValue
         }
 
         function setDidMutationFail(newValue: boolean) {
@@ -94,8 +99,10 @@ export const useModerationSubmissionsStore = defineStore(
             setSelectedModerationListViewChosen,
             selectedFacilityId,
             selectedHealthcareProfessionalId,
-            updatingMutationFromTopBar,
-            setUpdatingMutationFromTopBar,
+            updatingSubmissionFromTopBar,
+            setUpdatingSubmissionFromTopBar,
+            approvingSubmissionFromTopBar,
+            setApprovingSubmissionFromTopBar,
             selectedModerationListViewTabChosen,
             setSelectedModerationListViewTabChosen }
     }


### PR DESCRIPTION
## 🔧 What changed
Before the variable names in the store were reading `mutation` and `query`. It wasn't desirable to name a ref the same as the actual API calls, so it was updated to be a name that fit with what the variable is doing and then updated where the variables were being previously used.