### PR TITLE
feat: add loader to ModEdithealthcareProfessionalSection component

### DIFF
--- a/components/ModEditHealthcareProfessionalSection.vue
+++ b/components/ModEditHealthcareProfessionalSection.vue
@@ -1,4 +1,5 @@
 <template>
+    <Loader />
     <div v-if="isHealthcareProfessionalInitialized">
         <div class="mod-healthcare-professional-section">
             <h2 class="mb-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal">
@@ -272,6 +273,9 @@ let toast: ToastInterface
 const route = useRoute()
 
 const { t } = useI18n()
+
+const loadingStore = useLoadingStore()
+loadingStore.setIsLoading(true)
 
 const localesStore = useLocaleStore()
 const healthcareProfessionalsStore = useHealthcareProfessionalsStore()
@@ -592,6 +596,8 @@ onBeforeMount(async () => {
         = new Set(healthcareProfessionalsStore.healthcareProfessionalSectionFields.degrees)
 
     isHealthcareProfessionalInitialized.value = true
+
+    loadingStore.setIsLoading(false)
 
     await nextTick()
 })


### PR DESCRIPTION
Resolves #954 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
added the loading component when opening a healthcare professional profile in moderation
## 🧪 Testing instructions
loading is usually too fast, so changing network speed may allow you to view the loading component
## 📸 Screenshots
-   ### After
https://github.com/user-attachments/assets/7214da0c-f3bc-4376-af49-3c3ccb95af34


