### PR TITLE
feat: implement mod top bar UI for hp and facility

### DIFF
--- a/components/ModEditFacilityOrProfessionalTopbar.vue
+++ b/components/ModEditFacilityOrProfessionalTopbar.vue
@@ -1,0 +1,99 @@
+<template>
+    <div class="flex justify-between w-full">
+        <div>
+            <button
+                data-testid="mod-edit-facility-hp-topbar-copy-id"
+                class="flex w-90 bg-neutral p-2 m-2 border-2 border-inverted rounded hover"
+                @click="copyFacilityOrHPId"
+            >
+                ID: {{ selectedId }}
+                <SVGSuccessCheckMark
+                    v-if="showCopySuccessIcon"
+                    role="img"
+                    title="clipboard copy"
+                    class="ml-2 w-6"
+                />
+                <SVGCopyContent
+                    v-if="!showCopySuccessIcon"
+                    role="img"
+                    title="successful copy"
+                    class="ml-2 w-6"
+                />
+            </button>
+        </div>
+        <div class="facility-hp-topbar-actions flex justify p-2 font-bold ">
+            <button
+                type="button"
+                class="flex justify-center items-center rounded-full bg-secondary-bg border-primary-text-muted
+                border-2 w-28 text-sm mr-2"
+                data-testid="mod-edit-facility-hp-topbar-update"
+            >
+                <span>
+                    {{ $t('modEditFacilityOrHPTopbar.updateAndExit') }}
+                </span>
+            </button>
+            <button
+                type="button"
+                class="flex justify-center items-center rounded-full bg-secondary-bg border-primary border-2 w-28 text-sm mr-2 "
+                data-testid="mod-edit-facility-hp-topbar-delete"
+            >
+                {{
+                    $t('modEditFacilityOrHPTopbar.delete') }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, type ComputedRef, type Ref } from 'vue'
+import { type ToastInterface, useToast } from 'vue-toastification'
+import { useI18n } from '#imports'
+import SVGCopyContent from '~/assets/icons/content-copy.svg'
+import SVGSuccessCheckMark from '~/assets/icons/checkmark-square.svg'
+import { useFacilitiesStore } from '~/stores/facilitiesStore'
+import { useHealthcareProfessionalsStore } from '~/stores/healthcareProfessionalsStore'
+import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
+
+// Initialize the stores in use
+const facilitiesStore = useFacilitiesStore()
+const healthcareProfessionalsStore = useHealthcareProfessionalsStore()
+const moderationScreenStore = useModerationScreenStore()
+
+// Initialize the value of the selected Id based off of Moderation Screen
+const selectedId: ComputedRef<string> = computed(() => setSelectedId())
+
+// Initialize the variable that will be used to mount the toast library
+let toast: ToastInterface
+
+const { t } = useI18n()
+
+const showCopySuccessIcon: Ref<boolean> = ref(false)
+
+const copyFacilityOrHPId = async () => {
+    try {
+        await navigator.clipboard.writeText(selectedId.value)
+        showCopySuccessIcon.value = true
+        setTimeout(() => {
+            showCopySuccessIcon.value = false
+        }, 2000)
+    } catch (err: unknown) {
+        toast.error(`${t('modEditFacilityOrHPTopbar.copyFailure')} ${selectedId.value}: ${err}`)
+        console.error(`Failed to copy ID ${selectedId.value}: ${err}`)
+    }
+}
+
+function setSelectedId() {
+    switch (moderationScreenStore.activeScreen) {
+        case ModerationScreen.EditFacility:
+            return facilitiesStore.selectedFacilityId
+        case ModerationScreen.EditHealthcareProfessional:
+            return healthcareProfessionalsStore.selectedHealthcareProfessionalId
+        default:
+            return ''
+    }
+}
+
+onMounted(() => {
+    toast = useToast()
+})
+</script>

