### PR TITLE
feat: implement button on GitHub to update locale files

### DIFF
--- a/.github/workflows/lint-locales-reaction-fix.yml
+++ b/.github/workflows/lint-locales-reaction-fix.yml
@@ -1,0 +1,67 @@
+name: Add Locales with Comment Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  actions: write
+  pull-requests: write
+
+jobs:
+  add-missing-locales:
+    # This only runs if the event comes from a pull request and the body contains 3 worlds in a row
+    if: |
+      github.event.issue.pull_request && contains(github.event.comment.body, '🌍🌍🌍')
+    name: Add Missing Locale Keys 🌍
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [21.3.0]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Yarn/ Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+
+      - name: Install Dependencies
+        run: yarn install --immutable
+
+        # This finds which PR the the comment came from and the branch
+      - name: Get PR Head Branch
+        id: pr_info
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prNumber = context.payload.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            core.setOutput('head_ref', pr.head.ref);
+      
+          # This checks out to the branch from the PR
+      - name: Checkout PR Branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr_info.outputs.head_ref }}
+          fetch-depth: 0
+      
+          # This runs the linter and pushes it to the branch
+      - name: Fix Missing Locale Keys, Commit, and Push Changes
+        run: |
+          node i18n/checkLocaleKeys.js
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          git commit -m "chore: fix missing locale keys" || echo "No changes to commit"
+          git push origin ${{ steps.pr_info.outputs.head_ref }}
+      

--- a/.github/workflows/lint-locales.yml
+++ b/.github/workflows/lint-locales.yml
@@ -1,17 +1,17 @@
-name: Lint-Locales
+name: Lint Locales
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
     branches: [ "main" ]
   schedule:
     - cron: '45 15 * * 4'
+
 permissions:
   contents: read
-  security-events: write
-  actions: write  # This is needed for pull requests to delete
+  pull-requests: write
+  actions: write  # Ensure actions permissions are set to write
 
 jobs:
   locale-lint:
@@ -25,12 +25,52 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Yarn/ Node ${{ matrix.node-version }}
+
+      - name: Install Node.js and Yarn
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "yarn"
+          cache: 'yarn'
+
       - name: Install Dependencies
         run: yarn install --immutable
+
       - name: Run Locales Lint
-        run: NODE_ENV=production yarn lint:locales
+        id: lint
+        run: |
+          NODE_ENV=production node i18n/checkLocaleKeys.js --report-only > missing_keys.txt
+          if [ -s missing_keys.txt ]; then
+            cat missing_keys.txt
+            exit 1
+          fi
+
+      - name: Create Comment for Triggering Auto Fix
+        if: failure()
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            // Read missing keys from the file
+            const missingKeysContent = fs.readFileSync('missing_keys.txt', 'utf8').trim();
+            const missingKeys = missingKeysContent ? missingKeysContent.split('\n') : [];
+
+            if (missingKeys.length === 0) {
+              console.log('No missing keys found.');
+              return;
+            }
+
+            const formattedKeys = missingKeys.map(key => key.trim() && !key.includes("json") ? `- ${key}` : `**${key}**`).join('\n');
+
+            const repo = context.repo.repo;
+            const owner = context.repo.owner;
+
+            const commentBody = `### Missing Locale Keys Found: \n${formattedKeys}\n\nTo add the missing keys, comment with the following emoji 3 times:\n\n\`\`\`🌍\`\`\``;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner,
+              repo,
+              body: commentBody
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ cypress/videos
 
 # VS Code
 .vscode
+
+# txt file added when linting files
+*missing_keys.txt

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,2 @@
 echo "linting ✨"
 yarn lint
-
-# Run the locale keys check script
-echo "😎checking locale file keys match😎"
-yarn lint:locales


### PR DESCRIPTION
Resolves #690
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Before on push it would lint the locales and auto update them for you. Now you can run the script yourself locally. Or press a button on GitHub to run a webhook that runs the script for you that will commit and push for you. This makes it so if developers don't run `yarn prepare` that they can still have a button on GitHub when they create a PR. Also it keeps from autorunning and updating files when a feature is not done being worked on through every commit push if translations are added.

## Testing
This was tested in a repository similar to ours since the workflow has to be in the main branch for it to work for comments

## 📸 Screenshots

-   ### After
![image](https://github.com/user-attachments/assets/80bf422b-d9c0-4f52-84ef-847daff9f221)
![image](https://github.com/user-attachments/assets/be672bef-24de-4b0f-8e68-27dfeaef7668)
![image](https://github.com/user-attachments/assets/15e7d83c-e30e-44a0-838d-9a899dd3f93a)


