### PR TITLE
chore: fix typo in ModerationScreen enum

### DIFF
--- a/stores/moderationScreenStore.ts
+++ b/stores/moderationScreenStore.ts
@@ -5,7 +5,7 @@ export enum ModerationScreen {
     Dashboard = 'DASHBOARD',
     EditSubmission = 'EDIT_SUBMISSION',
     EditHealthcareProfessional = 'EDIT_HEALTHCARE_PROFESSIONAL',
-    EditFacility = 'EDIT_FACILITIY'
+    EditFacility = 'EDIT_FACILITY'
 }
 
 export enum ModSubmissionLeftNavbarSectionIDs {


### PR DESCRIPTION
## 🔧 What changed
Tiny change to fix spelling mistake.

