### PR TITLE
fix: add cypress file to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ node_modules
 !.yarn/versions
 yarn-error.log
 
+#cypress
+cypress
 # jest
 coverage
 # eslint results


### PR DESCRIPTION
Resolves #1006 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

This PR adds the Cypress file to .gitignore to prevent test snapshots from being unintentionally committed when tests fail.

## 🧪 Testing instructions

NA
