### PR TITLE
fix(lang): update language dropdown options for search and i18n

### DIFF
--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -115,21 +115,28 @@ const specialtiesStore = useSpecialtiesStore()
 
 await locationsStore.fetchLocations()
 
-const languageOptions = [{
-    code: '',
-    simpleText: '----Any----',
-    displayText: '----Any----'
-}, ...localeStore.mvpLocaleDisplayOptions]
+const languageOptions = localeStore.localeDisplayOptions
+const languageOptionsWithPlaceHolder = setSearchBarLanguageDropdownOptions()
 
 const locationDropdownOptions: Ref<string[]> = ref(locationsStore.citiesDisplayOptions)
 const specialtyDropdownOptions: Ref<SpecialtyDisplayOption[]> = ref(specialtiesStore.specialtyDisplayOptions)
-const languageDropdownOptions: Ref<LocaleDisplay[]> = ref(languageOptions)
+const languageDropdownOptions: Ref<LocaleDisplay[]> = ref(languageOptionsWithPlaceHolder)
 
 const selectedSpecialty: Ref<Specialty | string> = ref('')
 const selectedLocation: Ref<string> = ref('')
 const selectedLanguage: Ref<Locale | string> = ref('')
 
 const placeHolderTextDisplay = '----Any----'
+
+function setSearchBarLanguageDropdownOptions() {
+    // This will remove any codes code that is falsy
+    const localeOptionsWithLocaleCodes = languageOptions.filter(locale => locale.code)
+    // This will add the placeholder text
+    localeOptionsWithLocaleCodes
+        .unshift({ code: '', simpleText: placeHolderTextDisplay, displayText: placeHolderTextDisplay })
+
+    return localeOptionsWithLocaleCodes
+}
 
 interface CityDisplayItems {
     [cityName: string]: {

--- a/stores/localeStore.ts
+++ b/stores/localeStore.ts
@@ -95,7 +95,6 @@ export const localeDisplayOptions = [
 export const mvpLocaleDisplayOptions = [
     { code: Locale.EnUs, simpleText: 'English', displayText: 'English (US)' },
     { code: Locale.JaJp, simpleText: '日本語', displayText: '日本語 (Japan)' },
-    { code: Locale.SwKe, simpleText: 'Swahili', displayText: 'Swahili (Kenya)' },
     { code: Locale.PtBr, simpleText: 'Português', displayText: 'Português (Brasil)' },
     { code: Locale.RuRu, simpleText: 'русский', displayText: 'Russian (Russia)' },
     { code: Locale.DeDe, simpleText: 'Deutsch', displayText: 'Deutsch(Deutschland)' },


### PR DESCRIPTION
Resolves #900 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
1. Swahili was removed from the options of what we have translated on our site. Even though we have a doctor that speaks Swahili. There is no translation of Swahili.
2. The search bar languages were changed to all the ones we include as `localeDisplayOptions` since even though we might not have the site translated yet within the language. We might have a doctor who speaks that language. As we do for Tagalog.

## 📸 Screenshots

-   ### Before
![image](https://github.com/user-attachments/assets/a2aa0243-56f4-4e77-995a-ad2ab48dc7f8)
![image](https://github.com/user-attachments/assets/934ed436-a088-44bc-b1a9-f041715031f4)

-   ### After
![image](https://github.com/user-attachments/assets/6fb5ace4-7cff-464b-84d4-db7fe00077fc)
![image](https://github.com/user-attachments/assets/9528e074-c393-4d01-91f8-1f96b1680764)


