### PR TITLE
feat: implement delete facility functionality to moderation panel

### DIFF
--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -348,7 +348,10 @@
     "delete": "Delete",
     "copyFailure": "Failed to copy ID",
     "update": "Update",
-    "facilityUpdatedSuccessfully": "Facility updated successfully"
+    "facilityUpdatedSuccessfully": "Facility updated successfully",
+    "deleteButtonText": "DELETE FOREVER",
+    "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
+    "facilityDeletedSuccessfully": "Facility deleted successfully"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -348,7 +348,10 @@
     "delete": "Delete",
     "copyFailure": "Failed to copy ID",
     "update": "Update",
-    "facilityUpdatedSuccessfully": "Facility updated successfully"
+    "facilityUpdatedSuccessfully": "Facility updated successfully",
+    "deleteButtonText": "DELETE FOREVER",
+    "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
+    "facilityDeletedSuccessfully": "Facility deleted successfully"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -154,8 +154,11 @@
     "modEditFacilityOrHPTopbar": {
         "copyFailure": "Failed to copy ID",
         "delete": "Delete",
+        "deleteButtonText": "DELETE FOREVER",
+        "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
         "update": "Update",
         "updateAndExit": "Update & Exit",
+        "facilityDeletedSuccessfully": "Facility deleted successfully",
         "facilityUpdatedSuccessfully": "Facility updated successfully"
     },
     "modEditSubmissionTopNav": {

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -331,7 +331,10 @@
     "delete": "Delete",
     "copyFailure": "Failed to copy ID",
     "update": "Update",
-    "facilityUpdatedSuccessfully": "Facility updated successfully"
+    "facilityUpdatedSuccessfully": "Facility updated successfully",
+    "deleteButtonText": "DELETE FOREVER",
+    "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
+    "facilityDeletedSuccessfully": "Facility deleted successfully"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -349,7 +349,10 @@
     "delete": "Delete",
     "copyFailure": "Failed to copy ID",
     "update": "Update",
-    "facilityUpdatedSuccessfully": "Facility updated successfully"
+    "facilityUpdatedSuccessfully": "Facility updated successfully",
+    "deleteButtonText": "DELETE FOREVER",
+    "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
+    "facilityDeletedSuccessfully": "Facility deleted successfully"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -348,7 +348,10 @@
     "delete": "Delete",
     "copyFailure": "Failed to copy ID",
     "update": "Update",
-    "facilityUpdatedSuccessfully": "Facility updated successfully"
+    "facilityUpdatedSuccessfully": "Facility updated successfully",
+    "deleteButtonText": "DELETE FOREVER",
+    "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
+    "facilityDeletedSuccessfully": "Facility deleted successfully"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -348,7 +348,10 @@
     "delete": "Delete",
     "copyFailure": "Failed to copy ID",
     "update": "Update",
-    "facilityUpdatedSuccessfully": "Facility updated successfully"
+    "facilityUpdatedSuccessfully": "Facility updated successfully",
+    "deleteButtonText": "DELETE FOREVER",
+    "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
+    "facilityDeletedSuccessfully": "Facility deleted successfully"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -150,7 +150,10 @@
     "delete": "Burahin",
     "updateAndExit": "I-update at I-Exit",
     "update": "Update",
-    "facilityUpdatedSuccessfully": "Facility updated successfully"
+    "facilityUpdatedSuccessfully": "Facility updated successfully",
+    "deleteButtonText": "DELETE FOREVER",
+    "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
+    "facilityDeletedSuccessfully": "Facility deleted successfully"
   },
   "modEditSubmissionTopNav": {
     "saveAndExit": "I-Save at I-Exit",


### PR DESCRIPTION
Resolves #916 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
There was no way for an admin to delete a facility

## 🧪 Testing instructions
Tests are being added in ticket #538 currently
We are discussing the best way to have a testing environment going forward.


