### PR TITLE
feat: refactor arraysAreEqual utility function to also handle non-primitive variables

### DIFF
--- a/test/vitest/arrayUtils.spec.ts
+++ b/test/vitest/arrayUtils.spec.ts
@@ -1,11 +1,7 @@
-import { setActivePinia, createPinia } from 'pinia'
 import { expect } from 'chai'
 import { arraysAreEqual } from '@/utils/arrayUtils'
 
 describe('arraysAreEqual', () => {
-    beforeEach(() => {
-        setActivePinia(createPinia())
-    })
 
     it('should sort and find two arrays with the same primitive values to be equal', () => {
         expect(arraysAreEqual([1,2,3], [3,1,2])).to.be.true

--- a/test/vitest/arrayUtils.spec.ts
+++ b/test/vitest/arrayUtils.spec.ts
@@ -1,0 +1,46 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { expect } from 'chai'
+import { arraysAreEqual } from '@/utils/arrayUtils'
+
+describe('arraysAreEqual', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+    })
+
+    it('should sort and find two arrays with the same primitive values to be equal', () => {
+        expect(arraysAreEqual([1,2,3], [3,1,2])).to.be.true;
+    })
+
+    it('should sort and find two arrays with different primitive values to be not equal', () => {
+        expect(arraysAreEqual([1,2,3], [4,5,6])).to.be.false;
+    })
+
+
+    it('should sort and find two arrays with the same object values to be equal', () => {
+        const arr1 = [{name: "Tony", profession: "tester"}, {name: "Sara", profession: "coder"}];
+        const arr2 = [{name: "Sara", profession: "coder"}, {name: "Tony", profession: "tester"}];
+
+        expect(arraysAreEqual(arr1, arr2)).to.be.true;
+    })
+
+    it('should sort and find two arrays with different object values to be not equal', () => {
+        const arr1 = [{name: "Tony", profession: "tester"}, {name: "Sara", profession: "coder"}];
+        const arr2 = [{name: "Max", profession: "Truck Driver"}, {name: "Helen", profession: "History Professor"}];
+
+        expect(arraysAreEqual(arr1, arr2)).to.be.false;
+    })
+
+    it('should sort and find two arrays with the same array values to be equal', () => {
+        const arr1 = [[1,2,3], [4,5,6]];
+        const arr2 = [ [4,5,6], [1,2,3]];
+
+        expect(arraysAreEqual(arr1, arr2)).to.be.true;
+    })
+
+    it('should sort and find two arrays with different array values to be not equal', () => {
+        const arr1 = [[1,2,3], [4,5,6]];
+        const arr2 = [ [7,8,9], [1,2,3]];
+
+        expect(arraysAreEqual(arr1, arr2)).to.be.false;
+    })
+})

--- a/test/vitest/arrayUtils.spec.ts
+++ b/test/vitest/arrayUtils.spec.ts
@@ -8,39 +8,39 @@ describe('arraysAreEqual', () => {
     })
 
     it('should sort and find two arrays with the same primitive values to be equal', () => {
-        expect(arraysAreEqual([1,2,3], [3,1,2])).to.be.true;
+        expect(arraysAreEqual([1,2,3], [3,1,2])).to.be.true
     })
 
     it('should sort and find two arrays with different primitive values to be not equal', () => {
-        expect(arraysAreEqual([1,2,3], [4,5,6])).to.be.false;
+        expect(arraysAreEqual([1,2,3], [4,5,6])).to.be.false
     })
 
 
     it('should sort and find two arrays with the same object values to be equal', () => {
-        const arr1 = [{name: "Tony", profession: "tester"}, {name: "Sara", profession: "coder"}];
-        const arr2 = [{name: "Sara", profession: "coder"}, {name: "Tony", profession: "tester"}];
+        const arr1 = [{name: "Tony", profession: "tester"}, {name: "Sara", profession: "coder"}]
+        const arr2 = [{name: "Sara", profession: "coder"}, {name: "Tony", profession: "tester"}]
 
-        expect(arraysAreEqual(arr1, arr2)).to.be.true;
+        expect(arraysAreEqual(arr1, arr2)).to.be.true
     })
 
     it('should sort and find two arrays with different object values to be not equal', () => {
-        const arr1 = [{name: "Tony", profession: "tester"}, {name: "Sara", profession: "coder"}];
-        const arr2 = [{name: "Max", profession: "Truck Driver"}, {name: "Helen", profession: "History Professor"}];
+        const arr1 = [{name: "Tony", profession: "tester"}, {name: "Sara", profession: "coder"}]
+        const arr2 = [{name: "Max", profession: "Truck Driver"}, {name: "Helen", profession: "History Professor"}]
 
-        expect(arraysAreEqual(arr1, arr2)).to.be.false;
+        expect(arraysAreEqual(arr1, arr2)).to.be.false
     })
 
     it('should sort and find two arrays with the same array values to be equal', () => {
-        const arr1 = [[1,2,3], [4,5,6]];
-        const arr2 = [ [4,5,6], [1,2,3]];
+        const arr1 = [[1,2,3], [4,5,6]]
+        const arr2 = [ [4,5,6], [1,2,3]]
 
-        expect(arraysAreEqual(arr1, arr2)).to.be.true;
+        expect(arraysAreEqual(arr1, arr2)).to.be.true
     })
 
     it('should sort and find two arrays with different array values to be not equal', () => {
-        const arr1 = [[1,2,3], [4,5,6]];
-        const arr2 = [ [7,8,9], [1,2,3]];
+        const arr1 = [[1,2,3], [4,5,6]]
+        const arr2 = [ [7,8,9], [1,2,3]]
 
-        expect(arraysAreEqual(arr1, arr2)).to.be.false;
+        expect(arraysAreEqual(arr1, arr2)).to.be.false
     })
 })

