### PR TITLE
fix: add Back button functionality to Edit Facility/Professional in the mod panel

### DIFF
--- a/components/ModEditFacilityOrProfessionalTopbar.vue
+++ b/components/ModEditFacilityOrProfessionalTopbar.vue
@@ -24,6 +24,16 @@
         <div class="facility-hp-topbar-actions flex justify p-2 font-bold ">
             <button
                 type="button"
+                class="flex justify-center items-center rounded-full bg-secondary-bg border-primary-text-muted 
+                border-2 w-28 text-sm mr-2"
+                data-testid="mod-edit-facility-hp-topbar-delete"
+                @click="cancelUpdateAndExit"
+            >
+                {{
+                    $t('modEditFacilityOrHPTopbar.back') }}
+            </button>
+            <button
+                type="button"
                 :disabled="!enableUpdateButtons"
                 class="flex justify-center items-center rounded-full bg-secondary-bg border-primary-text-muted
                 border-2 w-28 text-sm mr-2"
@@ -331,6 +341,11 @@ const deleteFacilityOrHealthcareProfessional = async () => {
         modalStore.hideModal()
         return response
     }
+}
+
+const cancelUpdateAndExit = () => {
+    router.push('/moderation')
+    moderationScreenStore.setActiveScreen(ModerationScreen.Dashboard)
 }
 
 onMounted(() => {

--- a/components/ModEditFacilityOrProfessionalTopbar.vue
+++ b/components/ModEditFacilityOrProfessionalTopbar.vue
@@ -24,7 +24,7 @@
         <div class="facility-hp-topbar-actions flex justify p-2 font-bold ">
             <button
                 type="button"
-                class="flex justify-center items-center rounded-full bg-secondary-bg border-primary-text-muted 
+                class="flex justify-center items-center rounded-full bg-secondary-bg border-primary-text-muted
                 border-2 w-28 text-sm mr-2"
                 data-testid="mod-edit-facility-hp-topbar-delete"
                 @click="cancelUpdateAndExit"

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -389,7 +389,8 @@
     "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
     "facilityDeletedSuccessfully": "Facility deleted successfully",
     "healthcareProfessionalDeletedSuccessfully": "Healthcare professional deleted successfully",
-    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully"
+    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully",
+    "back": "Back"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -389,7 +389,8 @@
     "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
     "facilityDeletedSuccessfully": "Facility deleted successfully",
     "healthcareProfessionalDeletedSuccessfully": "Healthcare professional deleted successfully",
-    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully"
+    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully",
+    "back": "Back"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -171,7 +171,8 @@
         "facilityDeletedSuccessfully": "Facility deleted successfully",
         "facilityUpdatedSuccessfully": "Facility updated successfully",
         "healthcareProfessionalDeletedSuccessfully": "Healthcare professional deleted successfully",
-        "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully"
+        "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully",
+        "back": "Back"
     },
     "modEditSubmissionTopNav": {
         "saveAndExit": "Save & Exit",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -351,7 +351,8 @@
     "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
     "facilityDeletedSuccessfully": "Facility deleted successfully",
     "healthcareProfessionalDeletedSuccessfully": "Healthcare professional deleted successfully",
-    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully"
+    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully",
+    "back": "Back"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -164,7 +164,8 @@
     "facilityDeletedSuccessfully": "Struttura eliminata con successo",
     "facilityUpdatedSuccessfully": "Struttura aggiornata con successo",
     "healthcareProfessionalDeletedSuccessfully": "Professionista sanitario eliminato con successo",
-    "healthcareProfessionalUpdatedSuccessfully": "Professionista sanitario aggiornato con successo"
+    "healthcareProfessionalUpdatedSuccessfully": "Professionista sanitario aggiornato con successo",
+    "back": "Back"
   },
   "modEditSubmissionTopNav": {
     "saveAndExit": "Salva & Esci",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -390,7 +390,8 @@
     "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
     "facilityDeletedSuccessfully": "Facility deleted successfully",
     "healthcareProfessionalDeletedSuccessfully": "Healthcare professional deleted successfully",
-    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully"
+    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully",
+    "back": "戻る"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -389,7 +389,8 @@
     "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
     "facilityDeletedSuccessfully": "Facility deleted successfully",
     "healthcareProfessionalDeletedSuccessfully": "Healthcare professional deleted successfully",
-    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully"
+    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully",
+    "back": "Back"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -389,7 +389,8 @@
     "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
     "facilityDeletedSuccessfully": "Facility deleted successfully",
     "healthcareProfessionalDeletedSuccessfully": "Healthcare professional deleted successfully",
-    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully"
+    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully",
+    "back": "Back"
   },
   "serverErrorMessages": {
     "UNAUTHENTICATED": "You do not have the authentication to do this action",

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -158,7 +158,9 @@
     "deleteConfirmationFacility": "Are you sure you want to delete the facility: {facility} , with ID: {id}?",
     "facilityDeletedSuccessfully": "Facility deleted successfully",
     "healthcareProfessionalDeletedSuccessfully": "Healthcare professional deleted successfully",
-    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully"
+    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully",
+    "back": "Bumalik"
+
   },
   "modEditSubmissionTopNav": {
     "saveAndExit": "I-Save at I-Exit",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -158,7 +158,8 @@
     "facilityDeletedSuccessfully": "Facility deleted successfully",
     "facilityUpdatedSuccessfully": "Facility updated successfully",
     "healthcareProfessionalDeletedSuccessfully": "Healthcare professional deleted successfully",
-    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully"
+    "healthcareProfessionalUpdatedSuccessfully": "Healthcare professional updated successfully",
+    "back": "Back"
   },
   "modEditSubmissionTopNav": {
     "saveAndExit": "Lưu và thoát.",


### PR DESCRIPTION
✅ Resolves #1136
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [X] PR assignee has been selected
- [X] PR label has been selected
- [X] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
- Added a "Back" button to the moderation screen to allow users to return to the dashboard without updating
- Created `cancelUpdateAndExit` method for navigating back
- Updated localization files:
  - Added new `modEditFacilityOrHPTopbar.back` key in English
  - Added translations for the "Back" button in Japanese and Tagalog
  - Added fallback "Back" string to other languages
- Ran the locale key checker to ensure all translation files include the new key

## 🧪 Testing instructions

**Back Button Functionality:**
1. Navigate to the moderation page and make sure the "Back" button is visible in the top bar
2. Click the "Back" button and ensure that the app returns to the dashboard
3. Ensure no update or changes are made to the facility or healthcare professional data

**Localization:**
1. Change the language of the app to **Japanese** and verify that the "Back" button displays as "戻る"
2. Change the language to **Tagalog** and verify that the "Back" button displays as "Bumalik"
3. In other languages, confirm that the button displays the English fallback "Back"

## 📸 Screenshots

-   ### Before
![image](https://github.com/user-attachments/assets/5765f9cb-f5d3-43c9-86a4-60ef026adeb6)

-   ### After
![image](https://github.com/user-attachments/assets/ad6fc634-2a89-4a01-9248-82eda33b4a63)

