### PR TITLE
fix: change which function validates google maps urls

### DIFF
--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -259,7 +259,7 @@
                 type="url"
                 :placeholder="$t('modSubmissionForm.placeholderTextFacilityGoogleMapsUrl')"
                 :required="true"
-                :input-validation-check="validateWebsite"
+                :input-validation-check="validateGoogleMapsUrlInput"
                 :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityGoogleMapsUrl')"
                 :autofill-value="submissionFormFields.googlemapsURL"
             />


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed
Put the correct validation for the url