### PR TITLE
fix: add a doctor page is centered for both firefox and chrome

### DIFF
--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -3,7 +3,7 @@
         <Loader v-show="!isFormInitialized" />
         <form
             v-show="isFormInitialized"
-            class="flex flex-col place-self-center"
+            class="flex flex-col items-center"
         >
             <h1
                 data-testid="submit-heading"


### PR DESCRIPTION
✅ Resolves #1076 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review


## 🔧 What changed
In the submission form, changed place-self-center to items-center to put the add doctor form content in the center of the page

## 🧪 Testing instructions
pull this branch to your local machine, and try going to the add a doctor page. You should see the content in the center of the page for both firefox and chrome

## 📸 Screenshots

-   ### Before

Chrome

![Screenshot 2025-04-02 144526](https://github.com/user-attachments/assets/0d075742-c48b-4ad9-9707-e4929c42866e)

Firefox

![Screenshot 2025-04-02 144544](https://github.com/user-attachments/assets/c29a527d-b1f4-4c99-b520-094b3fb2e8ac)



-   ### After

Chrome

![Screenshot 2025-04-02 144631](https://github.com/user-attachments/assets/83936473-fea7-4ce5-8e09-f110488ba254)


Firefox

![Screenshot 2025-04-02 144614](https://github.com/user-attachments/assets/c48af18d-58f4-4932-b7a6-fe89888e88f7)


