### PR TITLE
feat: implement modal for submission acceptance

### DIFF
--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -7,7 +7,25 @@
 
             class=" min-h-20 min-w-20"
         >
-            <div class="flex flex-col aspect-square h-96 items-center justify-around bg-primary-inverted p-10 rounded">
+            <div
+                v-if="moderationSubmissionStore.approvingSubmissionFromTopBar"
+                class="flex flex-col aspect-square h-96 items-center justify-around bg-primary-inverted p-10 rounded"
+            >
+                <span class="font-bold text-3xl">
+                    {{ $t('modSubmissionForm.submissionConfirmationMessage') }}
+                </span>
+                <button
+                    type="button"
+                    class="bg-primary p-4 rounded-full my-8 font-semibold text-xl"
+                    @click="submitForm"
+                >
+                    {{ $t('modSubmissionForm.submissionConfirmationAcceptanceButton') }}
+                </button>
+            </div>
+            <div
+                v-else
+                class="flex flex-col aspect-square h-96 items-center justify-around bg-primary-inverted p-10 rounded"
+            >
                 <span class="font-bold text-3xl">{{ $t('modSubmissionForm.confirmationModal') }}</span>
                 <button
                     class="bg-secondary p-4 rounded-full my-8 font-semibold text-xl hover:bg-primary"
@@ -482,7 +500,6 @@
 import { onMounted, type Ref, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { gql } from 'graphql-request'
-import Modal from './Modal.vue'
 import { gqlClient, graphQLClientRequestWithRetry } from '~/utils/graphql.js'
 import { useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
 import { Locale, type Submission, type MutationUpdateSubmissionArgs, type LocalizedNameInput, Insurance, Degree, Specialty } from '~/typedefs/gqlTypes'

--- a/components/ModEditSubmissionTopbar.vue
+++ b/components/ModEditSubmissionTopbar.vue
@@ -59,8 +59,10 @@ import { gql } from 'graphql-request'
 import SVGCopyContent from '~/assets/icons/content-copy.svg'
 import SVGSuccessCheckMark from '~/assets/icons/checkmark-square.svg'
 import { useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
+import { useModalStore } from '~/stores/modalStore'
 import { gqlClient, graphQLClientRequestWithRetry } from '~/utils/graphql'
 
+const modalStore = useModalStore()
 const moderationSubmissionStore = useModerationSubmissionsStore()
 const selectedSubmissionId: Ref<string> = ref(moderationSubmissionStore.selectedSubmissionId)
 
@@ -84,6 +86,7 @@ const saveAndExit = () => {
 
 const acceptSubmission = () => {
     moderationSubmissionStore.setApprovingSubmissionFromTopBar(true)
+    modalStore.showModal()
 }
 
 const rejectSubmission = async () => {


### PR DESCRIPTION
## 🔧 What changed
This is part of breaking out #718  into smaller PRs. This implements the Modal showing from the top bar when accept is clicked, so that you can confirm that you actually want to submit the facility into the database and you are sure about the changes you made. This keeps the user from accidentally submitting when on the page with a mis click.

## 📷  Screenshot

### After
![image](https://github.com/user-attachments/assets/96602e1f-8d9d-4790-80da-cb2d62045f0f)

