### PR TITLE
chore: update imports in `searchResultsStore`

### DIFF
--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -1,6 +1,7 @@
 import { gql } from 'graphql-request'
 import { defineStore } from 'pinia'
 import { ref, type Ref } from 'vue'
+import { gqlClient } from '../utils/graphql.js'
 import { useModalStore } from './modalStore'
 import { useLoadingStore } from './loadingStore.js'
 import type { Locale, Specialty, Facility, FacilitySearchFilters, HealthcareProfessional, HealthcareProfessionalSearchFilters } from '~/typedefs/gqlTypes.js'

--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia'
 import { ref, type Ref } from 'vue'
 import { useModalStore } from './modalStore'
 import { useLoadingStore } from './loadingStore.js'
-import type { Locale, Specialty, Facility, FacilitySearchFilters, HealthcareProfessional, HealthcareProfessionalSearchFilters, type Facility, type FacilitySearchFilters, type HealthcareProfessional, type HealthcareProfessionalSearchFilters } from '~/typedefs/gqlTypes.js'
+import type { Locale, Specialty, Facility, FacilitySearchFilters, HealthcareProfessional, HealthcareProfessionalSearchFilters } from '~/typedefs/gqlTypes.js'
 
 type SearchResult = {
     professional: HealthcareProfessional


### PR DESCRIPTION
Resolves #810 #810

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

1. This file had duplicate imports in the store from the `typeDefs/gqlTypes` file and they were removed. 
2. It was missing the import `gqlClient` and this was added.


