### PR TITLE
fix: change watch to selected submission Id to avoid unwanted UI updates

### DIFF
--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -872,9 +872,9 @@ watch(moderationSubmissionStore, newValue => {
     }
 })
 
-watch(moderationSubmissionStore, newValue => {
-    moderationSubmissionStore.filterSelectedSubmission(newValue.selectedSubmissionId)
-    initializeSubmissionFormValues(newValue.selectedSubmissionData)
+watch(() => moderationSubmissionStore.selectedSubmissionId, newValue => {
+    moderationSubmissionStore.filterSelectedSubmission(newValue)
+    initializeSubmissionFormValues(moderationSubmissionStore.selectedSubmissionData)
 })
 
 onMounted(() => {


### PR DESCRIPTION
Resolves #921 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
The watch is changed to watch the singular value of selectedSubmissionId instead of the whole store. This then updates the form with the new values if this changes due to someone being sent to this form with a link instead of anything in the store changing. If it watches the whole store it can have unreliable ui updates that prevent the acceptance of a submission after an update to that submission

## 🧪 Testing instructions
This bug was found in the creation and implementation of #538. 

