### PR TITLE
refactor: call init onMounted in index and moderation pages

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -21,9 +21,13 @@
 
 <script setup lang="ts">
 import { useScreenOrientation } from '~/utils/useScreenOrientation'
-import { useModalStore } from '~/stores/modalStore'
+import { useAuthStore } from '#imports'
 
-useModalStore()
+const authStore = useAuthStore()
 
 const { isPortrait } = useScreenOrientation()
+
+onMounted(async () => {
+    await authStore.init()
+})
 </script>

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -74,6 +74,8 @@ const router = useRouter()
 const doesTheUserHaveAccess: Ref<boolean> = ref(true)
 
 const checkIfUserIsLoggedIn = async () => {
+    // init the auth to see if we are in dev/testing mode or prod
+    await authStore.init()
     // This promise is here to make the Suspense component work.
     // It doesn't do anything, but <Suspense> requires an awaited setup method
     await new Promise(resolve => {

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -36,7 +36,6 @@ export const useAuthStore = defineStore('authStore', () => {
             isReady.value = true
         }
     }
-    init()
 
     const userId = computed(() => {
         if (!isReady.value) return undefined
@@ -135,5 +134,5 @@ export const useAuthStore = defineStore('authStore', () => {
         }
     }
 
-    return { userId, isLoggedIn, isLoadingAuth, isAdmin, isModerator, login, logout, getAuthBearerToken }
+    return { userId, isLoggedIn, isLoadingAuth, isAdmin, isModerator, login, logout, getAuthBearerToken, init }
 })


### PR DESCRIPTION
✅ Resolves #1190

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed
The `init` function being used for testing the `authStore` due to not being await as @ermish was worried about, was leading to some unintended side effects within development.

This moves to it being called in `index.vue` and `moderation.vue` to have it be awaited on mount. This will allow users to consistently test the moderation in dev while not having problems within the production environment

## 🧪 Testing instructions
Run the server locally on dev and log in. You can access both pages when logged in with the data and also it will show you logged in when you visit again assuming the cookie has not been removed
