### PR TITLE
feat: implement autofill to edit existing facility section

### DIFF
--- a/components/ModEditFacilitySection.vue
+++ b/components/ModEditFacilitySection.vue
@@ -1,243 +1,247 @@
 <template>
-    <div
-        class="mod-facility-section"
-    >
-        <h1
-            class="mb-3.5 text-start text-primary-text text-3xl font-bold font-sans leading-normal"
+    <div v-if="isFacilitySectionInitialized">
+        <div
+            class="mod-facility-section"
         >
-            {{ $t('modFacilitySection.facilityHeading') }}
-        </h1>
-        <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-            {{ $t('modFacilitySection.contactInformation') }}
-        </span>
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.nameEn"
-            data-testid="mod-facility-section-nameEn"
-            :label="$t('modFacilitySection.labelFacilityNameEn')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityNameEn')"
-            :required="true"
-            :input-validation-check="validateNameEn"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityNameEn')"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.nameJa"
-            data-testid="mod-facility-section-nameJa"
-            :label="$t('modFacilitySection.labelFacilityNameJa')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityNameJa')"
-            :required="true"
-            :input-validation-check="validateNameJa"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityNameJa')"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.phone"
-            data-testid="mod-facility-section-phone"
-            :label="$t('modFacilitySection.labelFacilityPhoneNumber')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityPhoneNumber')"
-            :required="true"
-            :input-validation-check="validatePhoneNumber"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityPhoneNumber')"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.email"
-            data-testid="mod-facility-section-email"
-            :label="$t('modFacilitySection.labelFacilityEmail')"
-            type="email"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityEmail')"
-            :required="false"
-            :input-validation-check="validateEmail"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityEmail')"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.website"
-            data-testid="mod-facility-section-website"
-            :label="$t('modFacilitySection.labelFacilityWebsite')"
-            type="url"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityWebsite')"
-            :required="false"
-            :input-validation-check="validateWebsite"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityWebsite')"
-        />
-    </div>
-
-    <div
-        class="mod-facility-address-section"
-    >
-        <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-            {{ $t('modFacilitySection.addresses') }}
-        </span>
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.postalCode"
-            data-testid="mod-facility-section-postalCode"
-            :label="$t('modFacilitySection.labelFacilityPostalCode')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityPostalCode')"
-            :required="true"
-            :input-validation-check="validatePostalCode"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityPostalCode')"
-        />
-        <div class="flex flex-col mt-4">
-            <label
-                for="Prefecture Japan"
-                class="mb-2 text-primary-text text-sm font-bold font-sans"
+            <h1
+                class="mb-3.5 text-start text-primary-text text-3xl font-bold font-sans leading-normal"
             >
