### PR TITLE
feat: change naming of name and id attributes of <select> elements

### DIFF
--- a/components/ModCreateHealthcareProfessionalSection.vue
+++ b/components/ModCreateHealthcareProfessionalSection.vue
@@ -50,10 +50,10 @@
                         {{ $t('modHealthcareProfessionalSection.labelHealthcareProfessionalNameLocale') }}
                     </label>
                     <select
-                        id="name_locales"
+                        id="name-locales"
                         v-model="nameLocaleInputs.locale"
                         data-testid="mod-healthcare-professional-section-name-locale"
-                        name="Name Locales"
+                        name="name-locales"
                         class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                                 text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                     >

--- a/components/ModEditFacilitySection.vue
+++ b/components/ModEditFacilitySection.vue
@@ -87,10 +87,10 @@
                     {{ $t('modFacilitySection.labelFacilityPrefectureEn') }}
                 </label>
                 <select
-                    id="1"
+                    id="prefecture-select-en"
                     v-model="facilityStore.facilitySectionFields.prefectureEn"
                     data-testid="mod-facility-section-prefectureEn"
-                    name="Prefecture Japan"
+                    name="prefecture-japan-en"
                     class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                 text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                 >
@@ -140,10 +140,10 @@
                     {{ $t('modFacilitySection.labelFacilityPrefectureJa') }}
                 </label>
                 <select
-                    id="1"
+                    id="prefecture-select-ja"
                     v-model="facilityStore.facilitySectionFields.prefectureJa"
                     data-testid="mod-facility-section-prefectureJa"
-                    name="Prefecture Japan"
+                    name="prefecture-japan-ja"
                     class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                 text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                 >

--- a/components/ModEditHealthcareProfessionalSection.vue
+++ b/components/ModEditHealthcareProfessionalSection.vue
@@ -55,10 +55,10 @@
                             {{ $t('modHealthcareProfessionalSection.labelHealthcareProfessionalNameLocale') }}
                         </label>
                         <select
-                            id="name_locales"
+                            id="name-locales"
                             v-model="nameLocaleInputs.locale"
                             data-testid="mod-healthcare-professional-section-name-locale"
-                            name="Name Locales"
+                            name="name-locales"
                             class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                                 text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                         >

--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -147,10 +147,10 @@
                     {{ $t('modSubmissionForm.labelFacilityPrefectureEn') }}
                 </label>
                 <select
-                    id="1"
+                    id="prefecture-select-en"
                     v-model="submissionFormFields.prefectureEn"
                     data-testid="submission-form-prefectureEn"
-                    name="Prefecture Japan"
+                    name="prefecture-japan-en"
                     class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                         text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                 >
@@ -200,10 +200,10 @@
                     {{ $t('modSubmissionForm.labelFacilityPrefectureJa') }}
                 </label>
                 <select
-                    id="1"
+                    id="prefecture-select-ja"
                     v-model="submissionFormFields.prefectureJa"
                     data-testid="submission-form-prefectureJa"
-                    name="prefecture-japan"
+                    name="prefecture-japan-ja"
                     class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                     text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                 >


### PR DESCRIPTION

✅ Resolves #1242
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Before, the `name` and `id` attributes of `select` elements were not unique and/or did not follow conventional naming practices. Now, `select` elements all have an unique `id` attribute and  `name` attributes are now all in kebab-case/lowercase.

## 🧪 Testing instructions

## 📸 Screenshots

-   ### Before

-   ### After



