### PR TITLE
fix: #1246 add clickable phone link with orange underline

### DIFF
--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -77,11 +77,15 @@
                 <div class="phone flex my-4">
                     <SVGPhoneIcon
                         role="img"
-                        alt="Facility Banner Image"
+                        alt="Facility36 Banner Image"
                         title="banner image"
                         class="banner-icon w-6 h-6 stroke-primary mr-2 self-center"
                     />
-                    {{ phone }}
+                    <a  v-if="phone"
+                            :href="`tel:${phone}`"
+                            class=" underline decoration-primary underline-offset-2 font-semibold hover:text-primary transition-all">
+                             {{ phone }}
+                    </a>   
                 </div>
                 <div
                     v-if="!excludedEmailAddresses.includes(email)"


### PR DESCRIPTION
**✅ Resolves #1246**

✅  PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) 
       specifications
✅  PR assignee has been selected
✅  PR label has been selected
✅  @NabbeunNabi has been selected for preliminary review
**🔧 What changed**
- Changed the static phone number link to a dynamic clickable link.
- Clicking the phone link now redirects users to the phone directory page.

**🧪 Testing instructions**
- Go to the page with the phone link.
- Click the phone link.
- Confirm it redirects properly to the phone directory.

**📸 Screenshots**

**Before**
![image](https://github.com/user-attachments/assets/142e3b0e-48ba-44bf-96cf-dad653539d9e)

- Static phone number link, non-clickable.

**After**
![image](https://github.com/user-attachments/assets/32c2fc76-fe07-4eed-ac9f-744b7ea911be)

- Dynamic clickable phone link that redirects to the phone directory.