-                {{ $t('modFacilitySection.labelFacilityPrefectureEn') }}
-            </label>
-            <select
-                id="1"
-                v-model="facilityStore.facilitySectionFields.prefectureEn"
-                data-testid="mod-facility-section-prefectureEn"
-                name="Prefecture Japan"
-                class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
-                text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
-            >
-                <option
-                    v-for="(prefecture, index) in listPrefectureJapanEn"
-                    :key="index"
-                >
-                    {{ prefecture }}
-                </option>
-            </select>
+                {{ $t('modFacilitySection.facilityHeading') }}
+            </h1>
+            <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
+                {{ $t('modFacilitySection.contactInformation') }}
+            </span>
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.nameEn"
+                data-testid="mod-facility-section-nameEn"
+                :label="$t('modFacilitySection.labelFacilityNameEn')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityNameEn')"
+                :required="true"
+                :input-validation-check="validateNameEn"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityNameEn')"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.nameJa"
+                data-testid="mod-facility-section-nameJa"
+                :label="$t('modFacilitySection.labelFacilityNameJa')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityNameJa')"
+                :required="true"
+                :input-validation-check="validateNameJa"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityNameJa')"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.phone"
+                data-testid="mod-facility-section-phone"
+                :label="$t('modFacilitySection.labelFacilityPhoneNumber')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityPhoneNumber')"
+                :required="true"
+                :input-validation-check="validatePhoneNumber"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityPhoneNumber')"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.email"
+                data-testid="mod-facility-section-email"
+                :label="$t('modFacilitySection.labelFacilityEmail')"
+                type="email"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityEmail')"
+                :required="false"
+                :input-validation-check="validateEmail"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityEmail')"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.website"
+                data-testid="mod-facility-section-website"
+                :label="$t('modFacilitySection.labelFacilityWebsite')"
+                type="url"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityWebsite')"
+                :required="false"
+                :input-validation-check="validateWebsite"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityWebsite')"
+            />
         </div>
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.cityEn"
-            data-testid="mod-facility-section-cityEn"
-            :label="$t('modFacilitySection.labelFacilityCityEn')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityCityEn')"
-            :required="true"
-            :input-validation-check="validateCityEn"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityCityEn')"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.addressLine1En"
-            data-testid="mod-facility-section-addressLine1En"
-            :label="$t('modFacilitySection.labelFacilityAddressLine1En')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine1En')"
-            :required="true"
-            :input-validation-check="validateAddressLineEn"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine1En')"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.addressLine2En"
-            data-testid="mod-facility-section-addressLine2En"
-            :label="$t('modFacilitySection.labelFacilityAddressLine2En')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine2En')"
-            :required="true"
-            :input-validation-check="validateAddressLineEn"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine2En')"
-        />
-        <div class="flex flex-col mt-4">
-            <label
-                for="Prefecture Japan"
-                class="mb-2 text-primary-text text-sm font-bold font-sans"
-            >
-                {{ $t('modFacilitySection.labelFacilityPrefectureJa') }}
-            </label>
-            <select
-                id="1"
-                v-model="facilityStore.facilitySectionFields.prefectureJa"
-                data-testid="mod-facility-section-prefectureJa"
-                name="Prefecture Japan"
-                class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
-                text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
-            >
-                <option
-                    v-for="(prefecture, index) in listPrefectureJapanJa"
-                    :key="index"
-                >
-                    {{ prefecture }}
-                </option>
-            </select>
-        </div>
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.cityJa"
-            data-testid="mod-facility-section-cityJa"
-            :label="$t('modFacilitySection.labelFacilityCityJa')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityCityJa')"
-            :required="true"
-            :input-validation-check="validateCityJa"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityCityJa')"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.addressLine1Ja"
-            data-testid="mod-facility-section-addressLine1Ja"
-            :label="$t('modFacilitySection.labelFacilityAddressLine1Ja')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine1Ja')"
-            :required="true"
-            :input-validation-check="validateAddressLineJa"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine1Ja')"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.addressLine2Ja"
-            data-testid="mod-facility-section-addressLine2Ja"
-            :label="$t('modFacilitySection.labelFacilityAddressLine2Ja')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine2Ja')"
-            :required="true"
-            :input-validation-check="validateAddressLineJa"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine2Ja')"
-        />
-    </div>
 
