### PR TITLE
fix: fix catch block in loadSecret function

### DIFF
--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -19,7 +19,7 @@ export const useAuthStore = defineStore('authStore', () => {
                     }
                     return false
                 } catch (err) {
-                    if (checkForTestingEnvironment.testingEnvironment) console.error('Failed to fetch auth secret', err)
+                    if (!checkForTestingEnvironment.testingEnvironment) console.error('Failed to fetch auth secret', err)
                     throw err
                 }
             })()


### PR DESCRIPTION
✅ Resolves #1184 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected


## 🔧 What changed
The catch block had the wrong check making `loadSecret` not work properly for those in development. This led to developers not being able to access the mod dashboard locally

## 🧪 Testing instructions
CI/CD still passes.
You can run the local server and make it to the mod dashboard manually in dev mode
