### PR TITLE
feat: add auth to API requests

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,3 +4,5 @@
 AUTH0_DOMAIN="https://findadoc.jp.auth0.com/"
 AUTH0_USERNAME="findadoctest@proton.me"
 AUTH0_PASSWORD="Your password here"
+AUTH0_CLIENTID="Your client ID here from https://manage.auth0.com/dashboard/jp/findadoc/applications/PnOZ9s1960Mnd5NuIxYAKyzqQVm2iesO/settings"
+AUTH0_CLIENTSECRET="Your client secret here from https://manage.auth0.com/dashboard/jp/findadoc/applications/PnOZ9s1960Mnd5NuIxYAKyzqQVm2iesO/settings"

--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,9 @@
 # .env.sample
-# Please make a copy of this file to `.env.test`, and update the password after contacting the main developers on slack to get the password
+# Please make a copy of this file to `.env`, and update the password after contacting the main developers on slack to get the password
 
 AUTH0_DOMAIN="https://findadoc.jp.auth0.com/"
 AUTH0_USERNAME="findadoctest@proton.me"
 AUTH0_PASSWORD="Your password here"
 AUTH0_CLIENTID="Your client ID here from https://manage.auth0.com/dashboard/jp/findadoc/applications/PnOZ9s1960Mnd5NuIxYAKyzqQVm2iesO/settings"
 AUTH0_CLIENTSECRET="Your client secret here from https://manage.auth0.com/dashboard/jp/findadoc/applications/PnOZ9s1960Mnd5NuIxYAKyzqQVm2iesO/settings"
+NUXT_AUTH_TOKEN_SECRET="Your secret here"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -38,17 +38,17 @@ jobs:
       - name: Install dependencies and build
         run: |
           yarn install
-          yarn prod:build
+          yarn ci:build
 
       - name: Start server and wait
         run: |
-          yarn prod:start &
+          yarn ci:start &
           npx wait-on http://localhost:3000
 
       - name: Run Cypress tests
         uses: cypress-io/github-action@v6
         with:
-          command: yarn test:e2e:prod
+          command: yarn test:e2e:ci
 
       - name: Upload screenshots
         if: failure()

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -44,6 +44,8 @@ jobs:
                 AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
                 AUTH0_USERNAME: ${{ secrets.AUTH0_USERNAME }}
                 AUTH0_PASSWORD: ${{ secrets.AUTH0_PASSWORD }}
+                AUTH0_CLIENTID: ${{ secrets.AUTH0_CLIENTID }}
+                AUTH0_CLIENTSECRET: ${{ secrets.AUTH0_CLIENTSECRET }}
               with:
                 command: yarn test:e2e:ci
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,57 +1,58 @@
 name: "Tests: Cypress e2e"
 
 on:
-    push:
-        branches: ["main"]
-    pull_request:
-        branches: ["main"]
-    schedule:
-        - cron: "45 15 * * 4"
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "45 15 * * 4"
+
 env:
+  NUXT_AUTH_TOKEN_SECRET: ${{ secrets.NUXT_AUTH_TOKEN_SECRET }}
+  AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+  AUTH0_USERNAME: ${{ secrets.AUTH0_USERNAME }}
+  AUTH0_PASSWORD: ${{ secrets.AUTH0_PASSWORD }}
+  AUTH0_CLIENTID: ${{ secrets.AUTH0_CLIENTID }}
+  AUTH0_CLIENTSECRET: ${{ secrets.AUTH0_CLIENTSECRET }}
   NUXT_PUBLIC_LOAD_STORES: true
+  NUXT_CYPRESS_TESTING: true
+
 jobs:
-    cypress-run:
-        name: Running Cypress tests ✨
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+  cypress-run:
+    name: Running Cypress tests ✨
+    runs-on: ubuntu-latest
 
-            - name: Cache yarn dependencies
-              uses: actions/cache@v3
-              with:
-                path: ~/.cache/yarn
-                key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                restore-keys: |
-                  ${{ runner.os }}-yarn-
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Log environment variable
-              run: echo "env_var=${{ env.LOAD_STORES }}"
+      - name: Cache yarn dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-            - name: Install dependencies and build
-              run: |
-                yarn install
-                yarn prod:build
+      - name: Install dependencies and build
+        run: |
+          yarn install
+          yarn prod:build
 
-            - name: Start server and wait
-              run: |
-                yarn prod:start &
-                npx wait-on http://localhost:3000
+      - name: Start server and wait
+        run: |
+          yarn prod:start &
+          npx wait-on http://localhost:3000
 
-            - name: Run Cypress tests
-              uses: cypress-io/github-action@v6
-              env:
-                AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
-                AUTH0_USERNAME: ${{ secrets.AUTH0_USERNAME }}
-                AUTH0_PASSWORD: ${{ secrets.AUTH0_PASSWORD }}
-                AUTH0_CLIENTID: ${{ secrets.AUTH0_CLIENTID }}
-                AUTH0_CLIENTSECRET: ${{ secrets.AUTH0_CLIENTSECRET }}
-              with:
-                command: yarn test:e2e:ci
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v6
+        with:
+          command: yarn test:e2e:prod
 
