### PR TITLE
feat(test): implement testing for auth

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,9 @@
 # .env.sample
-# Please make a copy of this file to `.env.test`, and update the password after contacting the main developers on slack to get the password
+# Please make a copy of this file to `.env`, and update the password after contacting the main developers on slack to get the password
 
 AUTH0_DOMAIN="https://findadoc.jp.auth0.com/"
 AUTH0_USERNAME="findadoctest@proton.me"
 AUTH0_PASSWORD="Your password here"
 AUTH0_CLIENTID="Your client ID here from https://manage.auth0.com/dashboard/jp/findadoc/applications/PnOZ9s1960Mnd5NuIxYAKyzqQVm2iesO/settings"
 AUTH0_CLIENTSECRET="Your client secret here from https://manage.auth0.com/dashboard/jp/findadoc/applications/PnOZ9s1960Mnd5NuIxYAKyzqQVm2iesO/settings"
+NUXT_AUTH_TOKEN_SECRET="Your secret here"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,57 +1,58 @@
 name: "Tests: Cypress e2e"
 
 on:
-    push:
-        branches: ["main"]
-    pull_request:
-        branches: ["main"]
-    schedule:
-        - cron: "45 15 * * 4"
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "45 15 * * 4"
+
 env:
+  NUXT_AUTH_TOKEN_SECRET: ${{ secrets.NUXT_AUTH_TOKEN_SECRET }}
+  AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
+  AUTH0_USERNAME: ${{ secrets.AUTH0_USERNAME }}
+  AUTH0_PASSWORD: ${{ secrets.AUTH0_PASSWORD }}
+  AUTH0_CLIENTID: ${{ secrets.AUTH0_CLIENTID }}
+  AUTH0_CLIENTSECRET: ${{ secrets.AUTH0_CLIENTSECRET }}
   NUXT_PUBLIC_LOAD_STORES: true
+  NUXT_CYPRESS_TESTING: true
+
 jobs:
-    cypress-run:
-        name: Running Cypress tests ✨
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+  cypress-run:
+    name: Running Cypress tests ✨
+    runs-on: ubuntu-latest
 
-            - name: Cache yarn dependencies
-              uses: actions/cache@v3
-              with:
-                path: ~/.cache/yarn
-                key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                restore-keys: |
-                  ${{ runner.os }}-yarn-
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Log environment variable
-              run: echo "env_var=${{ env.LOAD_STORES }}"
+      - name: Cache yarn dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
 
-            - name: Install dependencies and build
-              run: |
-                yarn install
-                yarn prod:build
+      - name: Install dependencies and build
+        run: |
+          yarn install
+          yarn prod:build
 
-            - name: Start server and wait
-              run: |
-                yarn prod:start &
-                npx wait-on http://localhost:3000
+      - name: Start server and wait
+        run: |
+          yarn prod:start &
+          npx wait-on http://localhost:3000
 
-            - name: Run Cypress tests
-              uses: cypress-io/github-action@v6
-              env:
-                AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
-                AUTH0_USERNAME: ${{ secrets.AUTH0_USERNAME }}
-                AUTH0_PASSWORD: ${{ secrets.AUTH0_PASSWORD }}
-                AUTH0_CLIENTID: ${{ secrets.AUTH0_CLIENTID }}
-                AUTH0_CLIENTSECRET: ${{ secrets.AUTH0_CLIENTSECRET }}
-              with:
-                command: yarn test:e2e:ci
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v6
+        with:
+          command: yarn test:e2e:prod
 
