### PR TITLE
chore: add steps to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,8 @@
-Resolves #[Issue number]
-- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs
+✅ Resolves #[Issue number]
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
+- [ ] PR assignee has been selected
+- [ ] PR label has been selected
+- [ ] @NabbeunNabi has been selected for preliminary review
 
 ## 🔧 What changed
 


### PR DESCRIPTION
Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
This adds a few additional checkboxes to the PR template to facilitate a smoother code review process.

## 📸 Screenshots

-   ### Before
<img width="441" alt="Screenshot 2025-02-08 at 6 25 49 PM" src="https://github.com/user-attachments/assets/c343eacd-4c38-46e6-9e96-6085e35596ad" />


-   ### After
<img width="449" alt="Screenshot 2025-02-08 at 6 23 19 PM" src="https://github.com/user-attachments/assets/9882d887-c11a-4cd9-8ba8-08b5553cc007" />