--- a/test/vitest/arrayUtils.spec.ts
+++ b/test/vitest/arrayUtils.spec.ts
@@ -2,40 +2,38 @@ import { expect } from 'chai'
 import { arraysAreEqual } from '@/utils/arrayUtils'
 
 describe('arraysAreEqual', () => {
-
     it('should sort and find two arrays with the same primitive values to be equal', () => {
-        expect(arraysAreEqual([1,2,3], [3,1,2])).to.be.true
+        expect(arraysAreEqual([1, 2, 3], [3, 1, 2])).to.be.true
     })
 
     it('should sort and find two arrays with different primitive values to be not equal', () => {
-        expect(arraysAreEqual([1,2,3], [4,5,6])).to.be.false
+        expect(arraysAreEqual([1, 2, 3], [4, 5, 6])).to.be.false
     })
 
-
     it('should sort and find two arrays with the same object values to be equal', () => {
-        const arr1 = [{name: "Tony", profession: "tester"}, {name: "Sara", profession: "coder"}]
-        const arr2 = [{name: "Sara", profession: "coder"}, {name: "Tony", profession: "tester"}]
+        const arr1 = [{ name: 'Tony', profession: 'tester' }, { name: 'Sara', profession: 'coder' }]
+        const arr2 = [{ name: 'Sara', profession: 'coder' }, { name: 'Tony', profession: 'tester' }]
 
         expect(arraysAreEqual(arr1, arr2)).to.be.true
     })
 
     it('should sort and find two arrays with different object values to be not equal', () => {
-        const arr1 = [{name: "Tony", profession: "tester"}, {name: "Sara", profession: "coder"}]
-        const arr2 = [{name: "Max", profession: "Truck Driver"}, {name: "Helen", profession: "History Professor"}]
+        const arr1 = [{ name: 'Tony', profession: 'tester' }, { name: 'Sara', profession: 'coder' }]
+        const arr2 = [{ name: 'Max', profession: 'Truck Driver' }, { name: 'Helen', profession: 'History Professor' }]
 
         expect(arraysAreEqual(arr1, arr2)).to.be.false
     })
 
     it('should sort and find two arrays with the same array values to be equal', () => {
-        const arr1 = [[1,2,3], [4,5,6]]
-        const arr2 = [ [4,5,6], [1,2,3]]
+        const arr1 = [[1, 2, 3], [4, 5, 6]]
+        const arr2 = [[4, 5, 6], [1, 2, 3]]
 
         expect(arraysAreEqual(arr1, arr2)).to.be.true
     })
 
     it('should sort and find two arrays with different array values to be not equal', () => {
-        const arr1 = [[1,2,3], [4,5,6]]
-        const arr2 = [ [7,8,9], [1,2,3]]
+        const arr1 = [[1, 2, 3], [4, 5, 6]]
+        const arr2 = [[7, 8, 9], [1, 2, 3]]
 
         expect(arraysAreEqual(arr1, arr2)).to.be.false
     })

--- a/utils/arrayUtils.ts
+++ b/utils/arrayUtils.ts
@@ -51,7 +51,7 @@ function canonicalize<T>(value: T): string {
 
     //Recursively handle arrays
     if (Array.isArray(value)) {
-        return '[' + value.map(canonicalize).join(',') + ']'
+        return `[${value.map(canonicalize).join(',')}]`
     }
 
     //sort and recursively handle objects
@@ -60,5 +60,5 @@ function canonicalize<T>(value: T): string {
     const keyValuePairs = keys.map(
         key => `${JSON.stringify(key)}:${canonicalize(obj[key])}`
     )
-    return '{' + keyValuePairs.join(',') + '}'
+    return `{${keyValuePairs.join(',')}}`
 }

--- a/utils/arrayUtils.ts
+++ b/utils/arrayUtils.ts
@@ -29,6 +29,7 @@ export function arraysAreEqual<T>(array1: T[],
     return true
 }
 
+//This function helps sort elements in an array
 function compareElements<T>(ele1: T, ele2: T): number {
     const ele1Str = canonicalize(ele1)
     const ele2Str = canonicalize(ele2)
@@ -37,7 +38,9 @@ function compareElements<T>(ele1: T, ele2: T): number {
     return 0
 }
 
-//This function handles different data types and returns them as canonicalized strings
+/*This function handles different data types and returns them as canonicalized strings.
+For example, two objects might contain the same key/value pairs but in different orders.
+This function would sort those objects and turn them into a "canon" comparable representation*/
 function canonicalize<T>(value: T): string {
     if (value === null) return 'null'
     if (value === undefined) return 'undefined'
@@ -46,11 +49,12 @@ function canonicalize<T>(value: T): string {
         return JSON.stringify(value)
     }
 
+    //Recursively handle arrays
     if (Array.isArray(value)) {
         return '[' + value.map(canonicalize).join(',') + ']'
-        //return '[' + (value as Array<unknown>).map(canonicalize).join(',') + ']'
     }
 
+    //sort and recursively handle objects
     const obj = value as { [key: string]: unknown }
     const keys = Object.keys(obj).sort()
     const keyValuePairs = keys.map(

--- a/utils/arrayUtils.ts
+++ b/utils/arrayUtils.ts
@@ -8,7 +8,7 @@ export function removeDuplicates<T>(inputArray: T[]): T[] {
     }, [])
 }
 
-//This is a helper function that sorts and compares that all the values in a primitive value array are equal
+//This is a helper function that sorts and compares that all the values in an array are equal
 export function arraysAreEqual<T>(array1: T[],
     array2: T[]): boolean {
     if (array1.length !== array2.length) {
@@ -16,9 +16,41 @@ export function arraysAreEqual<T>(array1: T[],
     }
 
     // Sort both arrays
-    const sortedArray1 = [...array1].sort((a, b) => (a > b ? 1 : -1))
-    const sortedArray2 = [...array2].sort((a, b) => (a > b ? 1 : -1))
+    const sortedArray1 = [...array1].sort(compareElements)
+    const sortedArray2 = [...array2].sort(compareElements)
 
     // Compare each element in the sorted arrays
-    return sortedArray1.every((value, index) => value === sortedArray2[index])
+    for (let i = 0; i < sortedArray1.length; i++) {
+        if (canonicalize(sortedArray1[i]) !== canonicalize(sortedArray2[i])) {
+          return false;
+        }
+      }
+
+      return true;
+}
+
+function compareElements<T>(ele1: T, ele2: T): number {
+    const  ele1Str = canonicalize(ele1);
+    const  ele2Str = canonicalize(ele2);
+    if (ele1Str < ele2Str) return -1;
+    if (ele1Str > ele2Str) return 1;
+    return 0
+}
+
+//This function handles different data types and returns them as canonicalized strings
+function canonicalize(value: any): string {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    
+    if (typeof value !== 'object') {
+      return JSON.stringify(value);
+    }
+    
+    if (Array.isArray(value)) {
+      return '[' + value.map(canonicalize).join(',') + ']';
+    }
+    
+    const keys = Object.keys(value).sort();
+    const keyValuePairs = keys.map(key => `${JSON.stringify(key)}:${canonicalize(value[key])}`);
+    return '{' + keyValuePairs.join(',') + '}';
 }

--- a/utils/arrayUtils.ts
+++ b/utils/arrayUtils.ts
@@ -22,35 +22,39 @@ export function arraysAreEqual<T>(array1: T[],
     // Compare each element in the sorted arrays
     for (let i = 0; i < sortedArray1.length; i++) {
         if (canonicalize(sortedArray1[i]) !== canonicalize(sortedArray2[i])) {
-          return false;
+            return false
         }
-      }
+    }
 
-      return true;
+    return true
 }
 
 function compareElements<T>(ele1: T, ele2: T): number {
-    const  ele1Str = canonicalize(ele1);
-    const  ele2Str = canonicalize(ele2);
-    if (ele1Str < ele2Str) return -1;
-    if (ele1Str > ele2Str) return 1;
+    const ele1Str = canonicalize(ele1)
+    const ele2Str = canonicalize(ele2)
+    if (ele1Str < ele2Str) return -1
+    if (ele1Str > ele2Str) return 1
     return 0
 }
 
 //This function handles different data types and returns them as canonicalized strings
-function canonicalize(value: any): string {
-    if (value === null) return 'null';
-    if (value === undefined) return 'undefined';
-    
+function canonicalize<T>(value: T): string {
+    if (value === null) return 'null'
+    if (value === undefined) return 'undefined'
+
     if (typeof value !== 'object') {
-      return JSON.stringify(value);
+        return JSON.stringify(value)
     }
-    
+
     if (Array.isArray(value)) {
-      return '[' + value.map(canonicalize).join(',') + ']';
+        return '[' + value.map(canonicalize).join(',') + ']'
+        //return '[' + (value as Array<unknown>).map(canonicalize).join(',') + ']'
     }
-    
-    const keys = Object.keys(value).sort();
-    const keyValuePairs = keys.map(key => `${JSON.stringify(key)}:${canonicalize(value[key])}`);
-    return '{' + keyValuePairs.join(',') + '}';
+
+    const obj = value as { [key: string]: unknown }
+    const keys = Object.keys(obj).sort()
+    const keyValuePairs = keys.map(
+        key => `${JSON.stringify(key)}:${canonicalize(obj[key])}`
+    )
+    return '{' + keyValuePairs.join(',') + '}'
 }


### PR DESCRIPTION
✅ Resolves #998
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
arraysAreEqual in utils/arraysUtils.ts can now sort and compare arrays that contain objects or arrays. It does this by turning the values into strings and then comparing them. Tests were also added in a new file test/vitest/arrayUtils.spec.ts that checks for primitive arrays as well as non-primitive.

## 🧪 Testing instructions
"yarn test:pinia" runs the test



