### PR TITLE
feat: add limit to fetch 100 submissions

### DIFF
--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -168,7 +168,8 @@ async function querySubmissions(): Promise<Submission[]> {
     try {
         const submissionsFilters = {
             filters: {
-                id: undefined
+                id: undefined,
+                limit: 100
             }
         }
 


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed
We added a filter to send the limit to the backend so that way it does not default to fetching 20 submissions. This will now fetch 100 submissions so moderators for now can approve or reject the submissions we have while we update the backend and frontend to include pagination.