### PR TITLE
chore: configure eslint to not ignore strings for max length

### DIFF
--- a/components/ModDashboardLeftNavbar.vue
+++ b/components/ModDashboardLeftNavbar.vue
@@ -59,7 +59,12 @@ import { ref, computed, type Ref, watchEffect } from 'vue'
 import SVGNoteStackAddSvg from '../assets/icons/note-stack-add.svg'
 import SVGCheckBoxSvg from '../assets/icons/check-box.svg'
 import SVGDisabledByDefault from '../assets/icons/disabled-by-default.svg'
-import { useModerationSubmissionsStore, SelectedSubmissionListViewTab, SubmissionStatus, SelectedModerationListView } from '~/stores/moderationSubmissionsStore'
+import {
+    useModerationSubmissionsStore,
+    SelectedSubmissionListViewTab,
+    SubmissionStatus,
+    SelectedModerationListView
+} from '~/stores/moderationSubmissionsStore'
 import type { Submission } from '~/typedefs/gqlTypes'
 
 const moderationSubmissionsStore = useModerationSubmissionsStore()

--- a/components/ModDashboardTopbar.vue
+++ b/components/ModDashboardTopbar.vue
@@ -24,7 +24,11 @@
 </template>
 
 <script setup lang="ts">
-import { SelectedModerationListView, SelectedSubmissionListViewTab, useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
+import {
+    SelectedModerationListView,
+    SelectedSubmissionListViewTab,
+    useModerationSubmissionsStore
+} from '~/stores/moderationSubmissionsStore'
 import { useI18n } from '#imports'
 import SVGLookingGlass from '~/assets/icons/looking-glass.svg'
 

--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -502,8 +502,26 @@ import { useRouter } from 'vue-router'
 import { gql } from 'graphql-request'
 import { gqlClient, graphQLClientRequestWithRetry } from '~/utils/graphql.js'
 import { useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
-import { Locale, type Submission, type MutationUpdateSubmissionArgs, type LocalizedNameInput, Insurance, Degree, Specialty } from '~/typedefs/gqlTypes'
-import { validateAddressLineEn, validateAddressLineJa, validateNameEn, validateNameJa, validatePhoneNumber, validateCityEn, validateEmail, validateFloat, validatePostalCode, validateWebsite, validateCityJa, validateUserSubmittedFirstName, validateUserSubmittedLastName } from '~/utils/formValidations'
+import { Locale,
+    type Submission,
+    type MutationUpdateSubmissionArgs,
+    type LocalizedNameInput,
+    Insurance,
+    Degree,
+    Specialty } from '~/typedefs/gqlTypes'
+import { validateAddressLineEn,
+    validateAddressLineJa,
+    validateNameEn,
+    validateNameJa,
+    validatePhoneNumber,
+    validateCityEn,
+    validateEmail,
+    validateFloat,
+    validatePostalCode,
+    validateWebsite,
+    validateCityJa,
+    validateUserSubmittedFirstName,
+    validateUserSubmittedLastName } from '~/utils/formValidations'
 import { ModSubmissionLeftNavbarSectionIDs, useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
 import { multiSelectWithoutKeyboard } from '~/utils/multiSelectWithoutKeyboard'
 import { useModalStore } from '~/stores/modalStore'
@@ -513,7 +531,9 @@ const router = useRouter()
 const modalStore = useModalStore()
 const screenStore = useModerationScreenStore()
 
+// Move all these values to the store
 // contactFields
+
 const nameEn: Ref<string> = ref('')
 const nameJa: Ref<string> = ref('')
 const phone: Ref<string> = ref('')
@@ -554,8 +574,19 @@ const extractSpecialtyOptions = (option: HTMLOptionElement): Specialty => option
 const localeOptions = Object.values(Locale) as Locale[]
 const extractLocaleOptions = (option: HTMLOptionElement): Locale => option.value as Locale
 
-const listPrefectureJapanEn: Ref<string[]> = ref(['Hokkaido', 'Aomori', 'Iwate', 'Miyagi', 'Akita', 'Yamagata', 'Fukushima', 'Ibaraki', 'Tochigi', 'Gumma', 'Saitama', 'Chiba', 'Tokyo', 'Kanagawa', 'Niigata', 'Toyama', 'Ishikawa', 'Fukui', 'Yamanashi', 'Nagano', 'Gifu', 'Shizuoka', 'Aichi', 'Mie', 'Shiga', 'Kyoto', 'Osaka', 'Hyogo', 'Nara', 'Wakayama', 'Tottori', 'Shimane', 'Okayama', 'Hiroshima', 'Yamaguchi', 'Tokushima', 'Kagawa', 'Ehime', 'Kochi', 'Fukuoka', 'Saga', 'Nagasaki', 'Kumamoto', 'Oita', 'Miyazaki', 'Kagoshima', 'Okinawa'])
-const listPrefectureJapanJa: Ref<string[]> = ref(['北海道', '青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県', '茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県', '新潟県', '富山県', '石川県', '福井県', '山梨県', '長野県', '岐阜県', '静岡県', '愛知県', '三重県', '滋賀県', '京都府', '大阪府', '兵庫県', '奈良県', '和歌山県', '鳥取県', '島根県', '岡山県', '広島県', '山口県', '徳島県', '香川県', '愛媛県', '高知県', '福岡県', '佐賀県', '長崎県', '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県'])
+const listPrefectureJapanEn: Ref<string[]> = ref([
+    'Hokkaido', 'Aomori', 'Iwate', 'Miyagi', 'Akita',
+    'Yamagata', 'Fukushima', 'Ibaraki', 'Tochigi', 'Gumma', 'Saitama', 'Chiba', 'Tokyo', 'Kanagawa',
+    'Niigata', 'Toyama', 'Ishikawa', 'Fukui', 'Yamanashi', 'Nagano', 'Gifu', 'Shizuoka', 'Aichi',
+    'Mie', 'Shiga', 'Kyoto', 'Osaka', 'Hyogo', 'Nara', 'Wakayama', 'Tottori', 'Shimane', 'Okayama',
+    'Hiroshima', 'Yamaguchi', 'Tokushima', 'Kagawa', 'Ehime', 'Kochi', 'Fukuoka', 'Saga',
+    'Nagasaki', 'Kumamoto', 'Oita', 'Miyazaki', 'Kagoshima', 'Okinawa'])
+const listPrefectureJapanJa: Ref<string[]> = ref([
+    '北海道', '青森県', '岩手県', '宮城県', '秋田県',
+    '山形県', '福島県', '茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県', '新潟県', '富山県',
+    '石川県', '福井県', '山梨県', '長野県', '岐阜県', '静岡県', '愛知県', '三重県', '滋賀県', '京都府', '大阪府',
+    '兵庫県', '奈良県', '和歌山県', '鳥取県', '島根県', '岡山県', '広島県', '山口県', '徳島県', '香川県', '愛媛県',
+    '高知県', '福岡県', '佐賀県', '長崎県', '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県'])
 
 const moderationSubmissionStore = useModerationSubmissionsStore()
 

--- a/components/ModEditSubmissionTopbar.vue
+++ b/components/ModEditSubmissionTopbar.vue
@@ -84,6 +84,7 @@ const saveAndExit = () => {
     moderationSubmissionStore.setUpdatingSubmissionFromTopBar(true)
 }
 
+// Move all API calls to the store
 const acceptSubmission = () => {
     moderationSubmissionStore.setApprovingSubmissionFromTopBar(true)
     modalStore.showModal()

--- a/components/ModInputField.vue
+++ b/components/ModInputField.vue
@@ -44,7 +44,10 @@ const props = defineProps({
     inputValidationCheck: Function
 })
 
-const labelsToOnlyValidateOnBlur = [t('modSubmissionForm.labelHealthcareProfessionalLastName'), t('modSubmissionForm.labelHealthcareProfessionalFirstName'), t('modSubmissionForm.labelHealthcareProfessionalMiddleName')]
+const labelsToOnlyValidateOnBlur = [
+    t('modSubmissionForm.labelHealthcareProfessionalLastName'),
+    t('modSubmissionForm.labelHealthcareProfessionalFirstName'),
+    t('modSubmissionForm.labelHealthcareProfessionalMiddleName')]
 
 const initialValidationCheck = async () => {
     if (!labelsToOnlyValidateOnBlur.includes(props.label)) {

--- a/components/ModMainContent.vue
+++ b/components/ModMainContent.vue
@@ -46,7 +46,8 @@ const setActiveScreenBasedOnRoute = async () => {
     } else if (routePathForModerationScreen.value.includes('edit-facility') && selectedIdFromModSubmissionList.value) {
         screenStore.setActiveScreen(ModerationScreen.EditFacility)
         moderationSubmissionsStore.selectedFacilityId = selectedIdFromModSubmissionList.value
-    } else if (routePathForModerationScreen.value.includes('edit-healthcare-professional') && selectedIdFromModSubmissionList.value) {
+    } else if (
+        routePathForModerationScreen.value.includes('edit-healthcare-professional') && selectedIdFromModSubmissionList.value) {
         screenStore.setActiveScreen(ModerationScreen.EditHealthcareProfessional)
         moderationSubmissionsStore.selectedHealthcareProfessionalId = selectedIdFromModSubmissionList.value
     } else {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ export default withNuxt(
             '.output/*',
             '.nuxt/*',
             'coverage/*',
-            'cypress/support/*',
+            'cypress/*',
             '.yarn/*',
             'typedefs/gqlTypes.ts'
         ]
@@ -172,7 +172,7 @@ export default withNuxt(
                     comments: 130,
                     ignoreTrailingComments: true,
                     ignoreUrls: true,
-                    ignoreStrings: true,
+                    ignoreStrings: false,
                     ignoreTemplateLiterals: true,
                     ignoreRegExpLiterals: true
                 }

--- a/i18n/checkLocaleKeys.js
+++ b/i18n/checkLocaleKeys.js
@@ -146,7 +146,9 @@ const runCICDChecksForLocaleFiles = (localeFilesWithoutEnFileName, referenceKeys
             keys.forEach(key => console.error(`- ${key}`))
         })
 
-        console.log('\x1b[93m\x1b[1mTo fix this error\x1b[0m\n\x1b[35m1) Run the command:\x1b[0m\n   yarn lint:locales\n\x1b[35m2) Push the updates\x1b[0m')
+        console.log('\x1b[93m\x1b[1mTo fix this error\x1b[0m')
+        console.log('\x1b[35m1)Run the command:\x1b[0m')
+        console.log('yarn lint:locales\n\x1b[35m2Push the updates\x1b[0m')
         process.exitCode = 1 // Exit with error code
         process.exit()
     }

--- a/stores/localeStore.ts
+++ b/stores/localeStore.ts
@@ -19,8 +19,10 @@ export const useLocaleStore = defineStore('locale', () => {
     function formatLanguages(
         spokenLanguages: Locale[], localeDisplayOptions: { code: string, simpleText: string }[]
     ) {
-        return spokenLanguages?.map(languageCode => localeDisplayOptions.find(option => option.code === languageCode)?.simpleText || 'Not Specified')
-          ?? []
+        return spokenLanguages?.map(languageCode =>
+            localeDisplayOptions.find(option =>
+                option.code === languageCode)?.simpleText || 'Not Specified')
+                ?? []
     }
 
     return { locale, localeDisplayOptions, mvpLocaleDisplayOptions, setLocale, formatLanguages }

--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -4,7 +4,12 @@ import { ref, type Ref } from 'vue'
 import { gqlClient } from '../utils/graphql.js'
 import { useModalStore } from './modalStore'
 import { useLoadingStore } from './loadingStore.js'
-import type { Locale, Specialty, Facility, FacilitySearchFilters, HealthcareProfessional, HealthcareProfessionalSearchFilters } from '~/typedefs/gqlTypes.js'
+import type { Locale,
+    Specialty,
+    Facility,
+    FacilitySearchFilters,
+    HealthcareProfessional,
+    HealthcareProfessionalSearchFilters } from '~/typedefs/gqlTypes.js'
 
 type SearchResult = {
     professional: HealthcareProfessional

--- a/utils/formValidations.ts
+++ b/utils/formValidations.ts
@@ -1,4 +1,11 @@
-import { hasJapaneseCharacters, hasLatinCharacters, isValidEmail, isValidPhoneNumber, isValidWebsite, isFloat, isValidPostalCode, isValidUrl } from './stringUtils'
+import { hasJapaneseCharacters,
+    hasLatinCharacters,
+    isValidEmail,
+    isValidPhoneNumber,
+    isValidWebsite,
+    isFloat,
+    isValidPostalCode,
+    isValidUrl } from './stringUtils'
 import { Locale } from '~/typedefs/gqlTypes'
 
 export function validateNameEn(nameEn: string): boolean {


### PR DESCRIPTION
## 🔧 What changed
There are several lines in our codebase that exceed the maximum length of 130. Most of them are because refs are treated as strings. This change to the eslint config will make it so lines with strings must also be 130 characters or less. The `/cypress` director was added to the ignore list, because it tests long urls that are not treated as strings.


