### PR TITLE
fix: add event default to prevent default action

### DIFF
--- a/utils/closeOnOutsideClick.ts
+++ b/utils/closeOnOutsideClick.ts
@@ -9,6 +9,7 @@ export const vCloseOnOutsideClick = {
         let isOpen = false
 
         el.clickOutsideEvent = event => {
+            event.preventDefault()
             const eventTarget: EventTarget | null = event.target
             const isClickInsideElement = (el == eventTarget || el.contains(eventTarget as Node))
             if (isOpen && !isClickInsideElement) {


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed
The default browser action was causing weird side events for events when people were clicking if a modal was ever opened.
This prevents that from happening

## 📸 Screenshots

-   ### Before

-   ### After