--- a/components/ModMainContent.vue
+++ b/components/ModMainContent.vue
@@ -31,11 +31,15 @@ import { useRoute } from 'vue-router'
 import { computed, nextTick, onMounted, watch } from 'vue'
 import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
 import { useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
+import { useFacilitiesStore } from '~/stores/facilitiesStore'
+import { useHealthcareProfessionalsStore } from '~/stores/healthcareProfessionalsStore'
 
 const route = useRoute()
 
 const screenStore = useModerationScreenStore()
 const moderationSubmissionsStore = useModerationSubmissionsStore()
+const facilitiesStore = useFacilitiesStore()
+const healthcareProfessionalStore = useHealthcareProfessionalsStore()
 
 const routePathForModerationScreen = computed(() => route.path as string)
 const selectedIdFromModSubmissionList = computed(() => route.params.id as string)
@@ -47,16 +51,16 @@ const setActiveScreenBasedOnRoute = async () => {
         moderationSubmissionsStore.selectedSubmissionId = selectedIdFromModSubmissionList.value
     } else if (routePathForModerationScreen.value.includes('edit-facility') && selectedIdFromModSubmissionList.value) {
         screenStore.setActiveScreen(ModerationScreen.EditFacility)
-        moderationSubmissionsStore.selectedFacilityId = selectedIdFromModSubmissionList.value
+        facilitiesStore.selectedFacilityId = selectedIdFromModSubmissionList.value
     } else if (
         routePathForModerationScreen.value.includes('edit-healthcare-professional') && selectedIdFromModSubmissionList.value) {
         screenStore.setActiveScreen(ModerationScreen.EditHealthcareProfessional)
-        moderationSubmissionsStore.selectedHealthcareProfessionalId = selectedIdFromModSubmissionList.value
+        healthcareProfessionalStore.selectedHealthcareProfessionalId = selectedIdFromModSubmissionList.value
     } else {
         screenStore.setActiveScreen(ModerationScreen.Dashboard)
         moderationSubmissionsStore.selectedSubmissionId = ''
-        moderationSubmissionsStore.selectedFacilityId = ''
-        moderationSubmissionsStore.selectedHealthcareProfessionalId = ''
+        facilitiesStore.selectedFacilityId = ''
+        healthcareProfessionalStore.selectedHealthcareProfessionalId = ''
     }
 }
 

--- a/components/ModTopbar.vue
+++ b/components/ModTopbar.vue
@@ -17,13 +17,13 @@
             v-else-if="moderationScreenStore.activeScreen === ModerationScreen.EditFacility"
             class="h-[76px] w-full"
         >
-            Facility Topbar
+            <ModEditFacilityOrProfessionalTopbar />
         </div>
         <div
             v-else-if="moderationScreenStore.activeScreen === ModerationScreen.EditHealthcareProfessional"
             class="h-[76px] w-full"
         >
-            Healthcare Professional Topbar
+            <ModEditFacilityOrProfessionalTopbar />
         </div>
     </div>
 </template>

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -313,5 +313,10 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update"
+  },
+  "modEditFacilityOrHPTopbar": {
+    "updateAndExit": "Update & Exit",
+    "delete": "Delete",
+    "copyFailure": "Failed to copy ID"
   }
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -313,5 +313,10 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update"
+  },
+  "modEditFacilityOrHPTopbar": {
+    "updateAndExit": "Update & Exit",
+    "delete": "Delete",
+    "copyFailure": "Failed to copy ID"
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -143,6 +143,11 @@
         "healthcareProfessionals": "Healthcare Professionals",
         "facilities": "Facilities"
     },
