### PR TITLE
test: set defaultCommandTimeout to 10000ms for stability

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -15,7 +15,8 @@ const config = defineConfig({
         experimentalRunAllSpecs: true,
         requestTimeout: 10000,
         responseTimeout: 30000,
-        pageLoadTimeout: 60000
+        pageLoadTimeout: 60000,
+        defaultCommandTimeout: 10000
     }
 })
 

--- a/test/cypress/e2e/about.cy.ts
+++ b/test/cypress/e2e/about.cy.ts
@@ -3,7 +3,7 @@ import enUS from '../../../i18n/locales/en.json'
 describe('About page', () => {
     context('Desktop resolution', () => {
         before(() => {
-            cy.visit('/about', { timeout: 10000 })
+            cy.visit('/about')
         })
 
         beforeEach(() => {
@@ -55,7 +55,7 @@ describe('About page', () => {
 
     context('Portrait mode', () => {
         before(() => {
-            cy.visit('/about', { timeout: 10000 })
+            cy.visit('/about')
         })
 
         beforeEach(() => {

--- a/test/cypress/e2e/home.cy.ts
+++ b/test/cypress/e2e/home.cy.ts
@@ -4,7 +4,7 @@ describe('Visits the home page', () => {
 
     context('Landscape mode', () => {
         before(() => {
-            cy.visit('/', { timeout: 10000 })
+            cy.visit('/')
         })
 
         beforeEach(() => {
@@ -24,7 +24,7 @@ describe('Visits the home page', () => {
         })
 
         it('allows setting search fields', () => {
-            cy.get('[data-testid="search-button"]', { timeout: 10000 }).should('be.visible')
+            cy.get('[data-testid="search-button"]').should('be.visible')
 
             cy.get('.search-specialty select').select('Dermatology')
             cy.get('.search-specialty select').should('be.visible', 'Dermatology')
@@ -37,15 +37,15 @@ describe('Visits the home page', () => {
         })
 
         it('can select "select a language"', () => {
-            cy.get('[data-testid="search-bar-language"]', { timeout: 10000 }).trigger('click')
+            cy.get('[data-testid="search-bar-language"]').trigger('click')
         })
 
         it('can select "English" from the language bar', () => {
-            cy.get('[data-testid="search-bar-language"]', { timeout: 10000 }).should('be.visible')
+            cy.get('[data-testid="search-bar-language"]').should('be.visible')
 
-            cy.get('[data-testid="search-bar-language"]', { timeout: 10000 }).select('English')
+            cy.get('[data-testid="search-bar-language"]').select('English')
 
-            cy.get('[data-testid="search-bar-language"]', { timeout: 10000 }).should(
+            cy.get('[data-testid="search-bar-language"]').should(
                 'have.value',
                 'en_US'
             )
@@ -128,7 +128,7 @@ describe('Visits the home page', () => {
     // Portrait mode tests - usually for mobile and tablet
     context('Portrait mode', () => {
         before(() => {
-            cy.visit('/', { timeout: 10000 })
+            cy.visit('/')
         })
 
         beforeEach(() => {

--- a/test/cypress/e2e/moderationDashboard.cy.ts
+++ b/test/cypress/e2e/moderationDashboard.cy.ts
@@ -21,7 +21,7 @@ describe(
                 // The resolution is in the beforeEach() instead of before() to
                 // prevent Cypress from defaulting to other screen sizes between tests.
                 cy.viewport('macbook-16')
-                cy.visit('/login', { timeout: 10000 })
+                cy.visit('/login')
                 Cypress.session.clearCurrentSessionData()
 
                 // This intercepts the call to the GraphQL API in order to use fake data in the tests to protect the real data.
@@ -47,16 +47,16 @@ describe(
 
                 /* Chaining of visit was used here to make sure the user was logged in and that it would
                  100 percent visit moderation */
-                cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click().visit('/moderation')
+                cy.get('[data-testid=top-nav-mod-link]').click().visit('/moderation')
 
                 cy.url({ timeout: 10000 }).should('include', '/moderation')
 
-                cy.wait('@getSubmissions', { timeout: 10000 })
+                cy.wait('@getSubmissions')
             })
 
             it('shows mod dashboard left navbar buttons with correct counts and functionality', () => {
                 // The number for include text is for the status in the fake data.
-                cy.get('[data-testid=mod-dashboard-leftnav-for-review]', { timeout: 10000 })
+                cy.get('[data-testid=mod-dashboard-leftnav-for-review]')
                     .should('exist')
                     .should(
                         'include.text',
@@ -89,22 +89,22 @@ describe(
                         '0'
                     )
 
-                cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).should('exist')
+                cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
 
                 cy.get('[data-testid=mod-dashboard-leftnav-approved]')
                     .click()
 
-                cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).should('exist')
+                cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
 
                 cy.get('[data-testid=mod-dashboard-leftnav-rejected]')
                     .click()
 
-                cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).should('not.exist')
+                cy.get('[data-testid="mod-submission-list-item-1"]').should('not.exist')
 
                 cy.get('[data-testid=mod-dashboard-leftnav-for-review]')
                     .click()
 
-                cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).should('exist')
+                cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
             })
 
             it.skip('it shows the moderation top nav', () => {
@@ -123,17 +123,17 @@ describe(
                 cy.get('[data-testid="mod-facility-list-item-1"]').should('not.exist')
                 cy.get('[data-testid="mod-submission-list-item-1').should('exist')
 
-                cy.get('[data-testid="submission-type-select"]', { timeout: 10000 }).select('FACILITIES')
+                cy.get('[data-testid="submission-type-select"]').select('FACILITIES')
                 cy.get('[data-testid="mod-healthcare-professional-list-item-1"]').should('not.exist')
                 cy.get('[data-testid="mod-facility-list-item-1"]').should('exist')
                 cy.get('[data-testid="mod-submission-list-item-1').should('not.exist')
 
-                cy.get('[data-testid="submission-type-select"]', { timeout: 10000 }).select('HEALTHCARE_PROFESSIONALS')
+                cy.get('[data-testid="submission-type-select"]').select('HEALTHCARE_PROFESSIONALS')
                 cy.get('[data-testid="mod-healthcare-professional-list-item-1"]').should('exist')
                 cy.get('[data-testid="mod-facility-list-item-1"]').should('not.exist')
                 cy.get('[data-testid="mod-submission-list-item-1').should('not.exist')
 
-                cy.get('[data-testid="submission-type-select"]', { timeout: 10000 }).select('SUBMISSIONS')
+                cy.get('[data-testid="submission-type-select"]').select('SUBMISSIONS')
                 cy.get('[data-testid="mod-healthcare-professional-list-item-1"]').should('not.exist')
                 cy.get('[data-testid="mod-facility-list-item-1"]').should('not.exist')
                 cy.get('[data-testid="mod-submission-list-item-1').should('exist')
@@ -157,7 +157,7 @@ describe('Moderation Edit Submission Form', () => {
         before(function() {
             cy.viewport('macbook-16')
 
-            cy.visit('/login', { timeout: 10000 })
+            cy.visit('/login')
             Cypress.session.clearCurrentSessionData()
 
             // This intercepts the call to the graphQL api in order to use fake data in the tests to protect
@@ -184,13 +184,13 @@ describe('Moderation Edit Submission Form', () => {
 
             /* Chaining of visit was used here to make sure the user was logged in and that it would
                  100 percent visit moderation */
-            cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click().visit('/moderation')
+            cy.get('[data-testid=top-nav-mod-link]').click().visit('/moderation')
 
             cy.url({ timeout: 10000 }).should('include', '/moderation')
 
-            cy.wait('@getSubmissions', { timeout: 10000 })
+            cy.wait('@getSubmissions')
 
-            cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).click()
+            cy.get('[data-testid="mod-submission-list-item-1"]').click()
         })
 
         after(() => {
@@ -244,13 +244,13 @@ describe('Moderation Edit Submission Form', () => {
         it('should autofill the form', function() {
             const submission = this.fakeSubmissionResponse.data.submissions[1].facility
 
-            cy.get('[data-testid="submission-form-nameEn"]').find('input', { timeout: 10000 })
+            cy.get('[data-testid="submission-form-nameEn"]').find('input')
                 .should('have.value', submission.nameEn)
 
-            cy.get('[data-testid="submission-form-nameJa"]').find('input', { timeout: 10000 })
+            cy.get('[data-testid="submission-form-nameJa"]').find('input')
                 .should('have.value', submission.nameJa)
 
-            cy.get('[data-testid="submission-form-phone"]').find('input', { timeout: 10000 })
+            cy.get('[data-testid="submission-form-phone"]').find('input')
                 .should('have.value', submission.contact.phone)
         })
 
@@ -284,43 +284,43 @@ describe('Moderation Edit Submission Form', () => {
         it('should be display error messages', () => {
             cy.get('[data-testid="submission-form-nameEn"]').find('input').clear().type('立川中央病院').realPress('Tab')
             cy.get('[data-testid="submission-form-nameEn"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid English Name')
+                .find('p').should('exist').contains('Invalid English Name')
 
             cy.get('[data-testid="submission-form-nameJa"]').find('input').clear().type('Tachikawa Hospital').realPress('Tab')
             cy.get('[data-testid="submission-form-nameJa"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Japanese Name')
+                .find('p').should('exist').contains('Invalid Japanese Name')
 
             cy.get('[data-testid="submission-form-phone"]').find('input').clear().type('Hello').realPress('Tab')
             cy.get('[data-testid="submission-form-phone"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Phone Number')
+                .find('p').should('exist').contains('Invalid Phone Number')
 
             cy.get('[data-testid="submission-form-email"]').find('input').clear().type('example').realPress('Tab')
             cy.get('[data-testid="submission-form-email"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Email Address')
+                .find('p').should('exist').contains('Invalid Email Address')
 
             cy.get('[data-testid="submission-form-website"]').find('input').clear().type('example').realPress('Tab')
             cy.get('[data-testid="submission-form-website"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Website URL')
+                .find('p').should('exist').contains('Invalid Website URL')
 
             cy.get('[data-testid="submission-form-postalCode"]').find('input').clear().type('180-0').realPress('Tab')
             cy.get('[data-testid="submission-form-postalCode"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Postal Code')
+                .find('p').should('exist').contains('Invalid Postal Code')
 
             cy.get('[data-testid="submission-form-cityEn"]').find('input').clear().type('渋谷区').realPress('Tab')
             cy.get('[data-testid="submission-form-cityEn"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid English City Name')
+                .find('p').should('exist').contains('Invalid English City Name')
 
             cy.get('[data-testid="submission-form-addressLine1En"]').find('input').clear().type('道の駅').realPress('Tab')
             cy.get('[data-testid="submission-form-addressLine1En"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid English Address')
+                .find('p').should('exist').contains('Invalid English Address')
 
             cy.get('[data-testid="submission-form-addressLine2En"]').find('input').clear().type('道の駅').realPress('Tab')
             cy.get('[data-testid="submission-form-addressLine2En"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid English Address')
+                .find('p').should('exist').contains('Invalid English Address')
 
             cy.get('[data-testid=submission-form-cityJa]').find('input').clear().type('Shibuya').realPress('Tab')
             cy.get('[data-testid=submission-form-cityJa]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Japanese City Name')
+                .find('p').should('exist').contains('Invalid Japanese City Name')
 
             cy.get('[data-testid="submission-form-addressLine1Ja"]')
                 .find('input').clear().type('Peanutbutter street').realPress('Tab')
@@ -332,12 +332,12 @@ describe('Moderation Edit Submission Form', () => {
             cy.get('[data-testid="submission-form-mapLatitude"]')
                 .find('input').clear().type('Not Number Latitude').realPress('Tab')
             cy.get('[data-testid="submission-form-mapLatitude"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Latitude')
+                .find('p').should('exist').contains('Invalid Latitude')
 
             cy.get('[data-testid="submission-form-mapLongitude"]')
                 .find('input').clear().type('Not Number Longitude').realPress('Tab')
             cy.get('[data-testid="submission-form-mapLongitude"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Longitude')
+                .find('p').should('exist').contains('Invalid Longitude')
         })
     })
 })
@@ -354,7 +354,7 @@ describe('Moderation Edit Submission Modal', () => {
         before(function() {
             cy.viewport('macbook-16')
 
-            cy.visit('/login', { timeout: 10000 })
+            cy.visit('/login')
             Cypress.session.clearCurrentSessionData()
 
             // This intercepts the call to the graphQL api in order to use fake data in the tests to protect
@@ -379,13 +379,13 @@ describe('Moderation Edit Submission Modal', () => {
 
             cy.url({ timeout: 10000 }).should('equal', 'http://localhost:3000/')
 
-            cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click().visit('/moderation')
+            cy.get('[data-testid=top-nav-mod-link]').click().visit('/moderation')
 
             cy.url({ timeout: 10000 }).should('include', '/moderation')
 
-            cy.wait('@getSubmissions', { timeout: 10000 })
+            cy.wait('@getSubmissions')
 
-            cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).click()
+            cy.get('[data-testid="mod-submission-list-item-1"]').click()
         })
 
         after(() => {
@@ -405,7 +405,7 @@ describe('Moderation Edit Submission Modal', () => {
         })
 
         it('should not display modal if user navigates back without making changes', () => {
-            cy.get('[data-testid="mod-submission-list-item-1"]', { timeout: 10000 }).click()
+            cy.get('[data-testid="mod-submission-list-item-1"]').click()
             // When the user clicks the back button on their browser without making changes...
             cy.go('back')
             // ...the modal with the confirmation button should not be visible...

--- a/test/cypress/e2e/moderationEditFacility.cy.ts
+++ b/test/cypress/e2e/moderationEditFacility.cy.ts
@@ -14,7 +14,7 @@ describe('Moderation edit facility form', () => {
             })
 
             cy.viewport('macbook-16')
-            cy.visit('/login', { timeout: 10000 })
+            cy.visit('/login')
             Cypress.session.clearCurrentSessionData()
 
             // This intercepts the call to the GraphQL API in order to use fake data in the tests to protect the real data.
@@ -40,14 +40,14 @@ describe('Moderation edit facility form', () => {
 
             /* Chaining of visit was used here to make sure the user was logged in and that it would
                 100 percent visit moderation */
-            cy.get('[data-testid=top-nav-mod-link]', { timeout: 10000 }).click().visit('/moderation')
+            cy.get('[data-testid=top-nav-mod-link]').click().visit('/moderation')
 
             cy.url({ timeout: 10000 }).should('include', '/moderation')
 
-            cy.wait('@getFacilities', { timeout: 10000 })
-            cy.get('[data-testid="submission-type-select"]', { timeout: 10000 }).select('FACILITIES')
+            cy.wait('@getFacilities')
+            cy.get('[data-testid="submission-type-select"]').select('FACILITIES')
 
-            cy.get('[data-testid="mod-facility-list-item-1"]', { timeout: 10000 }).click()
+            cy.get('[data-testid="mod-facility-list-item-1"]').click()
         })
 
         after(() => {
@@ -109,46 +109,46 @@ describe('Moderation edit facility form', () => {
 
         it('should be display error messages', () => {
             cy.get('[data-testid="mod-facility-section-nameEn"]').find('input').clear().type('立川中央病院').realPress('Tab')
-            cy.get('[data-testid="mod-facility-section-nameEn"]').find('p', { timeout: 10000 })
+            cy.get('[data-testid="mod-facility-section-nameEn"]').find('p')
                 .should('exist')
                 .contains('Invalid English Name')
 
             cy.get('[data-testid="mod-facility-section-nameJa"]')
                 .find('input').clear().type('Tachikawa Hospital').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-nameJa"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Japanese Name')
+                .find('p').should('exist').contains('Invalid Japanese Name')
 
             cy.get('[data-testid="mod-facility-section-phone"]').find('input').clear().type('Hello').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-phone"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Phone Number')
+                .find('p').should('exist').contains('Invalid Phone Number')
 
             cy.get('[data-testid="mod-facility-section-email"]').find('input').clear().type('example').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-email"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Email Address')
+                .find('p').should('exist').contains('Invalid Email Address')
 
             cy.get('[data-testid="mod-facility-section-website"]').find('input').clear().type('example').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-website"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Website URL')
+                .find('p').should('exist').contains('Invalid Website URL')
 
             cy.get('[data-testid="mod-facility-section-postalCode"]').find('input').clear().type('180-0').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-postalCode"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Postal Code')
+                .find('p').should('exist').contains('Invalid Postal Code')
 
             cy.get('[data-testid="mod-facility-section-cityEn"]').find('input').clear().type('渋谷区').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-cityEn"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid English City Name')
+                .find('p').should('exist').contains('Invalid English City Name')
 
             cy.get('[data-testid="mod-facility-section-addressLine1En"]').find('input').clear().type('道の駅').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-addressLine1En"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid English Address')
+                .find('p').should('exist').contains('Invalid English Address')
 
             cy.get('[data-testid="mod-facility-section-addressLine2En"]').find('input').clear().type('道の駅').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-addressLine2En"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid English Address')
+                .find('p').should('exist').contains('Invalid English Address')
 
             cy.get('[data-testid=mod-facility-section-cityJa]').find('input').clear().type('Shibuya').realPress('Tab')
             cy.get('[data-testid=mod-facility-section-cityJa]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Japanese City Name')
+                .find('p').should('exist').contains('Invalid Japanese City Name')
 
             cy.get('[data-testid="mod-facility-section-addressLine1Ja"]')
                 .find('input').clear().type('Peanutbutter street').realPress('Tab')
@@ -161,12 +161,12 @@ describe('Moderation edit facility form', () => {
             cy.get('[data-testid="mod-facility-section-mapLatitude"]')
                 .find('input').clear().type('Not Number Latitude').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-mapLatitude"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Latitude')
+                .find('p').should('exist').contains('Invalid Latitude')
 
             cy.get('[data-testid="mod-facility-section-mapLongitude"]')
                 .find('input').clear().type('Not Number Longitude').realPress('Tab')
             cy.get('[data-testid="mod-facility-section-mapLongitude"]')
-                .find('p', { timeout: 10000 }).should('exist').contains('Invalid Longitude')
+                .find('p').should('exist').contains('Invalid Longitude')
         })
     })
 })

--- a/test/cypress/e2e/submit.cy.ts
+++ b/test/cypress/e2e/submit.cy.ts
@@ -4,7 +4,7 @@ import enUS from '../../../i18n/locales/en.json'
 describe('Submit page', () => {
     context('Desktop resolution', () => {
         before(() => {
-            cy.visit('/submit', { timeout: 10000 })
+            cy.visit('/submit')
         })
 
         beforeEach(() => {
@@ -15,97 +15,97 @@ describe('Submit page', () => {
         })
 
         it('shows the desktop top nav', () => {
-            cy.get('[data-testid="landscape-searchbar"]', { timeout: 10000 }).should('exist').should('be.visible')
+            cy.get('[data-testid="landscape-searchbar"]').should('exist').should('be.visible')
         })
 
         it('does not show the hamburger component', () => {
-            cy.get('[data-testid="hamburger-menu-icon"]', { timeout: 10000 }).should('not.be.visible')
+            cy.get('[data-testid="hamburger-menu-icon"]').should('not.be.visible')
         })
 
         it('has a heading', () => {
-            cy.get('h1', { timeout: 10000 })
+            cy.get('h1')
                 .should('have.attr', 'data-testid', 'submit-heading').contains(enUS.submitPage.heading)
         })
 
         it('has a subheading', () => {
-            cy.get('[data-testid="submit-subheading"]', { timeout: 10000 }).contains(enUS.submitPage.subheading)
+            cy.get('[data-testid="submit-subheading"]').contains(enUS.submitPage.subheading)
         })
 
         it('has an input field for Google Maps', () => {
-            cy.get('[data-testid="submit-input-googlemaps"]', { timeout: 10000 }).should('have.match', 'input')
+            cy.get('[data-testid="submit-input-googlemaps"]').should('have.match', 'input')
         })
 
         it('has an input field for last name', () => {
-            cy.get('[data-testid="submit-input-lastname"]', { timeout: 10000 }).should('have.match', 'input')
+            cy.get('[data-testid="submit-input-lastname"]').should('have.match', 'input')
         })
 
         it('has an input field for first name', () => {
-            cy.get('[data-testid="submit-input-firstname"]', { timeout: 10000 }).should('have.match', 'input')
+            cy.get('[data-testid="submit-input-firstname"]').should('have.match', 'input')
         })
 
         it('has a select field for language 1', () => {
-            cy.get('[data-testid="submit-select-language1"]', { timeout: 10000 }).should('have.match', 'select')
+            cy.get('[data-testid="submit-select-language1"]').should('have.match', 'select')
         })
 
         it('has a select field for language 2', () => {
-            cy.get('[data-testid="submit-select-language2"]', { timeout: 10000 }).should('have.match', 'select')
+            cy.get('[data-testid="submit-select-language2"]').should('have.match', 'select')
         })
 
         it('has a textarea for notes', () => {
-            cy.get('[data-testid="submit-input-notes"]', { timeout: 10000 }).should('have.match', 'textarea')
+            cy.get('[data-testid="submit-input-notes"]').should('have.match', 'textarea')
         })
 
         it('has a submit button', () => {
-            cy.get('[data-testid="submit-submitbutton"]', { timeout: 10000 }).should('have.match', 'button')
+            cy.get('[data-testid="submit-submitbutton"]').should('have.match', 'button')
         })
 
         it('shows the footer without scrolling', () => {
-            cy.get('[data-testid="footer"]', { timeout: 10000 }).should('be.visible')
+            cy.get('[data-testid="footer"]').should('be.visible')
         })
 
         it('does not submit an incomplete form', () => {
-            cy.get('[data-testid="submit-submitbutton"]', { timeout: 10000 }).click()
-            cy.get('[data-testid="submit-completed"]', { timeout: 10000 }).should('not.be.visible')
+            cy.get('[data-testid="submit-submitbutton"]').click()
+            cy.get('[data-testid="submit-completed"]').should('not.be.visible')
         })
 
         it.skip('submits a complete form', () => {
-            cy.get('[data-testid="submit-input-googlemaps"]', { timeout: 10000 }).type('https://example.com')
-            cy.get('[data-testid="submit-input-lastname"]', { timeout: 10000 }).type('some last name')
-            cy.get('[data-testid="submit-select-language1"]', { timeout: 10000 }).select('日本語 (Japan)')
-            cy.get('[data-testid="submit-submitbutton"]', { timeout: 10000 }).click()
-            cy.get('[data-testid="submit-completed"]', { timeout: 10000 }).should('be.visible')
+            cy.get('[data-testid="submit-input-googlemaps"]').type('https://example.com')
+            cy.get('[data-testid="submit-input-lastname"]').type('some last name')
+            cy.get('[data-testid="submit-select-language1"]').select('日本語 (Japan)')
+            cy.get('[data-testid="submit-submitbutton"]').click()
+            cy.get('[data-testid="submit-completed"]').should('be.visible')
         })
 
         it('requires a URL starting with https://', () => {
-            cy.get('[data-testid="submit-input-googlemaps"]', { timeout: 10000 }).type('http://example.com').blur()
+            cy.get('[data-testid="submit-input-googlemaps"]').type('http://example.com').blur()
             cy.contains(enUS.submitPage.googleMapsValidation).should('be.visible')
         })
 
         it('requires a last name of 30 characters or less', () => {
-            const lastNameField = cy.get('[data-testid="submit-input-lastname"]', { timeout: 10000 })
-            const firstNameField = cy.get('[data-testid="submit-input-firstname"]', { timeout: 10000 })
+            const lastNameField = cy.get('[data-testid="submit-input-lastname"]')
+            const firstNameField = cy.get('[data-testid="submit-input-firstname"]')
 
             lastNameField.type(' ').blur()
-            cy.contains(enUS.submitPage.lastNameValidation, { timeout: 10000 }).should('be.visible')
+            cy.contains(enUS.submitPage.lastNameValidation).should('be.visible')
 
             lastNameField.clear().type('The Frog').blur()
             firstNameField.type('Kermy').blur()
-            cy.contains(enUS.submitPage.firstNameValidation, { timeout: 10000 }).should('not.be.visible')
+            cy.contains(enUS.submitPage.firstNameValidation).should('not.be.visible')
 
             lastNameField.clear().type('a'.repeat(80), { delay: 0 })
             lastNameField.invoke('val').should('have.length', 30)
         })
 
         it('requires Spoken Language 1 to be selected', () => {
-            cy.contains(enUS.submitPage.spokenLanguageValidation, { timeout: 10000 }).should('be.visible')
-            cy.get('[data-testid="submit-select-language1"]', { timeout: 10000 }).select('日本語 (Japan)')
-            cy.contains(enUS.submitPage.spokenLanguageValidation, { timeout: 10000 }).should('not.be.visible')
+            cy.contains(enUS.submitPage.spokenLanguageValidation).should('be.visible')
+            cy.get('[data-testid="submit-select-language1"]').select('日本語 (Japan)')
+            cy.contains(enUS.submitPage.spokenLanguageValidation).should('not.be.visible')
         })
     })
 
     context('Portrait mode', () => {
         before(() => {
-            cy.visit('/submit', { timeout: 10000 })
+            cy.visit('/submit')
         })
 
         beforeEach(() => {
@@ -113,15 +113,15 @@ describe('Submit page', () => {
         })
 
         it('shows the hamburger component', () => {
-            cy.get('[data-testid="hamburger-menu-icon"]', { timeout: 10000 }).should('exist').should('be.visible')
+            cy.get('[data-testid="hamburger-menu-icon"]').should('exist').should('be.visible')
         })
 
         it('does not show the landscape searchbar', () => {
-            cy.get('[data-testid="landscape-searchbar"]', { timeout: 10000 }).should('not.be.visible')
+            cy.get('[data-testid="landscape-searchbar"]').should('not.be.visible')
         })
 
         it('does not show the footer', () => {
-            cy.get('[data-testid="footer"]').should('exist', { timeout: 10000 }).should('not.be.visible')
+            cy.get('[data-testid="footer"]').should('exist').should('not.be.visible')
         })
     })
 })


### PR DESCRIPTION
Resolves #866 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Before we were not maintaining good code quality by repeating the same timeout all over the cypress tests to make sure that our elements would be found. Cypress provides this setting in the configuration files as seen in the [documentation](https://docs.cypress.io/app/references/configuration#Timeouts). So we set this in the configuration files and removed the unnecessary code.

## 🧪 Testing instructions
You can run the tests locally with `yarn cypress open`, but the tests in CI/CD reflect the changes that were done as it changed the global timeouts only