-    <div
-        class="google-maps-section"
-    >
-        <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-            {{ $t('modFacilitySection.googleMapsInformation') }}
-        </span>
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.googlemapsURL"
-            data-testid="mod-facility-section-google-maps"
-            :label="$t('modFacilitySection.labelFacilityGoogleMapsUrl')"
-            type="url"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityGoogleMapsUrl')"
-            :required="true"
-            :input-validation-check="validateWebsite"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityGoogleMapsUrl')"
-            :autofill="facilityStore.facilitySectionFields.googlemapsURL"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.mapLatitude"
-            data-testid="mod-facility-section-mapLatitude"
-            :label="$t('modFacilitySection.labelFacilityMapLatitude')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityMapLatitude')"
-            :required="true"
-            :input-validation-check="validateFloat"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityMapLatitude')"
-        />
-        <ModInputField
-            v-model="facilityStore.facilitySectionFields.mapLongitude"
-            data-testid="mod-facility-section-mapLongitude"
-            :label="$t('modFacilitySection.labelFacilityMapLongitude')"
-            type="text"
-            :placeholder="$t('modFacilitySection.placeholderTextFacilityMapLongitude')"
-            :required="true"
-            :input-validation-check="validateFloat"
-            :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityMapLongitude')"
-        />
+        <div
+            class="mod-facility-address-section"
+        >
+            <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
+                {{ $t('modFacilitySection.addresses') }}
+            </span>
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.postalCode"
+                data-testid="mod-facility-section-postalCode"
+                :label="$t('modFacilitySection.labelFacilityPostalCode')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityPostalCode')"
+                :required="true"
+                :input-validation-check="validatePostalCode"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityPostalCode')"
+            />
+            <div class="flex flex-col mt-4">
+                <label
+                    for="Prefecture Japan"
+                    class="mb-2 text-primary-text text-sm font-bold font-sans"
+                >
+                    {{ $t('modFacilitySection.labelFacilityPrefectureEn') }}
+                </label>
+                <select
+                    id="1"
+                    v-model="facilityStore.facilitySectionFields.prefectureEn"
+                    data-testid="mod-facility-section-prefectureEn"
+                    name="Prefecture Japan"
+                    class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
+                text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
+                >
+                    <option
+                        v-for="(prefecture, index) in listPrefectureJapanEn"
+                        :key="index"
+                    >
+                        {{ prefecture }}
+                    </option>
+                </select>
+            </div>
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.cityEn"
+                data-testid="mod-facility-section-cityEn"
+                :label="$t('modFacilitySection.labelFacilityCityEn')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityCityEn')"
+                :required="true"
+                :input-validation-check="validateCityEn"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityCityEn')"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.addressLine1En"
+                data-testid="mod-facility-section-addressLine1En"
+                :label="$t('modFacilitySection.labelFacilityAddressLine1En')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine1En')"
+                :required="true"
+                :input-validation-check="validateAddressLineEn"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine1En')"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.addressLine2En"
+                data-testid="mod-facility-section-addressLine2En"
+                :label="$t('modFacilitySection.labelFacilityAddressLine2En')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine2En')"
+                :required="true"
+                :input-validation-check="validateAddressLineEn"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine2En')"
+            />
+            <div class="flex flex-col mt-4">
+                <label
+                    for="Prefecture Japan"
+                    class="mb-2 text-primary-text text-sm font-bold font-sans"
+                >
+                    {{ $t('modFacilitySection.labelFacilityPrefectureJa') }}
+                </label>
+                <select
+                    id="1"
+                    v-model="facilityStore.facilitySectionFields.prefectureJa"
+                    data-testid="mod-facility-section-prefectureJa"
+                    name="Prefecture Japan"
+                    class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
+                text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
+                >
+                    <option
+                        v-for="(prefecture, index) in listPrefectureJapanJa"
+                        :key="index"
+                    >
+                        {{ prefecture }}
+                    </option>
+                </select>
+            </div>
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.cityJa"
+                data-testid="mod-facility-section-cityJa"
+                :label="$t('modFacilitySection.labelFacilityCityJa')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityCityJa')"
+                :required="true"
+                :input-validation-check="validateCityJa"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityCityJa')"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.addressLine1Ja"
+                data-testid="mod-facility-section-addressLine1Ja"
+                :label="$t('modFacilitySection.labelFacilityAddressLine1Ja')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine1Ja')"
+                :required="true"
+                :input-validation-check="validateAddressLineJa"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine1Ja')"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.addressLine2Ja"
+                data-testid="mod-facility-section-addressLine2Ja"
+                :label="$t('modFacilitySection.labelFacilityAddressLine2Ja')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine2Ja')"
+                :required="true"
+                :input-validation-check="validateAddressLineJa"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine2Ja')"
+            />
+        </div>
+        <div
+            class="google-maps-section"
+        >
+            <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
+                {{ $t('modFacilitySection.googleMapsInformation') }}
+            </span>
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.googlemapsURL"
+                data-testid="mod-facility-section-google-maps"
+                :label="$t('modFacilitySection.labelFacilityGoogleMapsUrl')"
+                type="url"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityGoogleMapsUrl')"
+                :required="true"
+                :input-validation-check="validateWebsite"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityGoogleMapsUrl')"
+                :autofill="facilityStore.facilitySectionFields.googlemapsURL"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.mapLatitude"
+                data-testid="mod-facility-section-mapLatitude"
+                :label="$t('modFacilitySection.labelFacilityMapLatitude')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityMapLatitude')"
+                :required="true"
+                :input-validation-check="validateFloat"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityMapLatitude')"
+            />
+            <ModInputField
+                v-model="facilityStore.facilitySectionFields.mapLongitude"
+                data-testid="mod-facility-section-mapLongitude"
+                :label="$t('modFacilitySection.labelFacilityMapLongitude')"
+                type="text"
+                :placeholder="$t('modFacilitySection.placeholderTextFacilityMapLongitude')"
+                :required="true"
+                :input-validation-check="validateFloat"
+                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityMapLongitude')"
+            />
+        </div>
+        <ModHealthcareProfessionalSearchbar data-testid="mod-facility-section-doctor-search" />
+        <button
+            v-show="screenStore.activeScreen === ModerationScreen.EditFacility"
+            type="submit"
+            class="bg-currentColor text-white font-bold py-2 px-4 my-2 rounded w-56"
+        >
+            {{ $t('modFacilitySection.updateButtonText') }}
+        </button>
     </div>