+    "modEditFacilityOrHPTopbar": {
+        "copyFailure": "Failed to copy ID",
+        "delete": "Delete",
+        "updateAndExit": "Update & Exit"
+    },
     "modEditSubmissionTopNav": {
         "saveAndExit": "Save & Exit",
         "saving": "Saving...",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -317,5 +317,10 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update"
+  },
+  "modEditFacilityOrHPTopbar": {
+    "updateAndExit": "Update & Exit",
+    "delete": "Delete",
+    "copyFailure": "Failed to copy ID"
   }
 }

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -313,5 +313,10 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update"
+  },
+  "modEditFacilityOrHPTopbar": {
+    "updateAndExit": "Update & Exit",
+    "delete": "Delete",
+    "copyFailure": "Failed to copy ID"
   }
 }

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -313,5 +313,10 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update"
+  },
+  "modEditFacilityOrHPTopbar": {
+    "updateAndExit": "Update & Exit",
+    "delete": "Delete",
+    "copyFailure": "Failed to copy ID"
   }
 }

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -313,5 +313,10 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update"
+  },
+  "modEditFacilityOrHPTopbar": {
+    "updateAndExit": "Update & Exit",
+    "delete": "Delete",
+    "copyFailure": "Failed to copy ID"
   }
 }

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -8,6 +8,7 @@ export const useFacilitiesStore = defineStore(
     'facilitiesStore',
     () => {
         const facilityData: Ref<Facility[]> = ref([])
+        const selectedFacilityId: Ref<string> = ref('')
         const facilitySectionFields = {
             // contactFields
             nameEn: ref('') as Ref<string>,
@@ -52,7 +53,8 @@ export const useFacilitiesStore = defineStore(
             getFacilities,
             facilityData,
             updateFacility,
-            facilitySectionFields
+            facilitySectionFields,
+            selectedFacilityId
         }
     }
 )

--- a/stores/healthcareProfessionalsStore.ts
+++ b/stores/healthcareProfessionalsStore.ts
@@ -9,6 +9,7 @@ export const useHealthcareProfessionalsStore = defineStore(
     () => {
         const healthcareProfessionalsData: Ref<HealthcareProfessional[]>
         = ref([])
+        const selectedHealthcareProfessionalId: Ref<string> = ref('')
 
         async function getHealthcareProfessionals() {
             const healthcareProfessionalResults = await queryHealthcareProfessionals()
@@ -30,7 +31,8 @@ export const useHealthcareProfessionalsStore = defineStore(
         return {
             getHealthcareProfessionals,
             healthcareProfessionalsData,
-            updateHealthcareProfessional
+            updateHealthcareProfessional,
+            selectedHealthcareProfessionalId
         }
     }
 )

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -28,8 +28,6 @@ export const useModerationSubmissionsStore = defineStore(
         const submissionsData: Ref<Submission[]> = ref([])
         const selectedModerationListViewChosen: Ref<SelectedModerationListView> = ref(SelectedModerationListView.Submissions)
         const selectedSubmissionId: Ref<string> = ref('')
-        const selectedFacilityId: Ref<string> = ref('')
-        const selectedHealthcareProfessionalId: Ref<string> = ref('')
         const selectedSubmissionData: Ref<Submission | undefined> = ref()
         const filteredSubmissionDataForListComponent: Ref<Submission[]> = ref([])
         const didMutationFail: Ref<boolean> = ref(false)
@@ -153,8 +151,6 @@ export const useModerationSubmissionsStore = defineStore(
             setDidMutationFail,
             selectedModerationListViewChosen,
             setSelectedModerationListViewChosen,
-            selectedFacilityId,
-            selectedHealthcareProfessionalId,
             updatingSubmissionFromTopBar,
             setUpdatingSubmissionFromTopBar,
             approvingSubmissionFromTopBar,

--- a/test/cypress/e2e/moderationEditFacility.cy.ts
+++ b/test/cypress/e2e/moderationEditFacility.cy.ts
@@ -1,5 +1,6 @@
 import 'cypress-real-events'
 import 'cypress-plugin-tab'
+import enUS from '../../../i18n/locales/en.json'
 
 const FAKE_FACILITY_RESPONSE_PATH = 'moderation_dashboard/fakeModFacilityData.json'
 
@@ -52,6 +53,24 @@ describe('Moderation edit facility form', () => {
 
         after(() => {
             Cypress.session.clearCurrentSessionData()
+        })
+
+        it('contains the following fields and buttons in the topbar'), () => {
+            cy.get('[data-testid="mod-edit-facility-hp-topbar-update"]').should('exist')
+                .contains(enUS.modEditFacilityOrHPTopbar.updateAndExit)
+            cy.get('[data-testid="mod-edit-facility-hp-topbar-delete"]').should('exist')
+                .contains(enUS.modEditFacilityOrHPTopbar.delete)
+            cy.get('[data-testid="mod-edit-facility-hp-topbar-copy-id"]').should('exist')
+        }
+
+        it('it copies the selected id', () => {
+            cy.get('[data-testid="mod-edit-facility-hp-topbar-copy-id"]').click()
+
+            // Check that the value copied to the clipboard is the same that's displayed.
+            const clipboardResult = cy.window().then(win => win.navigator.clipboard.readText())
+
+            // The timeout is to give time for the clipboard to be read.
+            clipboardResult.should('exist', 10000)
         })
 
         it('contains the following input fields', () => {


### PR DESCRIPTION
Resolves #854 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Before there was no top bar that could be used in the screens in which we view and update or delete the facilities and healthcare professionals in our database. The respective Ids were moved into their respective stores for consistency in the code and separation of concerns with our stores. This also provides the clipboard functionality when a facility is selected

## 🧪 Testing instructions
You can run the cypress tests by going to the branch and running
- `yarn cypress open`
From here you can choose the `moderationEditFacility.cy.ts` test run and they will pass and show the elements exist.

## 📸 Screenshots

-   ### Before
N/A no topbar was implemented
-   ### After

https://github.com/user-attachments/assets/b45db4f1-1922-43e0-bfac-8f9d47afda0d




