### PR TITLE
fix: change locales to send code to backend

### DIFF
--- a/components/ModEditSubmissionTopbar.vue
+++ b/components/ModEditSubmissionTopbar.vue
@@ -2,6 +2,7 @@
     <div class="flex flex-row justify-between w-full">
         <div>
             <button
+                type="button"
                 data-testid="mod-edit-submission-copy-submission-id"
                 class="flex flex-row w-90 bg-neutral p-2 m-2 border-2 border-slate-400 rounded hover"
                 @click="copySubmissionId"

--- a/stores/localeStore.ts
+++ b/stores/localeStore.ts
@@ -9,11 +9,16 @@ export type LocaleDisplay = {
 }
 
 export const useLocaleStore = defineStore('locale', () => {
-    const enUsLocale = localeDisplayOptions.find(o => o.code == Locale.EnUs) as LocaleDisplay
+    const enUsLocale = localeDisplayOptions.find(o => o.code === Locale.EnUs) as LocaleDisplay
     const locale: Ref<LocaleDisplay> = ref(enUsLocale)
 
     function setLocale(selectedLocale: Locale) {
-        locale.value = localeDisplayOptions.find(l => l.code == selectedLocale) as LocaleDisplay
+        locale.value = localeDisplayOptions.find(l => l.code === selectedLocale) as LocaleDisplay
+    }
+
+    function formatLanguageCodeToSimpleText(selectedLocale: string) {
+        const language = localeDisplayOptions.find(locale => locale.code === selectedLocale)
+        return language?.simpleText || 'Language not found'
     }
 
     function formatLanguages(
@@ -25,7 +30,7 @@ export const useLocaleStore = defineStore('locale', () => {
                 ?? []
     }
 
-    return { locale, localeDisplayOptions, mvpLocaleDisplayOptions, setLocale, formatLanguages }
+    return { locale, localeDisplayOptions, mvpLocaleDisplayOptions, setLocale, formatLanguages, formatLanguageCodeToSimpleText }
 })
 
 export const localeDisplayOptions = [


### PR DESCRIPTION
Resolves #891 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
There was a bug that when the languages were formatted in an array there was no code, and the backend expects a code. So this has a function that fixes it so we display languages from code to text, and set the option value to the code itself. This allows us to send the correct information to the backend.

1. Fix the display to show text but set `option` value to the code
2. Fix the locales to be set initially to the values of spoken languages submitted
3. Change type button on the copy button to prevent default browser behavior
4. Add function to format a singular language code to simple text in order to display the healthcare professional spoken languages that are submitted
5. Update UI based on function

## 🧪 Testing instructions
Currently while intercept and testing is being built. You need to check out to this branch and run the server by running
```
npm run dev:startlocaldb
npm run dev
```

And then on the frontend run
```
yarn dev:localserver
```

Check the Submission form and try to submit a completed form.
## 📸 Screenshots

-   ### Before
- 
![image](https://github.com/user-attachments/assets/45d08f11-bf89-46ec-870d-163d8c363cd2)


-   ### After
![image](https://github.com/user-attachments/assets/c0b51aa5-76d8-480d-a845-2b35913aa033)
![image](https://github.com/user-attachments/assets/866896fa-e110-4f17-8248-6b23b80dde4d)
![image](https://github.com/user-attachments/assets/45ae4620-14c6-4748-bac0-a2caf4d24eef)
![image](https://github.com/user-attachments/assets/ef2e8acb-2919-40f7-9a26-55a297f42c10)

https://github.com/user-attachments/assets/20333180-3bac-4e20-9b9d-9980bce99728




