### PR TITLE
fix: remove skip from clipboard test on the moderation panel

### DIFF
--- a/test/cypress/e2e/moderationDashboard.cy.ts
+++ b/test/cypress/e2e/moderationDashboard.cy.ts
@@ -107,7 +107,7 @@ describe(
                 cy.get('[data-testid="mod-submission-list-item-1"]').should('exist')
             })
 
-            it.skip('it shows the moderation top nav', () => {
+            it('it shows the moderation top nav', () => {
                 cy.get('[data-testid="mod-submission-list-item-1"]').click()
                 cy.get('[data-testid="mod-edit-submission-copy-submission-id"]').click()
 


### PR DESCRIPTION
Resolves #540 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Before we were skipping a test that would click a button that copies the relevant `id` to a clipboard. I removed the skip due to our code having been updated to use lifecycle hooks to make sure the data is loaded before this button would be visible and then clicked. This test now passes.

## 🧪 Testing instructions
You can see that in CI/CD the tests are passing. You could also checkout to this branch and run:

```
yarn dev
```

Followed by:

```
yarn cypress open
```

And going to the file `moderationDashboard.cy.ts` file within the cypress GUI and run the tests to see them pass. You can see that they pass if run over and over again.


