### PR TITLE
refactor: all non-dynamic :to attributes replaced with to attributes

### DIFF
--- a/components/HamburgerMenu.vue
+++ b/components/HamburgerMenu.vue
@@ -75,25 +75,25 @@
                         data-testid="hamburger-menu-items"
                         class="mt-10 px-5 flex flex-col gap-6"
                     >
-                        <NuxtLink :to="'/'">
+                        <NuxtLink to="/">
                             <div @click="closeMenu()">
                                 {{ $t('hamburgerMenu.home') }}
                             </div>
                         </NuxtLink>
-                        <NuxtLink :to="'/about'">
+                        <NuxtLink to="/about">
                             <div @click="closeMenu()">
                                 {{ $t('hamburgerMenu.about') }}
                             </div>
                         </NuxtLink>
                         <NuxtLink
-                            :to="'https://forms.gle/4E763qfaq46kEsn99'"
+                            to="https://forms.gle/4E763qfaq46kEsn99"
                             target="_blank"
                         >
                             <div @click="closeMenu()">
                                 {{ $t('hamburgerMenu.contact') }}
                             </div>
                         </NuxtLink>
-                        <NuxtLink :to="'/submit'">
+                        <NuxtLink to="/submit">
                             <div @click="closeMenu()">
                                 {{ $t('hamburgerMenu.submit') }}
                             </div>
@@ -113,12 +113,12 @@
                                     {{ authStore.userId }}
                                 </div>
                             </div>
-                            <NuxtLink :to="'/moderation'">
+                            <NuxtLink to="/moderation">
                                 <div @click="closeMenu()">
                                     {{ $t('hamburgerMenu.moderation') }}
                                 </div>
                             </NuxtLink>
-                            <NuxtLink :to="'/'">
+                            <NuxtLink to="/">
                                 <div @click="logout()">
                                     {{ $t('hamburgerMenu.logout') }}
                                 </div>
@@ -173,7 +173,7 @@
                         class="flex gap-4"
                     >
                         <NuxtLink
-                            :to="'/terms'"
+                            to="/terms"
                             data-testid="hamburger-menu-footer-legal-terms"
                         >
                             <span @click="closeMenu()">
@@ -181,7 +181,7 @@
                             </span>
                         </NuxtLink>
                         <NuxtLink
-                            :to="'/privacypolicy'"
+                            to="/privacypolicy"
                             data-testid="hamburger-menu-footer-legal-privacy"
                         >
                             <span @click="closeMenu()">
@@ -194,7 +194,7 @@
                         class="flex gap-6"
                     >
                         <NuxtLink
-                            :to="'https://github.com/ourjapanlife'"
+                            to="https://github.com/ourjapanlife"
                             target="_blank"
                         >
                             <SVGGithubIcon
@@ -205,7 +205,7 @@
                         </NuxtLink>
                         <!-- Netlify Icons are available here: https://www.netlify.com/press/#badges -->
                         <NuxtLink
-                            :to="'https://www.netlify.com'"
+                            to="https://www.netlify.com"
                             target="_blank"
                             data-testid="hamburger-menu-footer-dev-links-netlify"
                         >
@@ -233,7 +233,7 @@
                             >
                                 NPO
                                 <NuxtLink
-                                    :to="'https://www.npo-hiroba.or.jp/search/zoom.php?pk=121289'"
+                                    to="https://www.npo-hiroba.or.jp/search/zoom.php?pk=121289"
                                     target="_blank"
                                     class="underline"
                                 >#9011005010215
@@ -244,7 +244,7 @@
                                 class="ml-2 mt-0.5"
                             >
                                 <NuxtLink
-                                    :to="'https://docs.google.com/spreadsheets/d/1CafQoHn1NNNoRy35QSt_nUZcgKL8QN2M'"
+                                    to="https://docs.google.com/spreadsheets/d/1CafQoHn1NNNoRy35QSt_nUZcgKL8QN2M"
                                     target="_blank"
                                     class="underline"
                                 >{{ $t('hamburgerMenu.balancesheet') }}

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -66,17 +66,17 @@
                 class="portrait:hidden flex gap-4 mx-6 self-center whitespace-nowrap"
             >
                 <NuxtLink
-                    :to="'/about'"
+                    to="/about"
                     class="hover:text-primary-hover transition-colors"
                 >{{ $t('topNav.about') }}
                 </NuxtLink>
                 <NuxtLink
-                    :to="'/'"
+                    to="/"
                     class="hover:text-primary-hover transition-colors"
                 >{{ $t('topNav.home') }}
                 </NuxtLink>
                 <NuxtLink
-                    :to="'/submit'"
+                    to="/submit"
                     class="hover:text-primary-hover transition-colors"
                 >{{ $t('topNav.submit') }}
                 </NuxtLink>
@@ -86,14 +86,14 @@
                     class="flex text-primary"
                 >
                     <NuxtLink
-                        :to="'/moderation'"
+                        to="/moderation"
                         class="hover:text-primary-hover transition-colors text-wrap mr-4"
                         data-testid="top-nav-mod-link"
                     >{{
                         $t('topNav.moderation') }}
                     </NuxtLink>
                     <NuxtLink
-                        :to="'/'"
+                        to="/"
                         class="mr-4"
                     >
                         <div

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -23,7 +23,7 @@
                         <span>{{ $t('login.unauthorizedline1') }}</span>
                         <span>{{ $t('login.unauthorizedline2') }}</span>
                         <NuxtLink
-                            :to="'https://forms.gle/4E763qfaq46kEsn99'"
+                            to="https://forms.gle/4E763qfaq46kEsn99"
                             target="_blank"
                             class="inline text-primary underline"
                         >


### PR DESCRIPTION
✅ Resolves #1128
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [X] PR assignee has been selected
- [X] PR label has been selected
- [X] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
- all instances of ``:to`` attributes on NuxtLink elements without dynamic urls have been replaced with ``to`` attributes with only one set of double quotes
## 🧪 Testing instructions
- all links in the hamburger menu and topbar should work as expected
## 📸 Screenshots

-   ### Before
N/A
-   ### After
N/A

