### PR TITLE
refactor: change toast from build to module in config

### DIFF
--- a/modules/vue-toastification-module.ts
+++ b/modules/vue-toastification-module.ts
@@ -1,0 +1,13 @@
+import { defineNuxtModule } from '@nuxt/kit'
+
+export default defineNuxtModule({
+    setup(_, nuxt) {
+        nuxt.hook('app:resolve', app => {
+            // Register the Toast plugin only on the client side instead of the build
+            app.plugins.push({
+                src: 'plugins/vue-toastification-plugin',
+                mode: 'client'
+            })
+        })
+    }
+})

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -85,11 +85,6 @@ export default defineNuxtConfig({
         link: [{ rel: 'icon', type: 'image/x-icon', href: '/assets/favicon.ico' }]
     },
 
-    //On build this will transpile the module to be available in deployment
-    build: {
-        transpile: ['vue-toastification']
-    },
-
     // Global CSS: https://go.nuxtjs.dev/config-css
     css: ['~/assets/css/tailwind.css'],
 
@@ -104,7 +99,8 @@ export default defineNuxtConfig({
         '@pinia/nuxt',
         'nuxt-viewport',
         'nuxt-svgo',
-        '@nuxt/eslint'
+        '@nuxt/eslint',
+        '@/modules/vue-toastification-module'
     ],
     eslint: {
         config: {


### PR DESCRIPTION
## 🔧 What changed
This refactors the toast to be a module in the nuxt config instead of in the build for consistency.

