### PR TITLE
chore: set skip ci to false for all contributors config

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -173,7 +173,7 @@
     }
   ],
   "contributorsPerLine": 7,
-  "skipCi": true,
+  "skipCi": false,
   "repoType": "github",
   "repoHost": "https://github.com",
   "projectName": "findadoc-web",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -161,6 +161,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "gminetoma",
+      "name": "Gustavo Minoru",
+      "avatar_url": "https://avatars.githubusercontent.com/u/73707876?v=4",
+      "profile": "https://github.com/gminetoma",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Have a look at the [CONTRIBUTING](/CONTRIBUTING.md) and [CODE_OF_CONDUCT](/CODE_
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Anissa3005"><img src="https://avatars.githubusercontent.com/u/114712265?v=4?s=100" width="100px;" alt="Anissa Chadouli"/><br /><sub><b>Anissa Chadouli</b></sub></a><br /><a href="https://github.com/ourjapanlife/findadoc-web/commits?author=Anissa3005" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/evan-desu"><img src="https://avatars.githubusercontent.com/u/86333067?v=4?s=100" width="100px;" alt="Evan Peterson"/><br /><sub><b>Evan Peterson</b></sub></a><br /><a href="https://github.com/ourjapanlife/findadoc-web/commits?author=evan-desu" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/gminetoma"><img src="https://avatars.githubusercontent.com/u/73707876?v=4?s=100" width="100px;" alt="Gustavo Minoru"/><br /><sub><b>Gustavo Minoru</b></sub></a><br /><a href="https://github.com/ourjapanlife/findadoc-web/commits?author=gminetoma" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
We're unable to merge PRs created by all-contributors with `skipCI` set to `true` because of branch protections.

