### PR TITLE
feat: add workflow for validating pr titles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 Resolves #[Issue number]
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs
 
 ## 🔧 What changed
 
@@ -9,3 +10,5 @@ Resolves #[Issue number]
 -   ### Before
 
 -   ### After
+
+

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,21 @@
+name: "Lint PR title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Have a look at the [CONTRIBUTING](/CONTRIBUTING.md) and [CODE_OF_CONDUCT](/CODE_
 
 ### Code Style
 
+- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
 - [ESLint](https://eslint.org/)
 - [EditorConfig](https://editorconfig.org)
 


### PR DESCRIPTION
## 🔧 What changed

We'd like to ensure that commit messages that go into main are consistent and high quality. Since we use the "squash and merge" setting, the PR title is what becomes the commit message when it is merged. This workflow will check that the PR title follows [conventional commit specifications](https://www.conventionalcommits.org/en/v1.0.0/).

## Resources
[Workflow documentation](https://github.com/amannn/action-semantic-pull-request)
[Slack discussion](https://find-a-doc.slack.com/archives/C02663QK8TD/p1727925045163499)