### PR TITLE
fix: remove bubbling from synthetic event

### DIFF
--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -863,7 +863,7 @@ async function submitCompletedForm(e: Event) {
     }
 }
 
-const syntheticEvent = new Event('submit', { bubbles: true, cancelable: true })
+const syntheticEvent = new Event('submit', { bubbles: false, cancelable: true })
 
 watch(moderationSubmissionStore, newValue => {
     //saves the submission by updating it and then going to the main


### PR DESCRIPTION
Resolves #912
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
- The synthetic event was bubbling up causing the multiselect fields to be deselected. This made the frontend validation fail when the submission had been updated correctly.

## 🧪 Testing instructions
Tests are currently being written #538 


