### PR TITLE
feat: add lazy load to i18n

### DIFF
--- a/components/LocaleSelector.vue
+++ b/components/LocaleSelector.vue
@@ -18,17 +18,26 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+// Nuxt vue-i18n documentation:
+// https://i18n.nuxtjs.org/docs/v8/api/vue-i18n
+
+import { onMounted, ref, watch } from 'vue'
 import { useLocaleStore } from '../stores/localeStore'
-import { Locale } from '~/typedefs/gqlTypes.js'
+import type { Locale } from '#i18n'
+import { Locale as GqlLocale } from '~/typedefs/gqlTypes.js'
 import { useI18n } from '#imports'
 
-const { locale } = useI18n()
+const { setLocale, getLocaleCookie } = useI18n()
 const localeStore = useLocaleStore()
-const selectedLocale = ref(Locale.EnUs)
 
-watch(selectedLocale, (newLocale: Locale) => {
-    localeStore.setLocale(newLocale)
-    locale.value = newLocale
+// getLocaleCookie to set the initial locale, if there is no cookie, it will default based on the nuxt.config.js
+// Browser's code language is using "-" instead of "_".
+const localeCookie = getLocaleCookie()?.replace('-', '_') || GqlLocale.EnUs
+const selectedLocale = ref(localeCookie)
+
+watch(selectedLocale, newLocale => {
+    localeStore.setLocale(newLocale as GqlLocale)
+    // setLocale to update the i18n plugin and set the 'i18n_redirected' cookie
+    setLocale(newLocale.replace('_', '-') as Locale)
 })
 </script>

--- a/components/LocaleSelector.vue
+++ b/components/LocaleSelector.vue
@@ -21,11 +21,8 @@
 // Nuxt vue-i18n documentation:
 // https://i18n.nuxtjs.org/docs/v8/api/vue-i18n
 
-import { onMounted, ref, watch } from 'vue'
-import { useLocaleStore } from '../stores/localeStore'
 import type { Locale } from '#i18n'
 import { Locale as GqlLocale } from '~/typedefs/gqlTypes.js'
-import { useI18n } from '#imports'
 
 const { setLocale, getLocaleCookie } = useI18n()
 const localeStore = useLocaleStore()

--- a/i18n.options.ts
+++ b/i18n.options.ts
@@ -1,9 +1,0 @@
-import i18n from './i18n/index.js'
-
-//@ts-expect-error to ignore the linter
-export default defineI18nConfig(() => ({
-    legacy: false,
-    locale: 'en_US',
-    fallbackLocale: 'en_US',
-    messages: i18n
-}))

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -1,36 +1,78 @@
-import en from './locales/en.json'
-import ja from './locales/ja.json'
-import pt from './locales/pt.json'
-import ru from './locales/ru.json'
-import de from './locales/de.json'
-import cn from './locales/cn.json'
-import fr from './locales/fr.json'
-import tl from './locales/tl.json'
-import vi from './locales/vi.json'
-import it from './locales/it.json'
+/*
+    The 'CustomLocale' object is based on our server's 'Locale' type.
+    We are extracting only the keys from it. Since our backend uses '_'
+    instead of '-' for the language code, we need to create a new type
+    to align with the browser and Nuxt language formats.
 
-const i18n = {
-    //eslint-disable-next-line
-    en_US: en,
-    //eslint-disable-next-line
-    ja_JP: ja,
-    //eslint-disable-next-line
-    pt_BR: pt,
-    //eslint-disable-next-line
-    ru_RU: ru,
-    //eslint-disable-next-line
-    de_DE: de,
-    //eslint-disable-next-line
-    zh_CN: cn,
-    //eslint-disable-next-line
-    fr_FR: fr,
-    //eslint-disable-next-line
-    tl_PH: tl,
-    //eslint-disable-next-line
-    vi_VN: vi,
-    //eslint-disable-next-line
-    it_IT: it
-}
+    We are using Partial because our server's type has more than 40 language codes,
+    but we haven't implemented all these languages yet.
+*/
+
+import type { LocaleObject } from '@nuxtjs/i18n'
+import type { Locale as OriginalLocale } from '~/typedefs/gqlTypes'
+
+type CustomLocale = Record<keyof typeof OriginalLocale, string>
+
+/**
+ * The browser's language code uses "-" instead of "_".
+ * Once the backend is updated to follow the browser's default locale code format, this will no longer be needed.
+ * At that point, we can import the codes directly from `gqlTypes.Locale`.
+ */
+const Locale = {
+    EnUs: 'en-US',
+    JaJp: 'ja-JP',
+    PtBr: 'pt-BR',
+    RuRu: 'ru-RU',
+    DeDe: 'de-DE',
+    ZhCn: 'zh-CN',
+    FrFr: 'fr-FR',
+    TlPh: 'tl-PH',
+    ViVn: 'vi-VN',
+    ItIt: 'it-IT'
+} as const satisfies Partial<CustomLocale>
+
+const i18n: LocaleObject[] = [
+    {
+        code: Locale.EnUs,
+        file: 'en.json'
+    },
+    {
+        code: Locale.JaJp,
+        file: 'ja.json'
+    },
+    {
+        code: Locale.PtBr,
+        file: 'pt.json'
+    },
+    {
+        code: Locale.RuRu,
+        file: 'ru.json'
+    },
+    {
+        code: Locale.DeDe,
+        file: 'de.json'
+    },
+    {
+        code: Locale.ZhCn,
+        file: 'cn.json'
+    },
+    {
+        code: Locale.FrFr,
+        file: 'fr.json'
+    },
+    {
+        code: Locale.TlPh,
+        file: 'tl.json'
+    },
+    {
+        code: Locale.ViVn,
+        file: 'vi.json'
+    },
+    {
+        code: Locale.ItIt,
+        file: 'it.json'
+    }
+]
 
 export default i18n
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,4 +1,5 @@
 import { defineNuxtConfig } from 'nuxt/config'
+import i18nLocales from './i18n'
 
 const SITE_TITLE = 'Find a Doc, Japan!'
 const SITE_DESCRIPTION
@@ -131,7 +132,17 @@ export default defineNuxtConfig({
     },
 
     i18n: {
-        vueI18n: './i18n.options.ts'
+        strategy: 'no_prefix',
+        locales: i18nLocales,
+        defaultLocale: 'en-US',
+        langDir: 'locales',
+        lazy: true,
+        detectBrowserLanguage: {
+            useCookie: true,
+            cookieKey: 'i18n_redirected',
+            fallbackLocale: 'en-US',
+            alwaysRedirect: true
+        }
     },
     svgo: {
         defaultImport: 'component'


### PR DESCRIPTION
Resolves #889
Resolves #1022 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
We no longer need the file './i18n.options.ts' to configure i18n.

The configuration is now handled directly in the Nuxt config file.

We are loading the last language used via cookies; therefore, we need to disable the language selector and display a loading indicator for the user until the loading process is complete.

The browser's language code uses "-", so we need to apply a small adjustment to align with our backend typing, which uses "_".

## Notes
This PR initiates a discussion on refactoring/updating our backend. See it here: [GitBook](https://app.gitbook.com/o/Hmir5Cugknp7uJaXBpz1/s/znzEKbLPVwI181bff5yl/update-locale-enum-on-backend)

## 📑  References
[Nuxt i18n Lazy-load translations](https://i18n.nuxtjs.org/docs/guide/lazy-load-translations)
[Nuxt Vue I18n API](https://i18n.nuxtjs.org/docs/v8/api/vue-i18n)

## 📸 Screenshots (#889)

-   ### Before
https://github.com/user-attachments/assets/261c2340-12b4-4437-9624-e2833bcd4768

-   ### After
https://github.com/user-attachments/assets/f2db64fd-cf85-4a89-b4c8-092f357bff5e

## 📸 Screenshots (#1022)

-   ### Before
![image](https://github.com/user-attachments/assets/7379339b-10ee-4b53-9bf5-32435937ac21)

-   ### After
![image](https://github.com/user-attachments/assets/de10f10e-47d8-4575-a390-8e62df7a898a)

