### PR TITLE
fix: update workflow to autogenerate PR with type differences

### DIFF
--- a/.github/workflows/generate-gql-types.yml
+++ b/.github/workflows/generate-gql-types.yml
@@ -6,8 +6,9 @@ on:
     - cron: '0 0 * * MON'
 
 permissions:
-  contents: write  # Allows for committing and creating pull requests
+  contents: write
   actions: write
+  pull-requests: write
 
 jobs:
   generate-gql-types:
@@ -18,41 +19,35 @@ jobs:
         node-version: [21.3.0]
 
     steps:
-      # Checkout the repository
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          
       - name: Install Yarn/Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
+
       - name: Install Dependencies
         run: yarn install --immutable
+
       - name: Generate GQL Types
         run: yarn generate
-      - name: Check for changes
-        run: git diff --exit-code -- typedefs/
-        continue-on-error: true
 
-      # Commit and push changes if any exist
-      - name: Commit changes
-        if: failure()
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add typedefs/
-          git commit -m "chore: update gql types"
-          git push
-
-      # Create a pull request if changes were committed
+        # This will only create a PR if there are diffs created by yarn generate
       - name: Create Pull Request
-        if: failure()
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: update gql types"
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
           title: "chore: update gql types"
           body: "This PR updates the GraphQL types."
           branch: "update-gql-types"
+          base: "main"
+          delete-branch: true
+        


### PR DESCRIPTION
✅ Resolves #1032 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Before this `cron` job was running but wasn't actually making a PR and exiting with an error code of 1 as seen in the before screenshot. Now it will run the script and if there are differences make a PR successfully as seen in #1034 automatically. After testing this was moved back to a `cron` job.

This uses this workflow action --> https://github.com/peter-evans/create-pull-request/tree/v5/
A PR will not be created if it isn't ahead of `main` as seen in the screenshot below.
## 📸 Screenshots

-   ### Before
![image](https://github.com/user-attachments/assets/3f9c4c9e-62af-43cc-8bc6-cf4ab1cc234a)
![image](https://github.com/user-attachments/assets/7522d4f3-8e28-4eb3-ba27-f06e75ce4c95)

-   ### After

![image](https://github.com/user-attachments/assets/df68c567-0c88-4005-b1f7-0cb9924df525)

![image](https://github.com/user-attachments/assets/72ebce39-9ea3-4585-b2ec-2f55d5ddaeb0)


