### PR TITLE
fix: add ci to e2e testing script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "prod:build": "yarn && yarn generate && nuxi generate",
         "prod:start": "nuxi start",
         "prepare:ci": "nuxi prepare",
-        "test": "yarn test:pinia --run && yarn test:e2e",
+        "test": "yarn test:pinia --run && yarn test:e2e:ci",
         "test:pinia": "nuxi prepare && nuxi generate && vitest",
         "test:pinia:coverage": "vitest run --coverage",
         "test:e2e": "dotenv -e .env.test -o -- cypress open",


### PR DESCRIPTION
Resolves #1011 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Before the script was missing ci which would cause the gui to open. For the test script we want it to all run in the console.

## 🧪 Testing instructions
run the tests with

```
yarn test
```

and no GUI should appear for cypress

