### PR TITLE
fix(style): make moderation dashboard scrollable

### DIFF
--- a/components/ModMainContent.vue
+++ b/components/ModMainContent.vue
@@ -1,17 +1,17 @@
 <template>
-    <div class="h-full overflow-hidden">
+    <div class="h-full overflow-y-auto">
         <div v-if="moderationScreenStore.dashboardScreenIsActive()">
             <ModSubmissionListContainer />
         </div>
         <div
             v-if="moderationScreenStore.editSubmissionScreenIsActive()"
-            class="h-full overflow-hidden"
+            class="h-full overflow-y-auto"
         >
             <ModEditSubmissionForm />
         </div>
         <div
             v-if="moderationScreenStore.editFacilityScreenIsActive()"
-            class="h-full overflow-hidden"
+            class="h-full overflow-y-auto"
         >
             <form class="p-4 h-full overflow-y-auto">
                 <ModEditFacilitySection />
@@ -19,7 +19,7 @@
         </div>
         <div
             v-if="moderationScreenStore.editHealthcareProfessionalScreenIsActive()"
-            class="h-full overflow-hidden"
+            class="h-full overflow-y-auto"
         >
             <form
                 class="p-4 h-full overflow-y-auto"
@@ -29,7 +29,7 @@
         </div>
         <div
             v-if="moderationScreenStore.createHealthcareProfessionalScreenIsActive()"
-            class="h-full overflow-hidden"
+            class="h-full overflow-y-auto"
         >
             <form
                 class="p-4 h-full overflow-y-auto"


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed
The y scrolling was hidden which disallowed moderators from scrolling when submissions were over 25. This fixes that

## 📸 Screenshots

-   ### After

https://github.com/user-attachments/assets/93235f46-6aa9-41d9-902c-9f0f9407354e


