### PR TITLE
feat: add lighthouse to workflows

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,24 @@
+name: Lighthouse CI
+on:
+    push:
+      branches: [ "main" ]
+    pull_request:
+      branches: [ "main" ]
+    schedule:
+      - cron: '45 18 * * 3'
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          urls: |
+            https://findadoc.jp/
+            https://findadoc.jp/submit
+            https://findadoc.jp/about
+            https://findadoc.jp/terms
+            https://findadoc.jp/privacypolicy
+          uploadArtifacts: true # save results as an action artifacts
+          temporaryPublicStorage: true # upload lighthouse report to the temporary storage


### PR DESCRIPTION
Resolves #143 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
We had an issue to add lighthouse so we can work on finding ways to better our sites accessibility as an  NPO that focuses on healthcare. This action now runs on PRs, the main branch, and once a week on Wednesday in order for us to diagnose where we can improve our site going forward.

This pr uses the following [lighthouse action](https://github.com/treosh/lighthouse-ci-action/tree/v12/)

## 🧪 Testing instructions
You can go to the workflow below and see the uploaded lighthouse scores for each of our paths. One example is the following link: https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1738807943395-80680.report.html

This link can be found in the screenshot below from the workflow when clicking on it.

## 📸 Screenshots

-   ### After

![image](https://github.com/user-attachments/assets/ec5682fc-32af-4b03-903d-193051932ee2)

