### PR TITLE
feat: create pagination and integrate for submission

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,0 @@
-# .env.sample
-# Please make a copy of this file to `.env`, and update the password after contacting the main developers on slack to get the password
-
-AUTH0_DOMAIN="https://findadoc.jp.auth0.com/"
-AUTH0_USERNAME="Your findadoc.jp moderation panel username"
-AUTH0_PASSWORD="Your findadoc.jp moderation panel password"
-AUTH0_CLIENTID="Your client ID here from https://manage.auth0.com/dashboard/jp/findadoc/applications/PnOZ9s1960Mnd5NuIxYAKyzqQVm2iesO/settings"
-AUTH0_CLIENTSECRET="Your client secret here from https://manage.auth0.com/dashboard/jp/findadoc/applications/PnOZ9s1960Mnd5NuIxYAKyzqQVm2iesO/settings"

--- a/components/ModPagination.vue
+++ b/components/ModPagination.vue
@@ -1,0 +1,70 @@
+<template>
+    <div class="flex items-center justify-between mt-4">
+        <p class="text-sm text-gray-600">
+            {{ startItem }} - {{ endItem }} of {{ totalItems }}
+        </p>
+        <div class="flex gap-2">
+            <button
+                v-if="currentPage > 1"
+                class="text-gray-600 disabled:opacity-30"
+                :disabled="currentPage === 1"
+                @click="emit('update:currentPage', currentPage - 1)"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="32"
+                    height="32"
+                    fill="currentColor"
+                    viewBox="0 0 16 16">
+                    <path
+                        fill-rule="evenodd"
+                        d="M11.354 1.646a.5.5 0 0 1 0 .708L6.707 7l4.647 4.646a.5.5 0 0
+                        1-.708.708l-5-5a.5.5 0 0 1 0-.708l5-5a.5.5 0 0 1 .708 0z"
+                    />
+                </svg>
+            </button>
+            <button
+                v-if="currentPage < totalPages"
+                class="text-gray-600 disabled:opacity-30"
+                :disabled="currentPage === totalPages"
+                @click="emit('update:currentPage', currentPage + 1)"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="32"
+                    height="32"
+                    fill="currentColor"
+                    viewBox="0 0 16 16">
+                    <path
+                        fill-rule="evenodd"
+                        d="M4.646 1.646a.5.5 0 0 1 .708 0l5 5a.5.5 0 0 1 0 .708l-5 5a.5.5 0 1
+                        1-.708-.708L9.293 7 4.646 2.354a.5.5 0 0 1 0-.708z"
+                    />
+                </svg>
+            </button>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+    currentPage: number
+    totalItems: number
+    itemsPerPage: number
+}>()
+
+const emit = defineEmits<{
+    (e: 'update:currentPage', value: number): void
+}>()
+
+const totalPages: Ref<number> = computed((): number =>
+    Math.ceil(props.totalItems / props.itemsPerPage))
+
+const startItem: Ref<number> = computed(() =>
+    props.totalItems === 0 ? 0 : (props.currentPage - 1) * props.itemsPerPage + 1)
+
+const endItem: Ref<number> = computed(() =>
+    props.totalItems === 0 ? 0 : Math.min(props.currentPage * props.itemsPerPage, props.totalItems))
+</script>

--- a/components/ModSubmissionListContainer.vue
+++ b/components/ModSubmissionListContainer.vue
@@ -21,7 +21,7 @@
             class="grid grid-cols-subgrid col-span-4"
         >
             <div
-                v-for="(submission, index) in modSubmissionsListStore.filteredSubmissionDataForListComponent"
+                v-for="(submission, index) in paginatedSubmissions"
                 :key="index"
                 class="grid grid-cols-subgrid col-span-4 bg-tertiary-bg"
             >
@@ -104,20 +104,30 @@
         <div v-else>
             {{ $t("modPanelSubmissionList.noSubmissions") }}
         </div>
+        <ModPagination
+  :currentPage="currentPage"
+  :totalItems="totalSubmissions"
+  :itemsPerPage="itemsPerPage"
+  @update:currentPage="val => currentPage = val"
+/>
     </div>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref, type Ref } from 'vue'
 import { ModerationScreen, useModerationScreenStore } from '~/stores/moderationScreenStore'
 import { SelectedModerationListView, useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
 import { useHealthcareProfessionalsStore } from '~/stores/healthcareProfessionalsStore'
 import { useFacilitiesStore } from '~/stores/facilitiesStore'
+import ModPagination from '~/components/ModPagination.vue'
 
 const modSubmissionsListStore = useModerationSubmissionsStore()
 const healthcareProfessionalsStore = useHealthcareProfessionalsStore()
 const facilitiesStore = useFacilitiesStore()
 const moderationScreenStore = useModerationScreenStore()
+
+const currentPage: Ref<number> = ref(1)
+const itemsPerPage = 20
 
 onMounted(async () => {
     await modSubmissionsListStore.getSubmissions()
@@ -143,4 +153,14 @@ const handleClickToSubmissionForm = (id: string) => {
     modSubmissionsListStore.selectedSubmissionId = id
     moderationScreenStore.setActiveScreen(ModerationScreen.EditSubmission)
 }
+
+const paginatedSubmissions = computed(() => {
+  const start = (currentPage.value - 1) * itemsPerPage
+  const end = start + itemsPerPage
+  return modSubmissionsListStore.filteredSubmissionDataForListComponent.slice(start, end)
+})
+
+const totalSubmissions = computed(() =>
+  modSubmissionsListStore.filteredSubmissionDataForListComponent.length
+)
 </script>


### PR DESCRIPTION
✅ Resolves [#1039](https://github.com/ourjapanlife/findadoc-web/issues/1039)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected
- [ ] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Created a reusable `<ModPagination />` component with props for `current-page`, `items-per-page`, and `total-items`
Added SVG arrow icons and conditional rendering logic to hide arrows at the first/last page
Integrated pagination into the `ModSubmissionListContainer.vue` for the submissions section
Introduced computed slicing (`paginatedSubmissions`) to show 20 items per page
Implemented conditional display of range text (e.g. “1 - 20 of 49”) only when data exists

## 🧪 Testing instructions

## 📸 Screenshots

-   ### Before

-   ### After

![image](https://github.com/user-attachments/assets/97cb94e6-ba3c-465d-99cf-914e1c859477)
![image](https://github.com/user-attachments/assets/7637c56e-f304-4a60-b1a4-cbc4269d51e6)

The second photo is from yesterday, with old arrows. I cannot show more photo because i'm having some issues if i try to run the test.