-    <ModHealthcareProfessionalSearchbar data-testid="mod-facility-section-doctor-search" />
-    <button
-        v-show="screenStore.activeScreen === ModerationScreen.EditFacility"
-        type="submit"
-        class="bg-currentColor text-white font-bold py-2 px-4 my-2 rounded w-56"
-    >
-        {{ $t('modFacilitySection.updateButtonText') }}
-    </button>
 </template>
 
 <script lang="ts" setup>
-import { type Ref, ref } from 'vue'
+import { type Ref, ref, onBeforeMount, nextTick } from 'vue'
+import { type ToastInterface, useToast } from 'vue-toastification'
+import { useRoute } from 'vue-router'
 import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
 import { useFacilitiesStore } from '~/stores/facilitiesStore'
+import { useI18n } from '#imports'
 import { validateAddressLineEn,
     validateAddressLineJa,
     validateNameEn,
@@ -250,8 +254,15 @@ import { validateAddressLineEn,
     validateWebsite,
     validateCityJa } from '~/utils/formValidations'
 
+// Initialize the variable that will be used to mount the toast library
+let toast: ToastInterface
+
+const { t } = useI18n()
+
 const screenStore = useModerationScreenStore()
 const facilityStore = useFacilitiesStore()
+
+const isFacilitySectionInitialized: Ref<boolean> = ref(false)
 
 const listPrefectureJapanEn: Ref<string[]> = ref([
     'Hokkaido', 'Aomori', 'Iwate', 'Miyagi', 'Akita',
@@ -266,4 +277,45 @@ const listPrefectureJapanJa: Ref<string[]> = ref([
     '石川県', '福井県', '山梨県', '長野県', '岐阜県', '静岡県', '愛知県', '三重県', '滋賀県', '京都府', '大阪府',
     '兵庫県', '奈良県', '和歌山県', '鳥取県', '島根県', '岡山県', '広島県', '山口県', '徳島県', '香川県', '愛媛県',
     '高知県', '福岡県', '佐賀県', '長崎県', '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県'])
+
+onBeforeMount(async () => {
+    isFacilitySectionInitialized.value = false
+
+    const route = useRoute()
+
+    /**
+    Set the variable to useToast when the before the component mounts
+    since vue-taostification is only available on the client.
+    If not done this way the build fails
+     */
+    toast = useToast()
+
+    // Wait for the route to be fully resolved
+    await nextTick()
+    // Ensure the route param `id` is available before proceeding
+    const id = route.params.id
+    if (!id) {
+        console.error(t('modFacilitySection.errorMessageFacilityId'))
+        toast.error('modFacilitySection.errorMessageFacilityId')
+        return
+    }
+
+    if (!facilityStore.facilityData.length) {
+        await facilityStore.getFacilities()
+    }
+
+    facilityStore.selectedFacilityId = id as string
+
+    // Set the active screen and ensure the UI state is consistent
+    screenStore.setActiveScreen(ModerationScreen.EditFacility)
+
+    facilityStore.setSelectedFacilityData(facilityStore.selectedFacilityId)
+
+    facilityStore.initializeFacilitySectionValues(facilityStore.selectedFacilityData)
+
+    isFacilitySectionInitialized.value = true
+
+    // Ensure UI updates are reflected
+    await nextTick()
+})
 </script>

--- a/components/ModSubmissionListContainer.vue
+++ b/components/ModSubmissionListContainer.vue
@@ -57,7 +57,6 @@
                 <div
                     :data-testid="`mod-facility-list-item-${index + 1}`"
                     class="grid grid-cols-subgrid col-span-4 bg-tertiary-bg cursor-pointer hover:bg-primary"
-                    @click="handleClickToFacilityForm(facility.id)"
                 >
                     <NuxtLink
                         :to="`/moderation/edit-facility/${facility.id}`"
@@ -119,6 +118,7 @@ import { useFacilitiesStore } from '~/stores/facilitiesStore'
 const modSubmissionsListStore = useModerationSubmissionsStore()
 const healthcareProfessionalsStore = useHealthcareProfessionalsStore()
 const facilitiesStore = useFacilitiesStore()
+const moderationScreenStore = useModerationScreenStore()
 
 onMounted(async () => {
     await modSubmissionsListStore.getSubmissions()
@@ -141,17 +141,12 @@ const submissionListItemTableColumns = computed(() => {
 })
 
 const handleClickToSubmissionForm = (id: string) => {
-    useModerationScreenStore().setActiveScreen(ModerationScreen.EditSubmission)
     modSubmissionsListStore.selectedSubmissionId = id
+    moderationScreenStore.setActiveScreen(ModerationScreen.EditSubmission)
 }
 
 const handleClickToHealthcareProfessionalForm = (id: string) => {
-    useModerationScreenStore().setActiveScreen(ModerationScreen.EditHealthcareProfessional)
-    modSubmissionsListStore.selectedHealthcareProfessionalId = id
-}
-
-const handleClickToFacilityForm = (id: string) => {
-    useModerationScreenStore().setActiveScreen(ModerationScreen.EditFacility)
-    modSubmissionsListStore.selectedFacilityId = id
+    healthcareProfessionalsStore.selectedHealthcareProfessionalId = id
+    moderationScreenStore.setActiveScreen(ModerationScreen.EditHealthcareProfessional)
 }
 </script>

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -312,7 +312,8 @@
     "placeholderTextFacilityPhoneNumber": "e.g. 08xxxxxxxxx",
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
-    "updateButtonText": "Update"
+    "updateButtonText": "Update",
+    "placeholderTextFacilityAddressLine1En": "Street address"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -313,7 +313,8 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update",
-    "placeholderTextFacilityAddressLine1En": "Street address"
+    "placeholderTextFacilityAddressLine1En": "Street address",
+    "errorMessageFacilityId": "Facility Id was not found"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -312,7 +312,8 @@
     "placeholderTextFacilityPhoneNumber": "e.g. 08xxxxxxxxx",
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
-    "updateButtonText": "Update"
+    "updateButtonText": "Update",
+    "placeholderTextFacilityAddressLine1En": "Street address"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -313,7 +313,8 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update",
-    "placeholderTextFacilityAddressLine1En": "Street address"
+    "placeholderTextFacilityAddressLine1En": "Street address",
+    "errorMessageFacilityId": "Facility Id was not found"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -204,6 +204,7 @@
         "labelFacilityGoogleMapsUrl": "Google maps URL",
         "labelFacilityMapLatitude": "Map latitude",
         "labelFacilityMapLongitude": "Map longitude",
+        "placeholderTextFacilityAddressLine1En": "Street address",
         "placeholderTextFacilityAddressLine2En": "Apartment, building, room...",
         "placeholderTextFacilityAddressLine1Ja": "Street address",
         "placeholderTextFacilityAddressLine2Ja": "Apartment, building, room...",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -170,6 +170,7 @@
     "modFacilitySection": {
         "addresses": "Addresses",  
         "contactInformation": "Contact Information",
+        "errorMessageFacilityId": "Facility Id was not found",
         "facilityHeading": "Facility Information",
         "googleMapsInformation": "Google maps information",
         "inputErrorMessageFacilityAddressLine1Ja": "Invalid Japanese Address",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -316,7 +316,8 @@
     "placeholderTextFacilityPhoneNumber": "e.g. 08xxxxxxxxx",
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
-    "updateButtonText": "Update"
+    "updateButtonText": "Update",
+    "placeholderTextFacilityAddressLine1En": "Street address"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -317,7 +317,8 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update",
-    "placeholderTextFacilityAddressLine1En": "Street address"
+    "placeholderTextFacilityAddressLine1En": "Street address",
+    "errorMessageFacilityId": "Facility Id was not found"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -312,7 +312,8 @@
     "placeholderTextFacilityPhoneNumber": "e.g. 08xxxxxxxxx",
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
-    "updateButtonText": "Update"
+    "updateButtonText": "Update",
+    "placeholderTextFacilityAddressLine1En": "Street address"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -313,7 +313,8 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update",
-    "placeholderTextFacilityAddressLine1En": "Street address"
+    "placeholderTextFacilityAddressLine1En": "Street address",
+    "errorMessageFacilityId": "Facility Id was not found"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -312,7 +312,8 @@
     "placeholderTextFacilityPhoneNumber": "e.g. 08xxxxxxxxx",
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
-    "updateButtonText": "Update"
+    "updateButtonText": "Update",
+    "placeholderTextFacilityAddressLine1En": "Street address"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -313,7 +313,8 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update",
-    "placeholderTextFacilityAddressLine1En": "Street address"
+    "placeholderTextFacilityAddressLine1En": "Street address",
+    "errorMessageFacilityId": "Facility Id was not found"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -312,7 +312,8 @@
     "placeholderTextFacilityPhoneNumber": "e.g. 08xxxxxxxxx",
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
-    "updateButtonText": "Update"
+    "updateButtonText": "Update",
+    "placeholderTextFacilityAddressLine1En": "Street address"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -313,7 +313,8 @@
     "placeholderTextFacilityPostalCode": "e.g. 186-0000",
     "placeholderTextFacilityWebsite": "e.g. http://www.example.com/",
     "updateButtonText": "Update",
-    "placeholderTextFacilityAddressLine1En": "Street address"
+    "placeholderTextFacilityAddressLine1En": "Street address",
+    "errorMessageFacilityId": "Facility Id was not found"
   },
   "modEditFacilityOrHPTopbar": {
     "updateAndExit": "Update & Exit",

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -9,6 +9,7 @@ export const useFacilitiesStore = defineStore(
     () => {
         const facilityData: Ref<Facility[]> = ref([])
         const selectedFacilityId: Ref<string> = ref('')
+        const selectedFacilityData: Ref<Facility | undefined> = ref()
         const facilitySectionFields = {
             // contactFields
             nameEn: ref('') as Ref<string>,
@@ -29,8 +30,37 @@ export const useFacilitiesStore = defineStore(
             // googleMapsFields
             googlemapsURL: ref('') as Ref<string>,
             mapLatitude: ref('') as Ref<string>,
-            mapLongitude: ref('') as Ref<string>
+            mapLongitude: ref('') as Ref<string>,
+            healthcareProfessionalIds: ref([]) as Ref<string[]>
         } as { [key: string]: Ref }
+
+        function setSelectedFacilityData(facilityId: string) {
+            selectedFacilityData.value = facilityData.value
+                .find((facility: Facility) => facility.id === facilityId)
+        }
+
+        function initializeFacilitySectionValues(facilityData: Facility | undefined) {
+            if (!facilityData) return
+
+            facilitySectionFields.nameEn.value = facilityData.nameEn
+            facilitySectionFields.nameJa.value = facilityData.nameJa
+            facilitySectionFields.phone.value = facilityData?.contact?.phone
+            facilitySectionFields.email.value = facilityData?.contact?.email
+            facilitySectionFields.website.value = facilityData?.contact?.website
+            facilitySectionFields.postalCode.value = facilityData.contact?.address.postalCode
+            facilitySectionFields.prefectureEn.value = facilityData?.contact?.address?.prefectureEn
+            facilitySectionFields.cityEn.value = facilityData?.contact?.address?.cityEn
+            facilitySectionFields.addressLine1En.value = facilityData?.contact?.address?.addressLine1En
+            facilitySectionFields.addressLine2En.value = facilityData?.contact?.address?.addressLine2En
+            facilitySectionFields.prefectureJa.value = facilityData?.contact?.address?.prefectureJa
+            facilitySectionFields.cityJa.value = facilityData?.contact?.address?.cityJa
+            facilitySectionFields.addressLine1Ja.value = facilityData?.contact?.address?.addressLine1Ja
+            facilitySectionFields.addressLine2Ja.value = facilityData?.contact?.address?.addressLine2Ja
+            facilitySectionFields.googlemapsURL.value = facilityData?.contact?.googleMapsUrl
+            facilitySectionFields.healthcareProfessionalIds.value = facilityData.healthcareProfessionalIds
+            facilitySectionFields.mapLatitude.value = facilityData.mapLatitude.toString()
+            facilitySectionFields.mapLongitude.value = facilityData.mapLongitude.toString()
+        }
 
         async function getFacilities() {
             const facilityResults = await queryFacilities()
@@ -67,7 +97,10 @@ export const useFacilitiesStore = defineStore(
             updateFacility,
             facilitySectionFields,
             selectedFacilityId,
-            deleteFacility
+            deleteFacility,
+            selectedFacilityData,
+            setSelectedFacilityData,
+            initializeFacilitySectionValues
         }
     }
 )
@@ -82,7 +115,7 @@ async function queryFacilities() {
         const response = await gqlClient.request<{ facilities: Facility[] }>(getAllFacilitiesForModeration, searchFacilitiesData)
         return response?.facilities ?? []
     } catch (error) {
-        console.log(`Error querying the facilities: ${JSON.stringify(error)}`)
+        console.error(`Error querying the facilities: ${JSON.stringify(error)}`)
         return []
     }
 }

--- a/test/cypress/e2e/moderationEditFacility.cy.ts
+++ b/test/cypress/e2e/moderationEditFacility.cy.ts
@@ -1,5 +1,6 @@
 import 'cypress-real-events'
 import 'cypress-plugin-tab'
+import facilityData from '../../fake_data/moderation_dashboard/fakeModFacilityData.json'
 import enUS from '../../../i18n/locales/en.json'
 
 const FAKE_FACILITY_RESPONSE_PATH = 'moderation_dashboard/fakeModFacilityData.json'
@@ -97,6 +98,39 @@ describe('Moderation edit facility form', () => {
             cy.get('[data-testid="mod-facility-section-prefectureJa"]').should('exist')
         })
 
+        it('should autofill all the form fields for an existing facility', () => {
+            cy.get('[data-testid="mod-facility-section-nameEn"]')
+                .find('input').should('have.value', facilityData.data.facilities[0].nameEn)
+            cy.get('[data-testid="mod-facility-section-nameJa"]')
+                .find('input').should('have.value', facilityData.data.facilities[0].nameJa)
+            cy.get('[data-testid="mod-facility-section-phone"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.phone)
+            cy.get('[data-testid="mod-facility-section-email"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.email)
+            cy.get('[data-testid="mod-facility-section-website"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.website)
+            cy.get('[data-testid="mod-facility-section-postalCode"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.address.postalCode)
+            cy.get('[data-testid="mod-facility-section-cityEn"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.address.cityEn)
+            cy.get('[data-testid="mod-facility-section-addressLine1En"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.address.addressLine1En)
+            cy.get('[data-testid="mod-facility-section-addressLine2En"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.address.addressLine2En)
+            cy.get('[data-testid="mod-facility-section-cityJa"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.address.cityJa)
+            cy.get('[data-testid="mod-facility-section-addressLine1Ja"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.address.addressLine1Ja)
+            cy.get('[data-testid="mod-facility-section-addressLine2Ja"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.address.addressLine2Ja)
+            cy.get('[data-testid="mod-facility-section-google-maps"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].contact.googleMapsUrl)
+            cy.get('[data-testid="mod-facility-section-mapLatitude"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].mapLatitude)
+            cy.get('[data-testid="mod-facility-section-mapLongitude"]').find('input')
+                .should('have.value', facilityData.data.facilities[0].mapLongitude)
+        })
+
         it('should be able to type in all input fields', () => {
             cy.get('[data-testid="mod-facility-section-nameEn"]').find('input').type('Hospital')
             cy.get('[data-testid="mod-facility-section-nameJa"]').find('input').type('立川中央病院')
@@ -116,8 +150,6 @@ describe('Moderation edit facility form', () => {
                 .type('www.google.com/maps/place/82+Yamatech%C5%8D,+Naka+Ward,+Yokohama,+Kanagawa+231-0862,')
                 .type('+Japan/@35.437123,139.651471,16z/data=!4m6!3m5!1s0x60185d201648e7c1:0x8f37d37bb381e29!8m2!3d35')
                 .type('.4371228!4d139.6514712!16s%2Fg%2F11clpxxvx5?hl=en-US&entry=ttu')
-            cy.get('[data-testid="mod-facility-section-mapLatitude"]').find('input').type('35.437123')
-            cy.get('[data-testid="mod-facility-section-mapLongitude"]').find('input').type('139.651471')
             cy.get('[data-testid="mod-facility-section-doctor-search"]').find('input').type('Aya Yumino')
         })
 

--- a/test/fake_data/moderation_dashboard/fakeModFacilityData.json
+++ b/test/fake_data/moderation_dashboard/fakeModFacilityData.json
@@ -2,21 +2,23 @@
     "data": {
       "facilities": [
         {
-          "address": {
-            "addressLine1En": "1649 Octavia Parkways",
-            "addressLine1Ja": "3581 蒼空Route",
-            "addressLine2En": "Suite 869",
-            "addressLine2Ja": "Apt. 110",
-            "cityEn": "East Linnea",
-            "cityJa": "南菜摘市",
-            "postalCode": "27629",
-            "prefectureEn": "Kentucky",
-            "prefectureJa": "秋田県"
-          },
-          "email": "KarelleKoss22@hotmail.com",
-          "googleMapsUrl": "https://usable-flung.net",
-          "phone": "920.452.4490 x40878",
-          "website": "https://amused-appetite.com",
+          "contact": {
+              "address": {
+                "addressLine1En": "1649 Octavia Parkways",
+                "addressLine1Ja": "3581 蒼空Route",
+                "addressLine2En": "Suite 869",
+                "addressLine2Ja": "Apt. 110",
+                "cityEn": "East Linnea",
+                "cityJa": "南菜摘市",
+                "postalCode": "27629",
+                "prefectureEn": "Akita",
+                "prefectureJa": "秋田県"
+              },
+              "email": "KarelleKoss22@hotmail.com",
+              "googleMapsUrl": "https://usable-flung.net",
+              "phone": "920.452.4490 x40878",
+              "website": "https://amused-appetite.com"
+        },
           "createdDate": "2024-10-18T05:45:37.282Z",
           "healthcareProfessionalIds": [
             "FUVTHAW5azp3q29J6H2X",


### PR DESCRIPTION
Resolves #863 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Before we were not autofilling the form for the facility based on the selected Facility from the list. Now we can autofill the form when we go to this route.

## 🧪 Testing instructions
Cypress tests were used to make sure the form was filled with our fake data. You can run by going to this branch and running:
`yarn cypress open` and navigate to the tests for `test/cypress/e2e/moderationEditFacility.cy.ts`

## 📸 Screenshots

-   ### Before
![image](https://github.com/user-attachments/assets/86f5ded0-58f3-4017-b2c4-e9b8ac9c0324)


-   ### After

https://github.com/user-attachments/assets/ed0300ec-c18d-4dae-94d4-e682f0ec2d86



