### PR TITLE
fix: avoid race condition `facilitiesStore.ts`

### DIFF
--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -11,6 +11,7 @@ import type { DeleteResult, Facility,
     Relationship } from '~/typedefs/gqlTypes'
 import { gqlClient, graphQLClientRequestWithRetry } from '~/utils/graphql'
 import type { ServerResponse } from '~/typedefs/serverResponse'
+import { arraysAreEqual } from '~/utils/arrayUtils'
 
 export const useFacilitiesStore = defineStore(
     'facilitiesStore',
@@ -214,7 +215,10 @@ export const useFacilitiesStore = defineStore(
                 selectedFacilityData.value = serverResponse.data
                 initializeFacilitySectionValues(serverResponse.data)
 
-                if (facilitySectionFields.healthProfessionalsRelations === healthProfessionalRelationsBeforeMutation) {
+                if (arraysAreEqual(
+                    facilitySectionFields.healthProfessionalsRelations,
+                    healthProfessionalRelationsBeforeMutation
+                )) {
                     facilitySectionFields.healthProfessionalsRelations = []
                 }
             }

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -195,8 +195,8 @@ export const useFacilitiesStore = defineStore(
                         website: facilitySectionFields.website
                     },
                     healthcareProfessionalIds: facilitySectionFields.healthProfessionalsRelations.length > 0
-            ? facilitySectionFields.healthProfessionalsRelations
-            : undefined,
+                        ? facilitySectionFields.healthProfessionalsRelations
+                        : undefined,
                     mapLatitude: parseFloat(facilitySectionFields.mapLatitude),
                     mapLongitude: parseFloat(facilitySectionFields.mapLongitude),
                     nameEn: facilitySectionFields.nameEn,

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -171,8 +171,10 @@ export const useFacilitiesStore = defineStore(
             return serverResponse
         }
 
-        async function updateFacility():
-        Promise<ServerResponse<Facility>> {
+        async function updateFacility(): Promise<ServerResponse<Facility>> {
+            // healthProfessionalRelations array before updating the healthcare professionals related to a facility
+            const preUpdateRelations = [...facilitySectionFields.healthProfessionalsRelations]
+
             const updateFacilityInput: MutationUpdateFacilityArgs = {
                 id: selectedFacilityId.value,
                 input: {
@@ -209,11 +211,20 @@ export const useFacilitiesStore = defineStore(
                 updateFacilityInput
             )
 
-            if (!serverResponse.errors?.length) {
+            if (!serverResponse.errors?.length && serverResponse.data) {
                 // update the necessary values with the updated response
-                selectedFacilityData.value = serverResponse.data!
-                initializeFacilitySectionValues(serverResponse.data!)
-                facilitySectionFields.healthProfessionalsRelations = []
+                selectedFacilityData.value = serverResponse.data
+                initializeFacilitySectionValues(serverResponse.data)
+
+                // compare the healthProfessionalRelations array from before and after updating the facility
+                const postUpdateRelations = facilitySectionFields.healthProfessionalsRelations
+                const hasUserChangedRelations
+                    = postUpdateRelations.length !== preUpdateRelations.length
+                      || !postUpdateRelations.every((relation, i) => relation === preUpdateRelations[i])
+
+                if (!hasUserChangedRelations) {
+                    facilitySectionFields.healthProfessionalsRelations = []
+                }
             }
 
             return serverResponse

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -172,8 +172,7 @@ export const useFacilitiesStore = defineStore(
         }
 
         async function updateFacility(): Promise<ServerResponse<Facility>> {
-            // healthProfessionalRelations array before updating the healthcare professionals related to a facility
-            const preUpdateRelations = [...facilitySectionFields.healthProfessionalsRelations]
+            const healthProfessionalRelationsBeforeMutation = facilitySectionFields.healthProfessionalsRelations
 
             const updateFacilityInput: MutationUpdateFacilityArgs = {
                 id: selectedFacilityId.value,
@@ -196,8 +195,8 @@ export const useFacilitiesStore = defineStore(
                         website: facilitySectionFields.website
                     },
                     healthcareProfessionalIds: facilitySectionFields.healthProfessionalsRelations.length > 0
-                        ? facilitySectionFields.healthProfessionalsRelations
-                        : undefined,
+            ? facilitySectionFields.healthProfessionalsRelations
+            : undefined,
                     mapLatitude: parseFloat(facilitySectionFields.mapLatitude),
                     mapLongitude: parseFloat(facilitySectionFields.mapLongitude),
                     nameEn: facilitySectionFields.nameEn,
@@ -211,18 +210,11 @@ export const useFacilitiesStore = defineStore(
                 updateFacilityInput
             )
 
-            if (!serverResponse.errors?.length && serverResponse.data) {
-                // update the necessary values with the updated response
+            if (!serverResponse.errors?.length) {
                 selectedFacilityData.value = serverResponse.data
                 initializeFacilitySectionValues(serverResponse.data)
 
-                // compare the healthProfessionalRelations array from before and after updating the facility
-                const postUpdateRelations = facilitySectionFields.healthProfessionalsRelations
-                const hasUserChangedRelations
-                    = postUpdateRelations.length !== preUpdateRelations.length
-                      || !postUpdateRelations.every((relation, i) => relation === preUpdateRelations[i])
-
-                if (!hasUserChangedRelations) {
+                if (facilitySectionFields.healthProfessionalsRelations === healthProfessionalRelationsBeforeMutation) {
                     facilitySectionFields.healthProfessionalsRelations = []
                 }
             }


### PR DESCRIPTION
✅ Resolves #1186 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
This PR updates the logic inside the `updateFacility()` function to unconditionally clear `facilitySectionFields.healthProfessionalsRelations` after a successful facility update.

By resetting the array once the update is confirmed, the code avoids potential race conditions and ensures a clean state for the next user interaction.

## 🧪 Testing instructions

## 📸 Screenshots
