### PR TITLE
fix: fix clrf line endings on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,7 +13,7 @@
 ##   Handle line endings automatically for files detected as
 ##   text and leave all files detected as binary untouched.
 ##   This will handle all files NOT defined below.
-*                 text=auto
+*                 text eol=lf
 
 # Source code
 *.bash            text eol=lf


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed
- Added fix for windows `clrf` line endings. This should stop them from being generated and use `lf` instead
