### PR TITLE
fix: reduce method only runs when submissions are present

### DIFF
--- a/components/ModDashboardLeftNavbar.vue
+++ b/components/ModDashboardLeftNavbar.vue
@@ -94,7 +94,17 @@ const updateSelectedDashboardView = (event: Event) => {
 }
 
 function createCountsForSubmissionListView(submissions: Submission[]) {
-    return submissions.reduce((statusCountObject, submission) => {
+    const submissionStatusCounts = {
+        forReviewCount: 0,
+        approvedCount: 0,
+        rejectedCount: 0
+    }
+
+    if (!submissions.length) {
+        return submissionStatusCounts
+    }
+
+    submissions.reduce((statusCountObject, submission) => {
         const isNewSubmission = !submission.isRejected && !submission.isApproved && !submission.isUnderReview
         if (submission.isUnderReview) {
             statusCountObject.forReviewCount += 1
@@ -109,11 +119,8 @@ function createCountsForSubmissionListView(submissions: Submission[]) {
             statusCountObject.forReviewCount += 1
         }
         return statusCountObject
-    }, {
-        forReviewCount: 0,
-        approvedCount: 0,
-        rejectedCount: 0
-    })
+    }, submissionStatusCounts)
+    return submissionStatusCounts
 }
 
 const autofillStatusCount = computed(() => createCountsForSubmissionListView(moderationSubmissionsStore.submissionsData))


### PR DESCRIPTION
✅ Resolves #1238 
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [X] PR assignee has been selected
- [X] PR label has been selected
- [X] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
A conditional has been added to the createCountsForSubmissionListView which prevents it from running if the provided array of Submissions is empty. Optional chaining operators and nullish coalescing operators have also been added to where the sorted submission counts appear to prevent potential TypeScript errors or blank spaces if they are undefined.

## 📸 Screenshots

-   ### Before
https://github.com/user-attachments/assets/fde7a1a6-c61c-4fc8-857b-4f6c3aafc0ae

-   ### After
https://github.com/user-attachments/assets/4551b327-445e-4f7e-9a98-8b6cb9685c64



