### PR TITLE
fix: fix ref not being reset to false after submission update

### DIFF
--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -1083,9 +1083,9 @@ const rejectSubmission = async () => {
     handleNavigateToModerationScreen()
 }
 
-watch(moderationSubmissionStore, newValue => {
+watch(() => moderationSubmissionStore.updatingSubmissionFromTopBar, newValue => {
     //saves the submission by updating it and then going to the main
-    if (newValue.updatingSubmissionFromTopBar) {
+    if (newValue) {
         submitUpdatedSubmission(syntheticEvent)
     }
 })

--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -1072,6 +1072,7 @@ const syntheticEvent = new Event('submit', { bubbles: false, cancelable: true })
 const resetModalRefs = async () => {
     moderationSubmissionStore.setShowRejectSubmissionConfirmation(false)
     moderationSubmissionStore.setApprovingSubmissionFromTopBar(false)
+    moderationSubmissionStore.setUpdatingSubmissionFromTopBar(false)
     formHasUnsavedChanges.value = false
 }
 

--- a/utils/closeOnOutsideClick.ts
+++ b/utils/closeOnOutsideClick.ts
@@ -9,6 +9,7 @@ export const vCloseOnOutsideClick = {
         let isOpen = false
 
         el.clickOutsideEvent = event => {
+            event.preventDefault()
             const eventTarget: EventTarget | null = event.target
             const isClickInsideElement = (el == eventTarget || el.contains(eventTarget as Node))
             if (isOpen && !isClickInsideElement) {


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Our `resetModalRefs` function that resets all the parts of the top bar and the modal was missing one of the values that needs to be reset to false. This has been fixed so the watch function that always watches when the dom changes does not auto update

Also the watch only looks at the necessary value of `updatingSubmissionFromTopBar`