### PR TITLE
chore: update Cypress CI to use Artifact v4

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -38,7 +38,7 @@ jobs:
               uses: cypress-io/github-action@v6
 
             - name: Upload screenshots
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               if: failure()
               with:
                 name: cypress-screenshots


### PR DESCRIPTION
[Documentation](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

Version 3 of artifact actions has been deprecated and stopped working on January 30th. We need to update to version 4 since it's used in our Cypress CI.

