### PR TITLE
feat: implement approve submission mutation in store

### DIFF
--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -101,6 +101,21 @@ export const useModerationSubmissionsStore = defineStore(
             }
         }
 
+        async function approveSubmission() {
+            if (!selectedSubmissionId.value) {
+                console.error('Submission Id is required')
+                return
+            }
+
+            const approveSubmissionInput: MutationUpdateSubmissionArgs = {
+                id: selectedSubmissionId.value,
+                input: {
+                    isApproved: true
+                }
+            }
+            updateSubmission(approveSubmissionInput)
+        }
+
         return { getSubmissions,
             submissionsData,
             filterSubmissionByStatus,
@@ -120,7 +135,8 @@ export const useModerationSubmissionsStore = defineStore(
             setApprovingSubmissionFromTopBar,
             selectedModerationListViewTabChosen,
             setSelectedModerationListViewTabChosen,
-            updateSubmission }
+            updateSubmission,
+            approveSubmission }
     }
 )
 


### PR DESCRIPTION
Resolves #802
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Before there was not a specific function that was to just approve a facility. This has now been implemented in the store so it can be tested as well as used in the `ModEditSubmissionForm` in #718.

## 🧪 Testing instructions
TBA > Before tests can be done we need to update our `vitest.config.ts` to be integrated with Nuxt to allow imports from the `nuxtApp` itself

This is being done in #821 



