### PR TITLE
refactor: update bot to only run on minor and security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "stabilityDays": 14,
     "prConcurrentLimit": 3,
     "reviewers": ["team:admins"],
+    "rangeStrategy": "bump",
     "packageRules": [
         {
             "matchPackagePatterns": ["^eslint"],

--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,15 @@
             "groupName": "eslint packages"
         },
         {
-            "matchPackagePatterns": ["node"],
-            "allowedVersions": "/18.*/"
+            "matchUpdateTypes": ["minor"],
+            "groupName": "Minor Updates"
         }
-    ]
+    ],
+    "vulnerabilityAlerts": {
+        "groupName": "Security Updates",
+        "prCreation": "immediate",
+        "commitMessageSuffix": "[SECURITY]",
+        "branchTopic": "{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
+        "vulnerabilityFixStrategy": "lowest"
+    }
 }


### PR DESCRIPTION
Resolves #766 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Looking through the [json](https://docs.renovatebot.com/renovate-schema.json), [docs](https://docs.renovatebot.com/configuration-options/) and with some research the renovate bot settings were updated based on the requirements in the ticket.
1. Updates the lock-file and bumps the `package.json`
2. Only update type is `minor`
3. It also detects vulnerability alerts so runs to update on security patches

