### PR TITLE
fix: remove unnecessary `defineProps` import

### DIFF
--- a/components/SearchResultsListItem.vue
+++ b/components/SearchResultsListItem.vue
@@ -48,7 +48,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineProps } from 'vue'
+import { computed } from 'vue'
 import SVGProfileIcon from '~/assets/icons/profile-icon.svg'
 import SVGChatBubblesIcon from '~/assets/icons/chat-bubbles.svg'
 import { useLocaleStore } from '~/stores/localeStore.js'


### PR DESCRIPTION
✅ Resolves #1046 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
`defineProps` was being unnecessarily imported since now it is a compiler macro. So it was removed from the import in the file where not necessary.

## 📸 Screenshots

-   ### Before
![image](https://github.com/user-attachments/assets/810b2fec-47b5-4217-bd1f-3e328f682abc)

-   ### After
![image](https://github.com/user-attachments/assets/1e25aff2-bd3d-4600-9e27-f30d11a0d850)

