### PR TITLE
feat: add leftNavBar for Healthcare Professional

### DIFF
--- a/components/ModEditHealthcareProfessionalSection.vue
+++ b/components/ModEditHealthcareProfessionalSection.vue
@@ -1,7 +1,10 @@
 <template>
     <Loader />
     <div v-if="isHealthcareProfessionalInitialized">
-        <div class="mod-healthcare-professional-section">
+        <div
+            :id="ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalName"
+            class="mod-healthcare-professional-section"
+        >
             <h2 class="mb-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal">
                 {{ $t('modHealthcareProfessionalSection.healthcareProfessionalNameHeading') }}
             </h2>
@@ -133,6 +136,7 @@
                     {{ $t('modHealthcareProfessionalSection.addHealthCareProfessionalLocaleName') }}
                 </button>
                 <h2
+                    :id="ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalMedicalInfo"
                     class="mod-healthcare-professional-section
                      my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
                 >
@@ -232,6 +236,7 @@
                 </ol>
             </div>
             <h2
+                :id="ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalFacilities"
                 class="mod-healthcare-professional-section
                  my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
             >

--- a/components/ModHealthcareProfessionalLeftNavbar.vue
+++ b/components/ModHealthcareProfessionalLeftNavbar.vue
@@ -1,0 +1,95 @@
+<template>
+    <div class="flex flex-col">
+        <h1 class="font-bold text-lg p-1 mb-2 text-ellipsis">
+            {{ moderationSubmissionsStore.selectedSubmissionData?.facility?.nameEn
+                || $t("modPanelSubmissionLeftNavbar.facilityNameUnknown") }}
+        </h1>
+        <div class="flex flex-col items-start">
+            <button
+                data-testid="submission-form-leftnav-healthcare-professional-name"
+                :class="{
+                    'bg-secondary': activeSection === ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalName,
+                    'bg-primary-inverted': activeSection
+                        !== ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalName,
+                }"
+                class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
+                @click="handleNavClick(ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalName)"
+            >
+                {{ $t("modPanelSubmissionLeftNavbar.healthcareProfessionalName") }}
+            </button>
+
+            <button
+                data-testid="submission-form-leftnav-healthcare-professional-medical-info"
+                :class="{
+                    'bg-secondary': activeSection
+                        === ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalMedicalInfo,
+                    'bg-primary-inverted': activeSection
+                        !== ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalMedicalInfo,
+                }"
+                class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
+                @click="handleNavClick(ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalMedicalInfo)"
+            >
+                {{ $t("modPanelSubmissionLeftNavbar.healthcareProfessionalMedicalInfo") }}
+            </button>
+
+            <button
+                data-testid="submission-form-leftnav-healthcare-professional-facilities"
+                :class="{
+                    'bg-secondary': activeSection
+                        === ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalFacilities,
+                    'bg-primary-inverted': activeSection
+                        !== ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalFacilities,
+                }"
+                class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
+                @click="handleNavClick(
+                    ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalFacilities)"
+            >
+                {{ $t("modPanelSubmissionLeftNavbar.healthcareProfessionalFacilities") }}
+            </button>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, type Ref, onMounted, onUnmounted } from 'vue'
+import { useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
+import { ModHealthcareProfessionalsLeftNavbarSections } from '~/stores/moderationScreenStore'
+import { handleScroll, observeFormSections, scrollToSectionOfForm, type SectionInformation } from '~/utils/handleScroll'
+
+const moderationSubmissionsStore = useModerationSubmissionsStore()
+const activeSection: Ref<string> = ref(ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalName)
+const isScrolling: Ref<boolean> = ref(false)
+
+const modLeftNavElementIdArray: SectionInformation[] = [
+    {
+        sectionTitle: 'healthcare-professional-medical-info',
+        sectionElementIdToScrollTo: ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalMedicalInfo
+    },
+    {
+        sectionTitle: 'healthcare-professional-related-facilities',
+        sectionElementIdToScrollTo: ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalFacilities
+    },
+    {
+        sectionTitle: 'healthcare-professional-name',
+        sectionElementIdToScrollTo: ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalName
+    }
+]
+
+const onScroll = () => {
+    handleScroll(modLeftNavElementIdArray, isScrolling, activeSection)
+}
+
+const handleNavClick = (sectionId: string) => {
+    scrollToSectionOfForm(sectionId)
+    activeSection.value = sectionId
+}
+
+onMounted(() => {
+    observeFormSections(modLeftNavElementIdArray, isScrolling, activeSection)
+    window.addEventListener('scroll', onScroll)
+})
+
+onUnmounted(() => {
+    window.removeEventListener('scroll', onScroll)
+})
+</script>

--- a/components/ModLeftNavbar.vue
+++ b/components/ModLeftNavbar.vue
@@ -8,7 +8,7 @@
         </div>
         <div v-else-if="store.activeScreen === ModerationScreen.EditHealthcareProfessional">
             <p class="text-xl font-bold">
-                NAVBAR REVIEW HEALTHCARE PROFESSIONAL
+                <ModHealthcareProfessionalLeftNavbar />
             </p>
         </div>
         <div v-else-if="store.activeScreen === ModerationScreen.EditFacility">

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -297,7 +297,8 @@
     "googleMapsInformation": "Google maps information",
     "healthcareProfessionalIds": "Healthcare Professional IDs",
     "healthcareProfessionalName": "Healthcare Professional Name",
-    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info"
+    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info",
+    "healthcareProfessionalFacilities": "Healthcare Professional Facilities"
   },
   "modDashboardTopbar": {
     "placeholderText": "Enter name or ID to search",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -297,7 +297,8 @@
     "googleMapsInformation": "Google maps information",
     "healthcareProfessionalIds": "Healthcare Professional IDs",
     "healthcareProfessionalName": "Healthcare Professional Name",
-    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info"
+    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info",
+    "healthcareProfessionalFacilities": "Healthcare Professional Facilities"
   },
   "modDashboardTopbar": {
     "placeholderText": "Enter name or ID to search",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -141,7 +141,8 @@
         "googleMapsInformation": "Google maps information",
         "healthcareProfessionalIds": "Healthcare Professional IDs",
         "healthcareProfessionalName": "Healthcare Professional Name",
-        "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info"
+        "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info",
+        "healthcareProfessionalFacilities": "Healthcare Professional Facilities"
     },
     "modDashboardTopbar": {
         "placeholderText": "Enter name or ID to search",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -259,7 +259,8 @@
     "googleMapsInformation": "Google maps information",
     "healthcareProfessionalIds": "Healthcare Professional IDs",
     "healthcareProfessionalName": "Healthcare Professional Name",
-    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info"
+    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info",
+    "healthcareProfessionalFacilities": "Healthcare Professional Facilities"
   },
   "modDashboardTopbar": {
     "placeholderText": "Enter name or ID to search",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -141,7 +141,8 @@
     "googleMapsInformation": "Informazioni Google Maps",
     "healthcareProfessionalIds": "ID professionista sanitario",
     "healthcareProfessionalName": "Nome del professionista sanitario",
-    "healthcareProfessionalMedicalInfo": "Info mediche professionista"
+    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info",
+    "healthcareProfessionalFacilities": "Strutture collegate ai medici"
   },
   "modDashboardTopbar": {
     "placeholderText": "Inserisci nome o ID per la ricerca",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -298,7 +298,8 @@
     "googleMapsInformation": "Google maps information",
     "healthcareProfessionalIds": "Healthcare Professional IDs",
     "healthcareProfessionalName": "Healthcare Professional Name",
-    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info"
+    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info",
+    "healthcareProfessionalFacilities": "Healthcare Professional Facilities"
   },
   "modDashboardTopbar": {
     "placeholderText": "Enter name or ID to search",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -297,7 +297,8 @@
     "googleMapsInformation": "Google maps information",
     "healthcareProfessionalIds": "Healthcare Professional IDs",
     "healthcareProfessionalName": "Healthcare Professional Name",
-    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info"
+    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info",
+    "healthcareProfessionalFacilities": "Healthcare Professional Facilities"
   },
   "modDashboardTopbar": {
     "placeholderText": "Enter name or ID to search",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -297,7 +297,8 @@
     "googleMapsInformation": "Google maps information",
     "healthcareProfessionalIds": "Healthcare Professional IDs",
     "healthcareProfessionalName": "Healthcare Professional Name",
-    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info"
+    "healthcareProfessionalMedicalInfo": "Healthcare Professional Medical Info",
+    "healthcareProfessionalFacilities": "Healthcare Professional Facilities"
   },
   "modDashboardTopbar": {
     "placeholderText": "Enter name or ID to search",

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -135,7 +135,8 @@
     "googleMapsInformation": "Impormasyon sa Google maps ",
     "healthcareProfessionalIds": "Mga ID ng propesyonal sa Pangangalagang Pangkalusugan",
     "healthcareProfessionalName": "Pangalan ng propesyonal sa Pangangalagang Pangkalusugan",
-    "healthcareProfessionalMedicalInfo": "Medikal na impormasyon ng propesyonal sa Pangangalagang Pangkalusugan"
+    "healthcareProfessionalMedicalInfo": "Medikal na impormasyon ng propesyonal sa Pangangalagang Pangkalusugan",
+    "healthcareProfessionalFacilities": "Healthcare Professional Related Facilities"
   },
   "modDashboardTopbar": {
     "placeholderText": "Maglagay ng pangalan o ID upang mahanap",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -135,7 +135,8 @@
     "googleMapsInformation": "Thông tin Google Maps",
     "healthcareProfessionalIds": "Mã số chuyên gia y tế",
     "healthcareProfessionalName": "Tên chuyên gia y tế",
-    "healthcareProfessionalMedicalInfo": "Thông tin Y tế dành cho Chuyên gia Chăm sóc Sức khỏe"
+    "healthcareProfessionalMedicalInfo": "Thông tin Y tế dành cho Chuyên gia Chăm sóc Sức khỏe",
+    "healthcareProfessionalFacilities": "Healthcare Professional Related Facilities"
   },
   "modDashboardTopbar": {
     "placeholderText": "Nhập tên hoặc mã ID để tìm kiếm",

--- a/stores/moderationScreenStore.ts
+++ b/stores/moderationScreenStore.ts
@@ -18,6 +18,13 @@ export enum ModSubmissionLeftNavbarSectionIDs {
     HealthcareProfessionalName = 'HEALTHCARE_PROFESSIONAL_NAME'
 }
 
+export enum ModHealthcareProfessionalsLeftNavbarSections {
+    HealthcareProfessionalIds = 'HEALTHCARE_PROFESSIONAL_IDS',
+    HealthcareProfessionalMedicalInfo = 'HEALTHCARE_PROFESSIONAL_MEDICAL_INFO',
+    HealthcareProfessionalName = 'HEALTHCARE_PROFESSIONAL_NAME',
+    HealthcareProfessionalFacilities = 'HEALTHCARE_PROFESSIONAL_FACILITIES'
+}
+
 export const useModerationScreenStore = defineStore(
     'moderationScreenStore',
     () => {

--- a/utils/handleScroll.ts
+++ b/utils/handleScroll.ts
@@ -9,7 +9,6 @@ export const handleScroll
 = (sectionDetailsObject: SectionInformation[], isScrolling: Ref<boolean> = ref(false), activeSection: Ref<string> = ref('')) => {
     if (isScrolling.value) return
     let newActiveSection: string | null = null
-
     sectionDetailsObject.forEach(section => {
         let rect = null
         const foundSectionById = document.getElementById(section.sectionElementIdToScrollTo)


### PR DESCRIPTION
✅ Resolves #968
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Adds the ModHealthcareProfessionalLeftNavBar, add name also on i18n locales.
Mod Edit HealthcareProfessional has a left nav bar. Able to freely navigate by clicking.

The only little bug is when you click "Healthcare Professional Related Facilities". That section doesn't go at the top of the form, but i don't know if it's because the form is short or i have to modify utils/handleScroll

## 🧪 Testing instructions

## 📸 Screenshots

![image](https://github.com/user-attachments/assets/c2448784-2bdd-4e77-b3f8-977ea1518e68)

![image](https://github.com/user-attachments/assets/20c506b8-f130-4454-ac76-a4c517fc7955)

-   ### Before

-   ### After


