### PR TITLE
fix: remove global variable declaration of env for cypress

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,15 +1,4 @@
-/* eslint-disable @typescript-eslint/no-namespace */
 import { defineConfig } from 'cypress'
-
-declare global {
-    namespace NodeJS {
-        interface ProcessEnv {
-            AUTH0_DOMAIN: string
-            AUTH0_USERNAME: string
-            AUTH0_PASSWORD: string
-        }
-    }
-}
 
 const config = defineConfig({
     projectId: 'brkojt',


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Before the global variable for auth env variables was being declared within the `cypress.config.ts`. Now it was removed since it caused CI/CD to fail and was unnecessary for tests
## 🧪 Testing instructions
CI/CD passes now

## 📸 Screenshots

-   ### Before
![image](https://github.com/user-attachments/assets/0187ca71-a8d3-40e5-99fb-23fdebb12b2e)


