### PR TITLE
refactor: move state to modal component and add emit

### DIFF
--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -7,7 +7,6 @@
         >
             <Loader />
             <Modal
-                v-show="store.$state.isOpen"
                 class="max-h-[calc(100vh-12rem)] ml-8 mt-12 overflow-y-auto"
             >
                 <SearchResultDetails />
@@ -22,7 +21,6 @@
         >
             <Loader />
             <Modal
-                v-show="store.$state.isOpen"
                 class="min-h-1/2 ml-8 mt-12"
             >
                 <SearchResultDetails />
@@ -39,8 +37,6 @@
 
 <script lang="ts" setup>
 import { useNuxtApp } from '#app'
-import { useModalStore } from '~/stores/modalStore'
 
 const { $viewport } = useNuxtApp()
-const store = useModalStore()
 </script>

--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -1,6 +1,5 @@
 <template>
     <Modal
-        v-show="modalStore.isOpen"
         data-testid="submission-form-modal"
         class=" min-h-20 min-w-20 fixed top-0 left-0 flex items-center justify-center h-full w-full z-10
          bg-secondary bg-opacity-40"

--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -1,5 +1,6 @@
 <template>
     <div
+        v-show="store.isOpen"
         class="absolute z-10 bg-primary-bg rounded-xl overflow-hidden
         hover:shadow-inner hover:shadow-secondary-bg/90"
     >
@@ -8,7 +9,7 @@
                 type="button"
                 class="close-button absolute right-6 top-5 bg-primary-inverted rounded-lg px-2 py-.5
                 group hover:bg-primary-hover transition-all duration-200"
-                @click="store.hideModal()"
+                @click="hideModalAndEmitClosedEvent"
             >
                 <span class="close-icon">
                     <svg
@@ -39,5 +40,10 @@
 import { useModalStore } from '~/stores/modalStore'
 
 const store = useModalStore()
+const emit = defineEmits(['modal-closed'])
+const hideModalAndEmitClosedEvent = () => {
+    emit('modal-closed')
+    store.hideModal()
+}
 </script>
 


### PR DESCRIPTION
Part of #770

## 🔧 What changed
This change adds a couple small improvements to the `Modal` component.
1. Moves the `v-show` to the component itself so we don't need to keep track of it everywhere it is used.
2. Emits `modal-closed` when the user hits the "X" button or clicks off screen. This will be useful for knowing when to reset the state of whatever called the modal (such as `approvingSubmissionFromTopBar`).