### PR TITLE
fix: ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,14 +31,17 @@ export default withNuxt(
                 }
             }
         },
-        files: ['test**/*.ts', './**/*.ts', './**/*.js'],
+        files: ['**/*.{ts,js}'],
         plugins: {
             '@typescript-eslint': tseslint.plugin,
             '@stylistic': stylistic
         },
         ignores: ['./typeDefs/gqlTypes.ts', './typesgeneratorconfig.ts'],
         rules: {
-            ...tseslint.configs.recommended,
+            // Current eslintRecommended rules (https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts)
+            // More information about the plugin (https://typescript-eslint.io/users/configs#eslint-recommended)
+            ...tseslint.configs.eslintRecommended.rules,
+
             // TS specific rules
             '@typescript-eslint/no-shadow': 'error',
             '@typescript-eslint/no-unused-vars': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,7 +52,6 @@ export default withNuxt(
             'no-unused-vars': 'off',
             'block-scoped-var': 'error',
             complexity: ['error', { max: 40 }],
-            curly: 'error',
             'dot-location': ['error', 'property'],
             'dot-notation': ['error', { allowPattern: '^[a-z]+(_[a-z]+)+$' }],
             'no-alert': 'error',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,7 +52,6 @@ export default withNuxt(
             'no-unused-vars': 'off',
             'block-scoped-var': 'error',
             complexity: ['error', { max: 40 }],
-            'consistent-return': 'error',
             curly: 'error',
             'dot-location': ['error', 'property'],
             'dot-notation': ['error', { allowPattern: '^[a-z]+(_[a-z]+)+$' }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,7 +36,7 @@ export default withNuxt(
             '@typescript-eslint': tseslint.plugin,
             '@stylistic': stylistic
         },
-        ignores: ['./typeDefs/gqlTypes.ts', './typesgeneratorconfig.ts'],
+        ignores: ['typeDefs/gqlTypes.ts', 'typesgeneratorconfig.ts', 'i18n/checkLocaleKeys.js'],
         rules: {
             // Current eslintRecommended rules (https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts)
             // More information about the plugin (https://typescript-eslint.io/users/configs#eslint-recommended)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import eslintJsPlugin from '@eslint/js'
 import tseslint from 'typescript-eslint'
 import stylistic from '@stylistic/eslint-plugin'
 import pluginCypress from 'eslint-plugin-cypress/flat'
+import pluginVitest from '@vitest/eslint-plugin'
 import pluginVue from 'eslint-plugin-vue'
 import withNuxt from './.nuxt/eslint.config.mjs'
 
@@ -15,7 +16,6 @@ export default withNuxt(
             '.nuxt/*',
             'coverage/*',
             '.yarn/*',
-            'test/vitest',
             'typedefs/gqlTypes.ts'
         ]
     },
@@ -103,6 +103,16 @@ export default withNuxt(
         ...pluginCypress.configs.recommended,
         rules: {
             'cypress/no-unnecessary-waiting': 'off'
+        }
+    },
+    // Linting for Vitest (https://github.com/vitest-dev/eslint-plugin-vitest)
+    {
+        files: ['test/vitest/**/*'],
+        ...pluginVitest.configs.recommended,
+        ...pluginVitest.configs.env,
+        rules: {
+            '@typescript-eslint/no-unused-expressions': 'off',
+            'no-unused-expressions': 'off'
         }
     }
 )

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -170,7 +170,9 @@ export default withNuxt(
                     ignoreTemplateLiterals: true,
                     ignoreRegExpLiterals: true
                 }
-            ], // be friendly to laptops
+            ],
+            '@stylistic/max-statements-per-line': 'off',
+            // be friendly to laptops
             '@stylistic/padding-line-between-statements': 'off', //we can choose newlines after variable declarations
             '@stylistic/no-multiple-empty-lines': ['error', { max: 1, maxEOF: 1 }],
             '@stylistic/object-curly-newline': ['error', { consistent: true }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,7 +65,8 @@ export default withNuxt(
             ],
             'vars-on-top': 'off',
             yoda: ['error', 'never', { exceptRange: true }],
-            'no-console': 'error', // we should use the logger instead
+            // Change to a logger in the future
+            'no-console': ['error', { allow: ['warn', 'error', 'info'] }],
             // Vue specific rules
 
             // Stylistic Issues and Opinions

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         "@testing-library/vue": "^8.1.0",
         "@vitejs/plugin-vue": "^5.1.2",
         "@vitest/coverage-v8": "^2.1.3",
+        "@vitest/eslint-plugin": "^1.1.27",
         "@vue/test-utils": "^2.4.6",
         "all-contributors-cli": "^6.26.1",
         "autoprefixer": "^10.4.20",

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -47,27 +47,27 @@ export const useFacilitiesStore = defineStore(
                 .find((facility: Facility) => facility.id === facilityId)
         }
 
-        function initializeFacilitySectionValues(facilityData: Facility | undefined) {
-            if (!facilityData) return
+        function initializeFacilitySectionValues(data: Facility | undefined) {
+            if (!data) return
 
-            facilitySectionFields.nameEn = facilityData.nameEn
-            facilitySectionFields.nameJa = facilityData.nameJa
-            facilitySectionFields.phone = facilityData?.contact?.phone
-            facilitySectionFields.email = facilityData?.contact?.email || undefined
-            facilitySectionFields.website = facilityData?.contact?.website || undefined
-            facilitySectionFields.postalCode = facilityData.contact?.address.postalCode
-            facilitySectionFields.prefectureEn = facilityData?.contact?.address?.prefectureEn
-            facilitySectionFields.cityEn = facilityData?.contact?.address?.cityEn
-            facilitySectionFields.addressLine1En = facilityData?.contact?.address?.addressLine1En
-            facilitySectionFields.addressLine2En = facilityData?.contact?.address?.addressLine2En
-            facilitySectionFields.prefectureJa = facilityData?.contact?.address?.prefectureJa
-            facilitySectionFields.cityJa = facilityData?.contact?.address?.cityJa
-            facilitySectionFields.addressLine1Ja = facilityData?.contact?.address?.addressLine1Ja
-            facilitySectionFields.addressLine2Ja = facilityData?.contact?.address?.addressLine2Ja
-            facilitySectionFields.googlemapsURL = facilityData?.contact?.googleMapsUrl
-            facilitySectionFields.healthcareProfessionalIds = facilityData.healthcareProfessionalIds
-            facilitySectionFields.mapLatitude = facilityData.mapLatitude.toString()
-            facilitySectionFields.mapLongitude = facilityData.mapLongitude.toString()
+            facilitySectionFields.nameEn = data.nameEn
+            facilitySectionFields.nameJa = data.nameJa
+            facilitySectionFields.phone = data?.contact?.phone
+            facilitySectionFields.email = data?.contact?.email || undefined
+            facilitySectionFields.website = data?.contact?.website || undefined
+            facilitySectionFields.postalCode = data.contact?.address.postalCode
+            facilitySectionFields.prefectureEn = data?.contact?.address?.prefectureEn
+            facilitySectionFields.cityEn = data?.contact?.address?.cityEn
+            facilitySectionFields.addressLine1En = data?.contact?.address?.addressLine1En
+            facilitySectionFields.addressLine2En = data?.contact?.address?.addressLine2En
+            facilitySectionFields.prefectureJa = data?.contact?.address?.prefectureJa
+            facilitySectionFields.cityJa = data?.contact?.address?.cityJa
+            facilitySectionFields.addressLine1Ja = data?.contact?.address?.addressLine1Ja
+            facilitySectionFields.addressLine2Ja = data?.contact?.address?.addressLine2Ja
+            facilitySectionFields.googlemapsURL = data?.contact?.googleMapsUrl
+            facilitySectionFields.healthcareProfessionalIds = data.healthcareProfessionalIds
+            facilitySectionFields.mapLatitude = data.mapLatitude.toString()
+            facilitySectionFields.mapLongitude = data.mapLongitude.toString()
         }
 
         async function getFacilities() {

--- a/stores/healthcareProfessionalsStore.ts
+++ b/stores/healthcareProfessionalsStore.ts
@@ -221,7 +221,7 @@ export async function getHealthcareProfessionalById(id: string) {
         }
         return result.healthcareProfessional
     } catch (error: unknown) {
-        console.log(`Error retrieving healthcare professional by id: ${id}: ${JSON.stringify(error)}`)
+        console.error(`Error retrieving healthcare professional by id: ${id}: ${JSON.stringify(error)}`)
         return []
     }
 }

--- a/stores/healthcareProfessionalsStore.ts
+++ b/stores/healthcareProfessionalsStore.ts
@@ -49,6 +49,7 @@ export const useHealthcareProfessionalsStore = defineStore(
         }
 
         function updateHealthcareProfessionalSectionFields(healthcareProfessional: HealthcareProfessional) {
+            // eslint-disable-next-line no-underscore-dangle
             healthcareProfessionalSectionFields.__typename = 'HealthcareProfessional'
             healthcareProfessionalSectionFields.acceptedInsurance = healthcareProfessional.acceptedInsurance
             healthcareProfessionalSectionFields.createdDate = healthcareProfessional.createdDate

--- a/stores/localeStore.ts
+++ b/stores/localeStore.ts
@@ -9,15 +9,15 @@ export type LocaleDisplay = {
 }
 
 export const useLocaleStore = defineStore('locale', () => {
-    const enUsLocale = localeDisplayOptions.find(o => o.code === Locale.EnUs) as LocaleDisplay
+    const enUsLocale = localeDisplayOptions.find(currentLocale => currentLocale.code === Locale.EnUs) as LocaleDisplay
     const locale: Ref<LocaleDisplay> = ref(enUsLocale)
 
     function setLocale(selectedLocale: Locale) {
-        locale.value = localeDisplayOptions.find(l => l.code === selectedLocale) as LocaleDisplay
+        locale.value = localeDisplayOptions.find(currentLocale => currentLocale.code === selectedLocale) as LocaleDisplay
     }
 
     function formatLanguageCodeToSimpleText(selectedLocale: string) {
-        const language = localeDisplayOptions.find(l => l.code === selectedLocale)
+        const language = localeDisplayOptions.find(currentLocale => currentLocale.code === selectedLocale)
         return language?.simpleText || 'Language not found'
     }
 

--- a/stores/localeStore.ts
+++ b/stores/localeStore.ts
@@ -17,7 +17,7 @@ export const useLocaleStore = defineStore('locale', () => {
     }
 
     function formatLanguageCodeToSimpleText(selectedLocale: string) {
-        const language = localeDisplayOptions.find(locale => locale.code === selectedLocale)
+        const language = localeDisplayOptions.find(l => l.code === selectedLocale)
         return language?.simpleText || 'Language not found'
     }
 

--- a/stores/locationsStore.ts
+++ b/stores/locationsStore.ts
@@ -55,6 +55,7 @@ async function queryFacilities(): Promise<Facility[]> {
         return result?.facilities ?? []
     } catch (error) {
         console.error(`Error getting facilities for dropdown: ${JSON.stringify(error)}`)
+        // eslint-disable-next-line no-alert
         alert('Error getting data! Please contact our support team by clicking the bottom right link on the page!')
         return []
     }

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -177,7 +177,7 @@ async function querySubmissions() {
         )
         return result?.submissions ?? []
     } catch (error) {
-        console.log(`Error querying the submissions: ${JSON.stringify(error)}`)
+        console.error(`Error querying the submissions: ${JSON.stringify(error)}`)
         return []
     }
 }

--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -100,6 +100,7 @@ async function queryProfessionals(searchSpecialty?: Specialty, searchLanguage?: 
         return professionalsSearchResult
     } catch (error) {
         console.error(`Error getting professionals: ${JSON.stringify(error)}`)
+        // eslint-disable-next-line no-alert
         alert('Error getting data! Please contact our support team by clicking the bottom right link on the page!')
         return []
     }
@@ -135,6 +136,7 @@ async function queryFacilities(healthcareProfessionalIds: string[], searchCity?:
         return locationFilteredSearchResults
     } catch (error) {
         console.error(`Error getting facilities: ${JSON.stringify(error)}`)
+        // eslint-disable-next-line no-alert
         alert('Error getting data! Please contact our support team by clicking the bottom right link on the page!')
         return []
     }

--- a/utils/stringUtils.ts
+++ b/utils/stringUtils.ts
@@ -45,7 +45,7 @@ export function isValidUrl(url: string | URL) {
     try {
         url = new URL(url)
     } catch (e) {
-        console.log(`Error: ${e}`)
+        console.error(`Error: ${e}`)
         return false
     }
     return url.protocol === 'https:'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4288,6 +4288,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/eslint-plugin@npm:^1.1.27":
+  version: 1.1.27
+  resolution: "@vitest/eslint-plugin@npm:1.1.27"
+  peerDependencies:
+    "@typescript-eslint/utils": ">= 8.0"
+    eslint: ">= 8.57.0"
+    typescript: ">= 5.0.0"
+    vitest: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+    vitest:
+      optional: true
+  checksum: 10/a2c5e79c449adc9929df4b38ff86f00e8ed16cb1c9c869410c56046681412d7eb07b0957ad90f48e44aaf8572534f2a54924b96057a77ecfc1276c4be6efafa7
+  languageName: node
+  linkType: hard
+
 "@vitest/expect@npm:2.1.9":
   version: 2.1.9
   resolution: "@vitest/expect@npm:2.1.9"
@@ -8221,6 +8238,7 @@ __metadata:
     "@testing-library/vue": "npm:^8.1.0"
     "@vitejs/plugin-vue": "npm:^5.1.2"
     "@vitest/coverage-v8": "npm:^2.1.3"
+    "@vitest/eslint-plugin": "npm:^1.1.27"
     "@vue/test-utils": "npm:^2.4.6"
     all-contributors-cli: "npm:^6.26.1"
     autoprefixer: "npm:^10.4.20"


### PR DESCRIPTION
✅ Resolves #982
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What Changed  

We are now using the correct recommended TSESLint rules (`tseslint.configs.eslintRecommended.rules`).  

Previously, we were using the wrong plugin property: `tseslint.configs.recommended`. This includes not only the rules but the entire recommended plugin configuration.  

### Added Vitest ESLint Plugin and Fixed the Following Errors:  

- #### Styling  
  - `max-statements-per-line` turned off and removed `curly` ESLint rule.  

- #### `no-console`  
  - Updated this rule to only affect `console.log`.  
  - `console.warn`, `console.error` and `console.info` can still be used.  
  - In the future, this rule should block all `console` commands once a logger is added.  

- #### `no-underscore-dangle`  
  - Added ESLint ignore and renamed variables.  

- #### `no-shadow`  
  - Renamed conflicting variables.  

- #### `consistent-return`  
  - Removed the rule due inconsistencies across the codebase.

- #### `no-alert`  
  - Added `eslint-disable-next-line no-alert`

### Notes:  
I didn't remove the `require-atomic-updates` warning. This needs further investigation—it may just be a false alarm.  