-            - name: Upload screenshots
-              uses: actions/upload-artifact@v4
-              if: failure()
-              with:
-                name: cypress-screenshots
-                path: cypress/screenshots
+      - name: Upload screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,7 +12,9 @@ const config = defineConfig({
             AUTH0_USERNAME: process.env.AUTH0_USERNAME,
             AUTH0_PASSWORD: process.env.AUTH0_PASSWORD,
             AUTH0_CLIENTID: process.env.AUTH0_CLIENTID,
-            AUTH0_CLIENTSECRET: process.env.AUTH0_CLIENTSECRET
+            AUTH0_CLIENTSECRET: process.env.AUTH0_CLIENTSECRET,
+            NUXT_AUTH_TOKEN_SECRET: process.env.NUXT_AUTH_TOKEN_SECRET,
+            CYPRESS_TESTING: process.env.CYPRESS_TESTING
         },
         setupNodeEvents() { },
         // Path to e2e specs folder

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -163,6 +163,10 @@ export default defineNuxtConfig({
         }
     },
     runtimeConfig: {
+        authTokenSecret: process.env.NUXT_AUTH_TOKEN_SECRET,
+
+        cypressTesting: process.env.NUXT_CYPRESS_TESTING,
+
         public: {
 
             GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY,

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
         "test": "yarn test:pinia --run && yarn test:e2e:ci",
         "test:pinia": "nuxi prepare && nuxi generate && vitest",
         "test:pinia:coverage": "vitest run --coverage",
-        "test:e2e": "cypress open",
-        "test:e2e:ci": "cypress run --e2e"
+        "test:e2e": "NUXT_CYPRESS_TESTING=true yarn dev:localserver & npx wait-on http://localhost:3000 && cypress open",
+        "test:e2e:headless": "NUXT_CYPRESS_TESTING=true yarn dev:localserver & npx wait-on http://localhost:3000 && cypress run --e2e",
+        "test:e2e:prod": "cypress run --e2e"
     },
     "packageManager": "yarn@4.4.0",
     "engines": {

--- a/server/api/auth-token.get.ts
+++ b/server/api/auth-token.get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(_ => {
+    // this code runs on the server only
+    const config = useRuntimeConfig()
+    return { token: config.authTokenSecret }
+})

--- a/server/api/test-environment.get.ts
+++ b/server/api/test-environment.get.ts
@@ -1,0 +1,7 @@
+import { defineEventHandler } from 'h3'
+
+export default defineEventHandler(_ => {
+    // this code runs on the server only
+    const config = useRuntimeConfig()
+    return { testingEnvironment: config.cypressTesting }
+})

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -7,7 +7,6 @@ import { auth0Login } from '../utils'
 
 Cypress.Commands.add('login', () => {
     const auth0UserName = Cypress.env('AUTH0_USERNAME')
-
     const log = Cypress.log({
         displayName: 'AUTH0_LOGIN',
         message: [`🔐 Authenticating | ${auth0UserName}`],
@@ -35,7 +34,6 @@ Cypress.Commands.add('login', () => {
         },
         cacheAcrossSpecs: true
     })
-
     log.snapshot('Successfully logged in')
     log.end()
 })

--- a/test/cypress/utils.ts
+++ b/test/cypress/utils.ts
@@ -5,44 +5,44 @@ export type IncomingHttpRequest = CyHttpMessages.IncomingHttpRequest
 
 // https://docs.cypress.io/app/guides/authentication-testing/auth0-authentication
 export const auth0Login = () => {
-    // This is using auth0's programmatic API for testing purposes and doesn't use the UI flow
-    // This is primarily because there's a consent approval error that pops up we can't target and this is easier in general.
-      
-      const options = {
-        method: 'POST',
-        url: `https://findadoc.jp.auth0.com/oauth/token`,
-        body: {
-          grant_type: 'password',
-          connection: 'Username-Password-Authentication',
-          username: Cypress.env('AUTH0_USERNAME'),
-          password: Cypress.env('AUTH0_PASSWORD'),
-          scope: 'openid profile email',
-          client_id: Cypress.env('AUTH0_CLIENTID'),
-          client_secret: Cypress.env('AUTH0_CLIENTSECRET'),
-        },
-      }
+  // This is using auth0's programmatic API for testing purposes and doesn't use the UI flow
+  // This is primarily because there's a consent approval error that pops up we can't target and this is easier in general.
 
-      cy.request(options).then((response) => {
-        const { body } = response
-        const { access_token, id_token } = body
+    const options = {
+      method: 'POST',
+      url: `https://findadoc.jp.auth0.com/oauth/token`,
+      body: {
+        grant_type: 'password',
+        connection: 'Username-Password-Authentication',
+        audience: 'findadoc',
+        username: Cypress.env('AUTH0_USERNAME'),
+        password: Cypress.env('AUTH0_PASSWORD'),
+        scope: 'openid profile email',
+        client_id: Cypress.env('AUTH0_CLIENTID'),
+        client_secret: Cypress.env('AUTH0_CLIENTSECRET'),
+      },
+    }
 
-        //We want to store the auth token so tests can reuse it and not login for every test
-        cy.window().then((win) => {
-          win.localStorage.setItem('auth_token', access_token)
-          win.localStorage.setItem('id_token', id_token)
-        })
+    cy.request(options).then((response) => {
+      const { body } = response
+      const { access_token, id_token } = body
+
+      //We want to store the auth token so tests can reuse it and not login for every test
+      cy.window().then((win) => {
+        win.localStorage.setItem('auth_token', access_token)
+        win.localStorage.setItem('id_token', id_token)
       })
+    })
 }
 
 export const aliasQuery = (req: IncomingHttpRequest, operation: string, responseBody: unknown) => {
     /**
     * Check if the GraphQL operation is included in the request body
     **/
-    const hasOperation = (req: IncomingHttpRequest, operation: string): boolean => {
-        const { query } = req.body
-        return query && query.includes(operation)
-    }
-
+  const hasOperation = (req: IncomingHttpRequest, operation: string): boolean => {
+    const { query } = req.body
+    return query && query.includes(operation)
+  }
     /**
      * https://docs.cypress.io/api/commands/intercept#Interception-lifecycle
      *
@@ -53,24 +53,24 @@ export const aliasQuery = (req: IncomingHttpRequest, operation: string, response
      *
      * To prevent this, we set 'cache-control' to 'no-store', this prevents all the requests to be cached.
      **/
-    const preventRequestCache = (req: IncomingHttpRequest) => {
-        req.on('before:response', res => {
-            // force all API responses to not be cached
-            res.headers['cache-control'] = 'no-store'
-        })
-    }
-
-    preventRequestCache(req)
-
-    if (!hasOperation(req, operation)) {
-        req.continue()
-        return
-    }
-
-    req.alias = operation
-
-    req.reply({
-        statusCode: 200,
-        body: responseBody
+  const preventRequestCache = (req: IncomingHttpRequest) => {
+    req.on('before:response', res => {
+      // force all API responses to not be cached
+      res.headers['cache-control'] = 'no-store'
     })
+  }
+
+  preventRequestCache(req)
+
+  if (!hasOperation(req, operation)) {
+    req.continue()
+    return
+  }
+
+  req.alias = operation
+
+  req.reply({
+    statusCode: 200,
+    body: responseBody
+  })
 }


### PR DESCRIPTION
✅ Resolves #570
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Tests for auth are passing and use programmatic auth instead of the UI which is more consistent. We have server routes that protects attacks and changes the different types of environments.

One is for development,
One testing,
One production

Also scripts were made for testing to not need to run the server anymore for tests. The scripts will run the server based on each scenario and be separate from the manual testing.

## 🧪 Testing instructions
To test the dev locally you can run `yarn test:e2e`

To test the dev locally headless you can run `yarn test:e2e:headless`

To test the prod build locally you can build it. Then run `yarn test:e2e:prod`