-            - name: Upload screenshots
-              uses: actions/upload-artifact@v4
-              if: failure()
-              with:
-                name: cypress-screenshots
-                path: cypress/screenshots
+      - name: Upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,7 +12,9 @@ const config = defineConfig({
             AUTH0_USERNAME: process.env.AUTH0_USERNAME,
             AUTH0_PASSWORD: process.env.AUTH0_PASSWORD,
             AUTH0_CLIENTID: process.env.AUTH0_CLIENTID,
-            AUTH0_CLIENTSECRET: process.env.AUTH0_CLIENTSECRET
+            AUTH0_CLIENTSECRET: process.env.AUTH0_CLIENTSECRET,
+            NUXT_AUTH_TOKEN_SECRET: process.env.NUXT_AUTH_TOKEN_SECRET,
+            CYPRESS_TESTING: process.env.CYPRESS_TESTING
         },
         setupNodeEvents() { },
         // Path to e2e specs folder

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig } from 'cypress'
+import dotenv from 'dotenv'
+
+// Load environment variables from .env file
+dotenv.config()
 
 const config = defineConfig({
     projectId: 'brkojt',
@@ -6,7 +10,9 @@ const config = defineConfig({
         env: {
             AUTH0_DOMAIN: process.env.AUTH0_DOMAIN,
             AUTH0_USERNAME: process.env.AUTH0_USERNAME,
-            AUTH0_PASSWORD: process.env.AUTH0_PASSWORD
+            AUTH0_PASSWORD: process.env.AUTH0_PASSWORD,
+            AUTH0_CLIENTID: process.env.AUTH0_CLIENTID,
+            AUTH0_CLIENTSECRET: process.env.AUTH0_CLIENTSECRET
         },
         setupNodeEvents() { },
         // Path to e2e specs folder

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -163,6 +163,10 @@ export default defineNuxtConfig({
         }
     },
     runtimeConfig: {
+        authTokenSecret: process.env.NUXT_AUTH_TOKEN_SECRET,
+
+        cypressTesting: process.env.NUXT_CYPRESS_TESTING,
+
         public: {
 
             GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -163,8 +163,6 @@ export default defineNuxtConfig({
         }
     },
     runtimeConfig: {
-        authTokenSecret: process.env.NUXT_AUTH_TOKEN_SECRET,
-
         cypressTesting: process.env.NUXT_CYPRESS_TESTING,
 
         public: {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
         "test": "yarn test:pinia --run && yarn test:e2e:ci",
         "test:pinia": "nuxi prepare && nuxi generate && vitest",
         "test:pinia:coverage": "vitest run --coverage",
-        "test:e2e": "dotenv -e .env.test -o -- cypress open",
-        "test:e2e:ci": "dotenv -e .env.test -o -- cypress run --e2e"
+        "test:e2e": "cypress open",
+        "test:e2e:ci": "cypress run --e2e"
     },
     "packageManager": "yarn@4.4.0",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
         "test": "yarn test:pinia --run && yarn test:e2e:ci",
         "test:pinia": "nuxi prepare && nuxi generate && vitest",
         "test:pinia:coverage": "vitest run --coverage",
-        "test:e2e": "cypress open",
-        "test:e2e:ci": "cypress run --e2e"
+        "test:e2e": "NUXT_CYPRESS_TESTING=true yarn dev:localserver & npx wait-on http://localhost:3000 && cypress open",
+        "test:e2e:headless": "NUXT_CYPRESS_TESTING=true yarn dev:localserver & npx wait-on http://localhost:3000 && cypress run --e2e",
+        "test:e2e:prod": "cypress run --e2e"
     },
     "packageManager": "yarn@4.4.0",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -13,13 +13,15 @@
         "lint:ci": "yarn prepare:ci && eslint . --config eslint.config.js --format @microsoft/eslint-formatter-sarif --output-file eslint-results.sarif",
         "prod:build": "yarn && yarn generate && nuxi generate",
         "prod:start": "nuxi start",
+        "ci:build": "yarn && yarn generate && nuxi generate && nuxi build",
+        "ci:start": "nuxi start",
         "prepare:ci": "nuxi prepare",
         "test": "yarn test:pinia --run && yarn test:e2e:ci",
         "test:pinia": "nuxi prepare && nuxi generate && vitest",
         "test:pinia:coverage": "vitest run --coverage",
         "test:e2e": "NUXT_CYPRESS_TESTING=true yarn dev:localserver & npx wait-on http://localhost:3000 && cypress open",
         "test:e2e:headless": "NUXT_CYPRESS_TESTING=true yarn dev:localserver & npx wait-on http://localhost:3000 && cypress run --e2e",
-        "test:e2e:prod": "cypress run --e2e"
+        "test:e2e:ci": "cypress run --e2e"
     },
     "packageManager": "yarn@4.4.0",
     "engines": {

--- a/server/api/auth-token.get.ts
+++ b/server/api/auth-token.get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(_ => {
+    // this code runs on the server only
+    const config = useRuntimeConfig()
+    return { token: config.authTokenSecret }
+})

--- a/server/api/auth-token.get.ts
+++ b/server/api/auth-token.get.ts
@@ -1,7 +1,0 @@
-import { defineEventHandler } from 'h3'
-
-export default defineEventHandler(_ => {
-    // this code runs on the server only
-    const config = useRuntimeConfig()
-    return { token: config.authTokenSecret }
-})

--- a/server/api/test-environment.get.ts
+++ b/server/api/test-environment.get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(_ => {
+    // this code runs on the server only
+    const config = useRuntimeConfig()
+    return { testingEnvironment: config.cypressTesting }
+})

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -47,7 +47,7 @@ export const useAuthStore = defineStore('authStore', () => {
             const startTime = Date.now()
             while (auth0?.isLoading.value) {
             // wait for the auth0 object to be ready
-                await new Promise(resolve => setTimeout(resolve, 50))
+                await new Promise(resolve => setTimeout(resolve, 100))
 
                 // break the loop after 10 seconds to avoid infinite loop
                 if (Date.now() - startTime > 10000) {
@@ -56,13 +56,14 @@ export const useAuthStore = defineStore('authStore', () => {
                 }
             }
 
-            if (!isLoggedIn.value) {
+            if (!auth0?.isAuthenticated.value) {
                 return undefined
             }
 
             const token = await auth0?.getAccessTokenSilently({
                 authorizationParams: {
-                    audience: 'https://findadoc.jp.auth0.com' // our Auth0 API identifier
+                    audience: 'findadoc',
+                    tokenSigningAlg: 'RS256'
                 }
             })
             return token

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -117,11 +117,7 @@ export const useFacilitiesStore = defineStore(
                 updateFacilityInput
             )
 
-            serverResponse.data = response.data?.updateFacility
-            serverResponse.errors = response.errors ? response.errors : []
-            serverResponse.hasErrors = response.hasErrors
-
-            if (!serverResponse.errors.length) {
+            if (!serverResponse.errors?.length) {
                 // update the necessary values with the updated response
                 selectedFacilityData.value = serverResponse.data!
                 initializeFacilitySectionValues(serverResponse.data!)

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -1,10 +1,14 @@
 import { defineStore } from 'pinia'
 import { ref, type Ref, reactive } from 'vue'
 import { gql } from 'graphql-request'
-import type { Maybe } from 'graphql/jsutils/Maybe'
-import type { DeleteResult, Facility,
+import type { DeleteResult,
+    Facility,
     HealthcareProfessional,
-    Mutation, MutationDeleteFacilityArgs, MutationUpdateFacilityArgs, Query, Relationship } from '~/typedefs/gqlTypes'
+    Mutation,
+    MutationDeleteFacilityArgs,
+    MutationUpdateFacilityArgs,
+    Query,
+    Relationship } from '~/typedefs/gqlTypes'
 import { gqlClient, graphQLClientRequestWithRetry } from '~/utils/graphql'
 import type { ServerResponse } from '~/typedefs/serverResponse'
 

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -4,7 +4,7 @@ import { gql } from 'graphql-request'
 import type { Maybe } from 'graphql/jsutils/Maybe'
 import type { DeleteResult, Facility,
     HealthcareProfessional,
-    Mutation, MutationDeleteFacilityArgs, MutationUpdateFacilityArgs, Relationship } from '~/typedefs/gqlTypes'
+    Mutation, MutationDeleteFacilityArgs, MutationUpdateFacilityArgs, Query, Relationship } from '~/typedefs/gqlTypes'
 import { gqlClient, graphQLClientRequestWithRetry } from '~/utils/graphql'
 import type { ServerError, ServerResponse } from '~/typedefs/serverResponse'
 
@@ -168,8 +168,13 @@ async function queryFacilities() {
         }
     }
     try {
-        const response = await gqlClient.request<{ facilities: Facility[] }>(getAllFacilitiesForModeration, searchFacilitiesData)
-        return response?.facilities ?? []
+        const response = await graphQLClientRequestWithRetry<Query['facilities']>(
+            gqlClient.request.bind(gqlClient),
+            getAllFacilitiesForModeration,
+            searchFacilitiesData
+        )
+
+        return response?.data as Facility[] ?? []
     } catch (error) {
         console.error(`Error querying the facilities: ${JSON.stringify(error)}`)
         return []

--- a/stores/healthcareProfessionalsStore.ts
+++ b/stores/healthcareProfessionalsStore.ts
@@ -83,9 +83,7 @@ export const useHealthcareProfessionalsStore = defineStore(
         }
 
         async function updateHealthcareProfessional():
-        Promise<ServerResponse<Maybe<HealthcareProfessional>>> {
-            const serverResponse = { data: {} as Maybe<HealthcareProfessional>, errors: [] as ServerError[], hasErrors: false }
-
+        Promise<ServerResponse<HealthcareProfessional>> {
             const facilitiesForRelationshipCreationArray = selectedFacilities.value
 
             // This is the array to be sent to the backend if there is a change in the relations
@@ -110,31 +108,27 @@ export const useHealthcareProfessionalsStore = defineStore(
                 }
             }
 
-            const response = await graphQLClientRequestWithRetry<Mutation>(
+            const serverResponse = await graphQLClientRequestWithRetry<Mutation['updateHealthcareProfessional']>(
                 gqlClient.request.bind(gqlClient),
                 updateHealthcareProfessionalGqlMutation,
                 updateHealthcareProfessionalInput
             )
 
-            serverResponse.data = response.data?.updateHealthcareProfessional
-            serverResponse.errors = response.errors
-                ? response.errors
-                : []
-            serverResponse.hasErrors = response.hasErrors
+            const responseData = serverResponse.data
 
             if (!serverResponse.errors.length && serverResponse.data) {
                 //This finds the index of the healthcare professional so we can replace the ones we have already queried
                 const outdatedHealthcareProfessionalIndex = healthcareProfessionalsData.value.findIndex(
-                    (healthcareProfessional: HealthcareProfessional) => healthcareProfessional.id === serverResponse.data!.id
+                    (healthcareProfessional: HealthcareProfessional) => healthcareProfessional.id === responseData!.id
                 )
 
                 //This will replace the data we had from the index with the new data
                 if (outdatedHealthcareProfessionalIndex !== -1) {
-                    healthcareProfessionalsData.value[outdatedHealthcareProfessionalIndex] = serverResponse.data!
+                    healthcareProfessionalsData.value[outdatedHealthcareProfessionalIndex] = responseData!
                 }
 
                 //This will update the data with what was returned from the server and is in our database
-                updateHealthcareProfessionalSectionFields(serverResponse.data!)
+                updateHealthcareProfessionalSectionFields(responseData!)
 
                 /*This resets the names we removed and kept track of in
                 order to change Locales if the wrong name for a locale was chosen */
@@ -192,18 +186,12 @@ export const useHealthcareProfessionalsStore = defineStore(
         }
 
         async function deleteHealthcareProfessional(healthcareProfessionalId: MutationDeleteHealthcareProfessionalArgs):
-        Promise<ServerResponse<Maybe<DeleteResult>>> {
-            const serverResponse = { data: {} as Maybe<DeleteResult>, errors: [] as ServerError[], hasErrors: false }
-
-            const response = await graphQLClientRequestWithRetry<Mutation>(
+        Promise<ServerResponse<DeleteResult>> {
+            const serverResponse = await graphQLClientRequestWithRetry<Mutation['deleteHealthcareProfessional']>(
                 gqlClient.request.bind(gqlClient),
                 deleteHealthcareProfessionalGqlMutation,
                 healthcareProfessionalId
             )
-
-            serverResponse.data = response.data?.deleteHealthcareProfessional
-            serverResponse.errors = response.errors ? response.errors : []
-            serverResponse.hasErrors = response.hasErrors
 
             return serverResponse
         }
@@ -236,7 +224,7 @@ export const useHealthcareProfessionalsStore = defineStore(
     }
 )
 
-async function queryHealthcareProfessionals() {
+async function queryHealthcareProfessionals(): Promise<HealthcareProfessional[]> {
     const searchHealthcareProfessionalsData = {
         filters: {
             limit: 400
@@ -256,7 +244,7 @@ async function queryHealthcareProfessionals() {
     }
 }
 
-export async function getHealthcareProfessionalById(id: string) {
+export async function getHealthcareProfessionalById(id: string): Promise<HealthcareProfessional[]> {
     try {
         const queryData = {
             healthcareProfessionalId: id

--- a/stores/healthcareProfessionalsStore.ts
+++ b/stores/healthcareProfessionalsStore.ts
@@ -13,7 +13,8 @@ import { type Insurance,
     type Relationship,
     RelationshipAction,
     type CreateHealthcareProfessionalInput,
-    type MutationCreateHealthcareProfessionalArgs } from '~/typedefs/gqlTypes'
+    type MutationCreateHealthcareProfessionalArgs,
+    type Query } from '~/typedefs/gqlTypes'
 import { gqlClient, graphQLClientRequestWithRetry } from '~/utils/graphql'
 import { useLocaleStore } from '~/stores/localeStore'
 import type { ServerError, ServerResponse } from '~/typedefs/serverResponse'
@@ -242,10 +243,13 @@ async function queryHealthcareProfessionals() {
         }
     }
     try {
-        const response = await gqlClient
-            .request<{ healthcareProfessionals: HealthcareProfessional[] }>
-            (getAllHealthcareProfessionalsData, searchHealthcareProfessionalsData)
-        return response?.healthcareProfessionals ?? []
+        const response = await graphQLClientRequestWithRetry<Query['healthcareProfessionals']>(
+            gqlClient.request.bind(gqlClient),
+            getAllHealthcareProfessionalsData,
+            searchHealthcareProfessionalsData
+        )
+
+        return response?.data ?? []
     } catch (error) {
         console.error(`Error querying the healthcare professionals: ${JSON.stringify(error)}`)
         return []
@@ -257,15 +261,16 @@ export async function getHealthcareProfessionalById(id: string) {
         const queryData = {
             healthcareProfessionalId: id
         }
-        const result = await gqlClient.request<{ healthcareProfessional: HealthcareProfessional[] }>(
+        const result = await graphQLClientRequestWithRetry<Query['healthcareProfessionals']>(
+            gqlClient.request.bind(gqlClient),
             getHealthcareProfessionalByIdGqlQuery,
             queryData
         )
 
-        if (!result.healthcareProfessional) {
+        if (!result.data) {
             throw new Error('The Healthcare Professional ID doesn\'t exist')
         }
-        return result.healthcareProfessional
+        return result.data
     } catch (error: unknown) {
         console.error(`Error retrieving healthcare professional by id: ${id}: ${JSON.stringify(error)}`)
         return []

--- a/stores/locationsStore.ts
+++ b/stores/locationsStore.ts
@@ -57,7 +57,7 @@ async function queryFacilities(): Promise<Facility[]> {
             searchFacilitiesData
         )
 
-        return result?.data as Facility[] ?? []
+        return result.data ?? []
     } catch (error) {
         console.error(`Error getting facilities for dropdown: ${JSON.stringify(error)}`)
         // eslint-disable-next-line no-alert

--- a/stores/locationsStore.ts
+++ b/stores/locationsStore.ts
@@ -4,7 +4,7 @@ import { ref, type Ref } from 'vue'
 import { gqlClient } from '../utils/graphql.js'
 import { useLoadingStore } from './loadingStore.js'
 import { useLocaleStore } from './localeStore.js'
-import { Locale, type Facility, type FacilitySearchFilters } from '~/typedefs/gqlTypes.js'
+import { Locale, type Facility, type FacilitySearchFilters, type Query } from '~/typedefs/gqlTypes.js'
 
 export const useLocationsStore = defineStore('locationsStore', () => {
     const citiesDisplayOptions: Ref<string[]> = ref([])
@@ -51,8 +51,13 @@ async function queryFacilities(): Promise<Facility[]> {
             } satisfies FacilitySearchFilters
         }
 
-        const result = await gqlClient.request<{ facilities: Facility[] }>(searchFacilitiesQuery, searchFacilitiesData)
-        return result?.facilities ?? []
+        const result = await graphQLClientRequestWithRetry<Query['facilities']>(
+            gqlClient.request.bind(gqlClient),
+            searchFacilitiesQuery,
+            searchFacilitiesData
+        )
+
+        return result?.data as Facility[] ?? []
     } catch (error) {
         console.error(`Error getting facilities for dropdown: ${JSON.stringify(error)}`)
         // eslint-disable-next-line no-alert

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -1,7 +1,6 @@
 import { gql } from 'graphql-request'
 import { defineStore } from 'pinia'
 import { ref, type Ref } from 'vue'
-import type { Maybe } from 'graphql/jsutils/Maybe'
 import type { Submission, MutationUpdateSubmissionArgs, Mutation, Query } from '~/typedefs/gqlTypes.js'
 import { gqlClient, graphQLClientRequestWithRetry } from '~/utils/graphql.js'
 import type { ServerResponse } from '~/typedefs/serverResponse'

--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -93,13 +93,13 @@ async function queryProfessionals(searchSpecialty?: Specialty, searchLanguage?: 
             } satisfies HealthcareProfessionalSearchFilters
         }
 
-        const response = await graphQLClientRequestWithRetry<Query['healthcareProfessionals']>(
+        const serverResponse = await graphQLClientRequestWithRetry<Query['healthcareProfessionals']>(
             gqlClient.request.bind(gqlClient),
             searchProfessionalsQuery,
             searchProfessionalsData
         )
 
-        const professionalsSearchResult = (response?.data ?? []) as HealthcareProfessional[]
+        const professionalsSearchResult = serverResponse?.data ?? []
         return professionalsSearchResult
     } catch (error) {
         console.error(`Error getting professionals: ${JSON.stringify(error)}`)
@@ -127,13 +127,13 @@ async function queryFacilities(healthcareProfessionalIds: string[], searchCity?:
             } satisfies FacilitySearchFilters
         }
 
-        const response = await graphQLClientRequestWithRetry<Query['facilities']>(
+        const serverResponse = await graphQLClientRequestWithRetry<Query['facilities']>(
             gqlClient.request.bind(gqlClient),
             searchFacilitiesQuery,
             searchFacilitiesData
         )
 
-        const facilitiesSearchResults = response?.data as Facility[] ?? []
+        const facilitiesSearchResults = serverResponse?.data ?? []
 
         //filter the search results by location if a location is selected
         const locationFilteredSearchResults = searchCity

--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -9,7 +9,8 @@ import type { Locale,
     Facility,
     FacilitySearchFilters,
     HealthcareProfessional,
-    HealthcareProfessionalSearchFilters } from '~/typedefs/gqlTypes.js'
+    HealthcareProfessionalSearchFilters,
+    Query } from '~/typedefs/gqlTypes.js'
 
 type SearchResult = {
     professional: HealthcareProfessional
@@ -92,11 +93,13 @@ async function queryProfessionals(searchSpecialty?: Specialty, searchLanguage?: 
             } satisfies HealthcareProfessionalSearchFilters
         }
 
-        const response = await gqlClient.request<{ healthcareProfessionals: HealthcareProfessional[] }>(
-            searchProfessionalsQuery, searchProfessionalsData
+        const response = await graphQLClientRequestWithRetry<Query['healthcareProfessionals']>(
+            gqlClient.request.bind(gqlClient),
+            searchProfessionalsQuery,
+            searchProfessionalsData
         )
 
-        const professionalsSearchResult = (response?.healthcareProfessionals ?? []) as HealthcareProfessional[]
+        const professionalsSearchResult = (response?.data ?? []) as HealthcareProfessional[]
         return professionalsSearchResult
     } catch (error) {
         console.error(`Error getting professionals: ${JSON.stringify(error)}`)
@@ -124,8 +127,13 @@ async function queryFacilities(healthcareProfessionalIds: string[], searchCity?:
             } satisfies FacilitySearchFilters
         }
 
-        const response = await gqlClient.request<{ facilities: Facility[] }>(searchFacilitiesQuery, searchFacilitiesData)
-        const facilitiesSearchResults = (response?.facilities ?? []) as Facility[]
+        const response = await graphQLClientRequestWithRetry<Query['facilities']>(
+            gqlClient.request.bind(gqlClient),
+            searchFacilitiesQuery,
+            searchFacilitiesData
+        )
+
+        const facilitiesSearchResults = response?.data as Facility[] ?? []
 
         //filter the search results by location if a location is selected
         const locationFilteredSearchResults = searchCity

--- a/stores/submissionStore.ts
+++ b/stores/submissionStore.ts
@@ -10,13 +10,13 @@ export const useSubmissionStore = defineStore('submissionStore', () => {
 
     async function createNewSubmission(newSubmission: MutationCreateSubmissionArgs):
     Promise<ServerResponse<Mutation['createSubmission']>> {
-        const response = await graphQLClientRequestWithRetry<Mutation['createSubmission']>(
+        const serverResponse = await graphQLClientRequestWithRetry<Mutation['createSubmission']>(
             gqlClient.request.bind(gqlClient),
             createSubmissionMutation,
             newSubmission
         )
 
-        return response
+        return serverResponse
     }
 
     return { createNewSubmission,

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -1,30 +1,8 @@
 // ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
+// docs for this file
 // https://on.cypress.io/custom-commands
 // ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
-// https://docs.cypress.io/app/guides/authentication-testing/auth0-authentication
 import { auth0Login } from '../utils'
 
 Cypress.Commands.add('login', () => {
@@ -38,13 +16,22 @@ Cypress.Commands.add('login', () => {
 
     log.snapshot('Connecting to auth0')
 
-    cy.session(`auth0-${auth0UserName}`, () => {
+    // Generate a unique session ID using timestamp
+    const sessionId = `auth0-${auth0UserName}-${Date.now()}`
+
+    // Clear session and localStorage
+    cy.clearAllSessionStorage()
+    cy.clearAllLocalStorage()
+
+    cy.session(sessionId, () => {
         auth0Login()
     }, {
         validate: () => {
-            // https://auth0.com/docs/manage-users/cookies/authentication-api-cookies
-            // https://docs.cypress.io/api/commands/getcookie
-            cy.getCookie('auth0', { domain: 'findadoc.jp.auth0.com' }).should('exist')
+            // Wait for and validate the auth token
+            cy.getAllLocalStorage().should(localStorage => {
+                const localStorageKeys = Object.values(localStorage).map(store => Object.keys(store)).flat()
+                expect(localStorageKeys).to.include('auth_token', 'Auth token not found in localStorage')
+            })
         },
         cacheAcrossSpecs: true
     })

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -7,7 +7,6 @@ import { auth0Login } from '../utils'
 
 Cypress.Commands.add('login', () => {
     const auth0UserName = Cypress.env('AUTH0_USERNAME')
-
     const log = Cypress.log({
         displayName: 'AUTH0_LOGIN',
         message: [`🔐 Authenticating | ${auth0UserName}`],
@@ -35,7 +34,6 @@ Cypress.Commands.add('login', () => {
         },
         cacheAcrossSpecs: true
     })
-
     log.snapshot('Successfully logged in')
     log.end()
 })

--- a/test/cypress/utils.ts
+++ b/test/cypress/utils.ts
@@ -5,44 +5,44 @@ export type IncomingHttpRequest = CyHttpMessages.IncomingHttpRequest
 
 // https://docs.cypress.io/app/guides/authentication-testing/auth0-authentication
 export const auth0Login = () => {
-    // This is using auth0's programmatic API for testing purposes and doesn't use the UI flow
-    // This is primarily because there's a consent approval error that pops up we can't target and this is easier in general.
-      
-      const options = {
-        method: 'POST',
-        url: `https://findadoc.jp.auth0.com/oauth/token`,
-        body: {
-          grant_type: 'password',
-          connection: 'Username-Password-Authentication',
-          username: Cypress.env('AUTH0_USERNAME'),
-          password: Cypress.env('AUTH0_PASSWORD'),
-          scope: 'openid profile email',
-          client_id: Cypress.env('AUTH0_CLIENTID'),
-          client_secret: Cypress.env('AUTH0_CLIENTSECRET'),
-        },
-      }
+  // This is using auth0's programmatic API for testing purposes and doesn't use the UI flow
+  // This is primarily because there's a consent approval error that pops up we can't target and this is easier in general.
 
-      cy.request(options).then((response) => {
-        const { body } = response
-        const { access_token, id_token } = body
+    const options = {
+      method: 'POST',
+      url: `https://findadoc.jp.auth0.com/oauth/token`,
+      body: {
+        grant_type: 'password',
+        connection: 'Username-Password-Authentication',
+        audience: 'findadoc',
+        username: Cypress.env('AUTH0_USERNAME'),
+        password: Cypress.env('AUTH0_PASSWORD'),
+        scope: 'openid profile email',
+        client_id: Cypress.env('AUTH0_CLIENTID'),
+        client_secret: Cypress.env('AUTH0_CLIENTSECRET'),
+      },
+    }
 
-        //We want to store the auth token so tests can reuse it and not login for every test
-        cy.window().then((win) => {
-          win.localStorage.setItem('auth_token', access_token)
-          win.localStorage.setItem('id_token', id_token)
-        })
+    cy.request(options).then((response) => {
+      const { body } = response
+      const { access_token, id_token } = body
+
+      //We want to store the auth token so tests can reuse it and not login for every test
+      cy.window().then((win) => {
+        win.localStorage.setItem('auth_token', access_token)
+        win.localStorage.setItem('id_token', id_token)
       })
+    })
 }
 
 export const aliasQuery = (req: IncomingHttpRequest, operation: string, responseBody: unknown) => {
     /**
     * Check if the GraphQL operation is included in the request body
     **/
-    const hasOperation = (req: IncomingHttpRequest, operation: string): boolean => {
-        const { query } = req.body
-        return query && query.includes(operation)
-    }
-
+  const hasOperation = (req: IncomingHttpRequest, operation: string): boolean => {
+    const { query } = req.body
+    return query && query.includes(operation)
+  }
     /**
      * https://docs.cypress.io/api/commands/intercept#Interception-lifecycle
      *
@@ -53,24 +53,24 @@ export const aliasQuery = (req: IncomingHttpRequest, operation: string, response
      *
      * To prevent this, we set 'cache-control' to 'no-store', this prevents all the requests to be cached.
      **/
-    const preventRequestCache = (req: IncomingHttpRequest) => {
-        req.on('before:response', res => {
-            // force all API responses to not be cached
-            res.headers['cache-control'] = 'no-store'
-        })
-    }
-
-    preventRequestCache(req)
-
-    if (!hasOperation(req, operation)) {
-        req.continue()
-        return
-    }
-
-    req.alias = operation
-
-    req.reply({
-        statusCode: 200,
-        body: responseBody
+  const preventRequestCache = (req: IncomingHttpRequest) => {
+    req.on('before:response', res => {
+      // force all API responses to not be cached
+      res.headers['cache-control'] = 'no-store'
     })
+  }
+
+  preventRequestCache(req)
+
+  if (!hasOperation(req, operation)) {
+    req.continue()
+    return
+  }
+
+  req.alias = operation
+
+  req.reply({
+    statusCode: 200,
+    body: responseBody
+  })
 }

--- a/typedefs/gqlTypes.ts
+++ b/typedefs/gqlTypes.ts
@@ -265,16 +265,16 @@ export type ModerationAutofillDatabaseSubmissionInput = {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  createFacility?: Maybe<Facility>;
-  createHealthcareProfessional?: Maybe<HealthcareProfessional>;
-  createSubmission?: Maybe<Submission>;
-  deleteFacility?: Maybe<DeleteResult>;
-  deleteHealthcareProfessional?: Maybe<DeleteResult>;
-  deleteSubmission?: Maybe<DeleteResult>;
-  moderationPanelUpdateSubmission?: Maybe<Submission>;
-  updateFacility?: Maybe<Facility>;
-  updateHealthcareProfessional?: Maybe<HealthcareProfessional>;
-  updateSubmission?: Maybe<Submission>;
+  createFacility: Facility;
+  createHealthcareProfessional: HealthcareProfessional;
+  createSubmission: Submission;
+  deleteFacility: DeleteResult;
+  deleteHealthcareProfessional: DeleteResult;
+  deleteSubmission: DeleteResult;
+  moderationPanelUpdateSubmission: Submission;
+  updateFacility: Facility;
+  updateHealthcareProfessional: HealthcareProfessional;
+  updateSubmission: Submission;
 };
 
 
@@ -374,12 +374,12 @@ export type PhysicalAddressInput = {
 export type Query = {
   __typename?: 'Query';
   auditLog?: Maybe<AuditLog>;
-  facilities?: Maybe<Array<Maybe<Facility>>>;
+  facilities: Array<Facility>;
   facility?: Maybe<Facility>;
   healthcareProfessional?: Maybe<HealthcareProfessional>;
-  healthcareProfessionals?: Maybe<Array<Maybe<HealthcareProfessional>>>;
+  healthcareProfessionals: Array<HealthcareProfessional>;
   submission?: Maybe<Submission>;
-  submissions?: Maybe<Array<Maybe<Submission>>>;
+  submissions: Array<Submission>;
 };
 
 
@@ -751,16 +751,16 @@ export type LocalizedNameResolvers<ContextType = any, ParentType extends Resolve
 };
 
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
-  createFacility?: Resolver<Maybe<ResolversTypes['Facility']>, ParentType, ContextType, RequireFields<MutationCreateFacilityArgs, 'input'>>;
-  createHealthcareProfessional?: Resolver<Maybe<ResolversTypes['HealthcareProfessional']>, ParentType, ContextType, RequireFields<MutationCreateHealthcareProfessionalArgs, 'input'>>;
-  createSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationCreateSubmissionArgs, 'input'>>;
-  deleteFacility?: Resolver<Maybe<ResolversTypes['DeleteResult']>, ParentType, ContextType, RequireFields<MutationDeleteFacilityArgs, 'id'>>;
-  deleteHealthcareProfessional?: Resolver<Maybe<ResolversTypes['DeleteResult']>, ParentType, ContextType, RequireFields<MutationDeleteHealthcareProfessionalArgs, 'id'>>;
-  deleteSubmission?: Resolver<Maybe<ResolversTypes['DeleteResult']>, ParentType, ContextType, RequireFields<MutationDeleteSubmissionArgs, 'id'>>;
-  moderationPanelUpdateSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationModerationPanelUpdateSubmissionArgs, 'input'>>;
-  updateFacility?: Resolver<Maybe<ResolversTypes['Facility']>, ParentType, ContextType, RequireFields<MutationUpdateFacilityArgs, 'id' | 'input'>>;
-  updateHealthcareProfessional?: Resolver<Maybe<ResolversTypes['HealthcareProfessional']>, ParentType, ContextType, RequireFields<MutationUpdateHealthcareProfessionalArgs, 'id' | 'input'>>;
-  updateSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationUpdateSubmissionArgs, 'id' | 'input'>>;
+  createFacility?: Resolver<ResolversTypes['Facility'], ParentType, ContextType, RequireFields<MutationCreateFacilityArgs, 'input'>>;
+  createHealthcareProfessional?: Resolver<ResolversTypes['HealthcareProfessional'], ParentType, ContextType, RequireFields<MutationCreateHealthcareProfessionalArgs, 'input'>>;
+  createSubmission?: Resolver<ResolversTypes['Submission'], ParentType, ContextType, RequireFields<MutationCreateSubmissionArgs, 'input'>>;
+  deleteFacility?: Resolver<ResolversTypes['DeleteResult'], ParentType, ContextType, RequireFields<MutationDeleteFacilityArgs, 'id'>>;
+  deleteHealthcareProfessional?: Resolver<ResolversTypes['DeleteResult'], ParentType, ContextType, RequireFields<MutationDeleteHealthcareProfessionalArgs, 'id'>>;
+  deleteSubmission?: Resolver<ResolversTypes['DeleteResult'], ParentType, ContextType, RequireFields<MutationDeleteSubmissionArgs, 'id'>>;
+  moderationPanelUpdateSubmission?: Resolver<ResolversTypes['Submission'], ParentType, ContextType, RequireFields<MutationModerationPanelUpdateSubmissionArgs, 'input'>>;
+  updateFacility?: Resolver<ResolversTypes['Facility'], ParentType, ContextType, RequireFields<MutationUpdateFacilityArgs, 'id' | 'input'>>;
+  updateHealthcareProfessional?: Resolver<ResolversTypes['HealthcareProfessional'], ParentType, ContextType, RequireFields<MutationUpdateHealthcareProfessionalArgs, 'id' | 'input'>>;
+  updateSubmission?: Resolver<ResolversTypes['Submission'], ParentType, ContextType, RequireFields<MutationUpdateSubmissionArgs, 'id' | 'input'>>;
 };
 
 export type PhysicalAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['PhysicalAddress'] = ResolversParentTypes['PhysicalAddress']> = {
@@ -778,12 +778,12 @@ export type PhysicalAddressResolvers<ContextType = any, ParentType extends Resol
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {
   auditLog?: Resolver<Maybe<ResolversTypes['AuditLog']>, ParentType, ContextType, Partial<QueryAuditLogArgs>>;
-  facilities?: Resolver<Maybe<Array<Maybe<ResolversTypes['Facility']>>>, ParentType, ContextType, RequireFields<QueryFacilitiesArgs, 'filters'>>;
+  facilities?: Resolver<Array<ResolversTypes['Facility']>, ParentType, ContextType, RequireFields<QueryFacilitiesArgs, 'filters'>>;
   facility?: Resolver<Maybe<ResolversTypes['Facility']>, ParentType, ContextType, RequireFields<QueryFacilityArgs, 'id'>>;
   healthcareProfessional?: Resolver<Maybe<ResolversTypes['HealthcareProfessional']>, ParentType, ContextType, RequireFields<QueryHealthcareProfessionalArgs, 'id'>>;
-  healthcareProfessionals?: Resolver<Maybe<Array<Maybe<ResolversTypes['HealthcareProfessional']>>>, ParentType, ContextType, RequireFields<QueryHealthcareProfessionalsArgs, 'filters'>>;
+  healthcareProfessionals?: Resolver<Array<ResolversTypes['HealthcareProfessional']>, ParentType, ContextType, RequireFields<QueryHealthcareProfessionalsArgs, 'filters'>>;
   submission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<QuerySubmissionArgs, 'id'>>;
-  submissions?: Resolver<Maybe<Array<Maybe<ResolversTypes['Submission']>>>, ParentType, ContextType, RequireFields<QuerySubmissionsArgs, 'filters'>>;
+  submissions?: Resolver<Array<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<QuerySubmissionsArgs, 'filters'>>;
 };
 
 export type SubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']> = {

--- a/typedefs/serverResponse.ts
+++ b/typedefs/serverResponse.ts
@@ -1,7 +1,7 @@
 import type { GraphQLError, SourceLocation } from 'graphql'
 
 export type ServerResponse<T> = {
-    data: T | undefined
+    data: T
     hasErrors: boolean
     errors?: ServerError[]
 }

--- a/utils/graphql.ts
+++ b/utils/graphql.ts
@@ -52,11 +52,17 @@ export const graphQLClientRequestWithRetry = async <T>(
 
             // Extract the first property from the response which contains our actual data.
             // In Grahpql, the default response has the property name matching the endpoint name.
-            // Ex. facilities endpoint returns { data: { facilities: T }}
-            // const flattenedResponseData = serverResponse.data ? Object.values(serverResponse.data as object)[0] as T : {} as T
+            // Ex. facilities endpoint returns { data: { facilities: T }, errors: []} or { facilities: T }
+            const flattenedResponseData = serverResponse.data
+                ? Object.values(serverResponse.data as object)[0] as T
+                : serverResponse
+                    ? Object.values(serverResponse as object)[0] as T
+                    : {} as T
 
-            // return { data: flattenedResponseData, errors: serverResponse.errors, hasErrors: serverResponse.hasErrors }
-            return serverResponse
+            return { data: flattenedResponseData,
+                errors: serverResponse.errors ?? [],
+                hasErrors: serverResponse.hasErrors } satisfies ServerResponse<T>
+            // return serverResponse
         } catch (error) {
             if (attempts < retryAmount) {
                 attempts++


### PR DESCRIPTION
Resolves #574
Resolves #571 

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

**NOTE: Mod panel testing is not working right now. It's unrelated to the changes, it just never worked yet with real auth connected. Let's fix this in a separate issue/PR. I spent about 5 hours on it already.** 


## 🔧 What changed

### Auth
- Added auth to every API request
- Built out auth token retrieval 

#### --Done in auth0 admin console --
- Created Roles for admin, user, and moderator roles in auth0. 
- Created an auth0 workflow automation to add roles into the auth JWT token. 
- Created a set of scopes (too much to copy here)
- Assigned scopes to roles
- Assigned roles to current users
- Set up ROPG password flow for testing

### Testing
- Changed to authenticate via API instead of manually clicking the login screen. This is because we were getting a consent popup that starts blocking our auth requests and will fail tests. 
- Had to do a ton of work to get this API login working. A lot of work on auth0 page. 


## 🧪 Testing instructions

- Everything should work on the site if you are logged in or an anonymous user
- Everything should work on the moderation dashboard if you are logged in. 
- You should NOT be able to  access the moderation dashboard without being logged in

