### PR TITLE
refactor: remove active screen setter to be consistent

### DIFF
--- a/components/ModSubmissionListContainer.vue
+++ b/components/ModSubmissionListContainer.vue
@@ -109,7 +109,6 @@
 
 <script setup lang="ts">
 import { computed, onMounted } from 'vue'
-import { ModerationScreen, useModerationScreenStore } from '~/stores/moderationScreenStore'
 import { SelectedModerationListView, useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
 import { useHealthcareProfessionalsStore } from '~/stores/healthcareProfessionalsStore'
 import { useFacilitiesStore } from '~/stores/facilitiesStore'
@@ -117,7 +116,6 @@ import { useFacilitiesStore } from '~/stores/facilitiesStore'
 const modSubmissionsListStore = useModerationSubmissionsStore()
 const healthcareProfessionalsStore = useHealthcareProfessionalsStore()
 const facilitiesStore = useFacilitiesStore()
-const moderationScreenStore = useModerationScreenStore()
 
 onMounted(async () => {
     await modSubmissionsListStore.getSubmissions()
@@ -141,6 +139,5 @@ const submissionListItemTableColumns = computed(() => {
 
 const handleClickToSubmissionForm = (id: string) => {
     modSubmissionsListStore.selectedSubmissionId = id
-    moderationScreenStore.setActiveScreen(ModerationScreen.EditSubmission)
 }
 </script>


### PR DESCRIPTION
This was removed from this file in order to have a consistent setting of the active screen. We check and set based on route or navigation back to dashboard

✅ Resolves #1227 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
This setting is done based on the path in the Main content and moving around so it does not to be set here anymore. This could lead to unintended side effects and updating more than necessary


