### PR TITLE
fix: implemented changes to display Search bar only on the index page

### DIFF
--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="flex flex-0 max-w-4xl">
         <div
-            v-show="route.path === '/'"
+            v-show="isHomepage"
             id="search-fields"
             class="grid-cols-3 mx-4"
         >
@@ -78,7 +78,7 @@
             </div>
         </div>
         <div
-            v-show="route.path === '/'"
+            v-show="isHomepage"
             id="search-button"
             class="flex items-center"
         >
@@ -102,7 +102,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watchEffect, type Ref } from 'vue'
+import { computed, ref, watchEffect, type Ref } from 'vue'
 import { useRoute } from 'vue-router'
 import SVGSearchIcon from '~/assets/icons/search-icon.svg'
 import { useSearchResultsStore } from '~/stores/searchResultsStore.js'
@@ -116,6 +116,7 @@ const locationsStore = useLocationsStore()
 const searchResultsStore = useSearchResultsStore()
 const specialtiesStore = useSpecialtiesStore()
 const route = useRoute()
+const isHomepage = computed(() => route.path === '/')
 
 await locationsStore.fetchLocations()
 

--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -1,9 +1,9 @@
 <template>
     <div class="flex flex-0 max-w-4xl">
         <div
+            v-show="route.path === '/'"
             id="search-fields"
             class="grid-cols-3 mx-4"
-            :class="{ hidden: route.path !== '/' }"
         >
             <div class="search-specialty col-span-1 inline-block w-1/3 py-4">
                 <select
@@ -78,9 +78,9 @@
             </div>
         </div>
         <div
+            v-show="route.path === '/'"
             id="search-button"
             class="flex items-center"
-            :class="{ hidden: route.path !== '/' }"
         >
             <button
                 id="searchButton"

--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -1,7 +1,6 @@
 <template>
     <div class="flex flex-0 max-w-4xl">
         <div
-            v-show="isHomepage"
             id="search-fields"
             class="grid-cols-3 mx-4"
         >
@@ -78,7 +77,6 @@
             </div>
         </div>
         <div
-            v-show="isHomepage"
             id="search-button"
             class="flex items-center"
         >
@@ -102,8 +100,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watchEffect, type Ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { ref, watchEffect, type Ref } from 'vue'
 import SVGSearchIcon from '~/assets/icons/search-icon.svg'
 import { useSearchResultsStore } from '~/stores/searchResultsStore.js'
 import { useLocationsStore } from '~/stores/locationsStore.js'
@@ -115,8 +112,6 @@ const localeStore = useLocaleStore()
 const locationsStore = useLocationsStore()
 const searchResultsStore = useSearchResultsStore()
 const specialtiesStore = useSpecialtiesStore()
-const route = useRoute()
-const isHomepage = computed(() => route.path === '/')
 
 await locationsStore.fetchLocations()
 

--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -3,6 +3,7 @@
         <div
             id="search-fields"
             class="grid-cols-3 mx-4"
+            :class="{ hidden: route.path !== '/' }"
         >
             <div class="search-specialty col-span-1 inline-block w-1/3 py-4">
                 <select
@@ -79,6 +80,7 @@
         <div
             id="search-button"
             class="flex items-center"
+            :class="{ hidden: route.path !== '/' }"
         >
             <button
                 id="searchButton"
@@ -101,6 +103,7 @@
 
 <script setup lang="ts">
 import { ref, watchEffect, type Ref } from 'vue'
+import { useRoute } from 'vue-router'
 import SVGSearchIcon from '~/assets/icons/search-icon.svg'
 import { useSearchResultsStore } from '~/stores/searchResultsStore.js'
 import { useLocationsStore } from '~/stores/locationsStore.js'
@@ -112,6 +115,7 @@ const localeStore = useLocaleStore()
 const locationsStore = useLocationsStore()
 const searchResultsStore = useSearchResultsStore()
 const specialtiesStore = useSpecialtiesStore()
+const route = useRoute()
 
 await locationsStore.fetchLocations()
 

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -51,6 +51,7 @@
             </NuxtLink>
         </div>
         <div
+            v-show="isHomepage"
             data-testid="landscape-searchbar"
             class="portrait:hidden flex align-middle"
         >
@@ -120,12 +121,16 @@
 </template>
 
 <script lang="ts" setup>
+import { useRoute } from 'vue-router'
+import { computed } from 'vue'
 import HamburgerMenu from './HamburgerMenu.vue'
 import SVGProfileIcon from '~/assets/icons/profile-icon.svg'
 import SVGSiteLogo from '~/assets/icons/site-logo.svg'
 import { useAuthStore } from '~/stores/authStore'
 
 const authStore = useAuthStore()
+const route = useRoute()
+const isHomepage = computed(() => route.path === '/')
 
 async function logout() {
     await authStore.logout()

--- a/test/cypress/e2e/about.cy.ts
+++ b/test/cypress/e2e/about.cy.ts
@@ -13,7 +13,7 @@ describe('About page', () => {
         })
 
         it('shows the desktop top nav', () => {
-            cy.get('[data-testid="landscape-searchbar"]').should('exist').should('be.visible')
+            cy.get('[data-testid="landscape-searchbar"]').should('exist').should('not.be.visible')
         })
 
         it('does not show the hamburger component', () => {

--- a/test/cypress/e2e/privacy.cy.ts
+++ b/test/cypress/e2e/privacy.cy.ts
@@ -6,7 +6,7 @@ describe('Privacy Policy page', () => {
         })
 
         it('shows the landscape top nav', () => {
-            cy.get('[data-testid="landscape-searchbar"]').should('exist').should('be.visible')
+            cy.get('[data-testid="landscape-searchbar"]').should('exist').should('not.be.visible')
         })
 
         it('does not show the hamburger component', () => {

--- a/test/cypress/e2e/submit.cy.ts
+++ b/test/cypress/e2e/submit.cy.ts
@@ -15,7 +15,7 @@ describe('Submit page', () => {
         })
 
         it('shows the desktop top nav', () => {
-            cy.get('[data-testid="landscape-searchbar"]').should('exist').should('be.visible')
+            cy.get('[data-testid="landscape-searchbar"]').should('exist').should('not.be.visible')
         })
 
         it('does not show the hamburger component', () => {


### PR DESCRIPTION
Resolves #913 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
1. Display the Search bar  on the index page only.
2. Make sure the Search bar is hidden on the about us page or add a doctor page.

## 🧪 Testing instructions

N/A

## 📸 Screenshots

-   ### Before
![Screenshot 2024-11-27 at 18 25 16](https://github.com/user-attachments/assets/0281d4a1-77cb-4683-a4c6-a1c249771e6b)
![Screenshot 2024-11-27 at 18 25 28](https://github.com/user-attachments/assets/10169ae8-7705-4e86-b66d-f8b733a781eb)

-   ### After

![Screenshot 2024-11-27 at 18 38 35](https://github.com/user-attachments/assets/12745f4c-588e-47b4-ae7b-f415d653d1cc)
![Screenshot 2024-11-27 at 18 38 22](https://github.com/user-attachments/assets/eaa94aaf-262c-4d82-9aa6-9f72869cbe74)

