### PR TITLE
feat: address in modal opens link in new tab; link styling

### DIFF
--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -56,10 +56,17 @@
                         class="w-6 h-6 stroke-primary mr-2 self-center"
                     />
                     <div class="flex flex-col">
-                        <div>{{ addressLine1 }}</div>
-                        <div v-if="addressLine2">
-                            {{ addressLine2 }}
-                        </div>
+                        <a
+                            :href="addressLink"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="underline text-blue"
+                        >
+                            <div>{{ addressLine1 }}</div>
+                            <div v-if="addressLine2">
+                                {{ addressLine2 }}
+                            </div>
+                        </a>
                     </div>
                 </div>
                 <div class="website flex my-4">
@@ -198,6 +205,9 @@ const addressLine2 = computed(() => {
     const englishAddress = `${addressObj?.cityEn}, ${addressObj?.prefectureEn} ${addressObj?.postalCode}`
     return localeStore.locale.code !== Locale.JaJp ? englishAddress : ''
 })
+const addressLink = computed(
+    () => resultsStore.$state.activeResult?.facilities[0].contact.googleMapsUrl
+)
 const website = computed(
     () => resultsStore.$state.activeResult?.facilities[0]?.contact?.website
 )


### PR DESCRIPTION
✅ Resolves #1245 
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [X] PR assignee has been selected
- [X] PR label has been selected
- [X] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
- Added an anchor tag around the address to the Google Maps link in the `resultsStore` which opens in a new tab
- Added styling to the link (inspired by #1250)
## 🧪 Testing instructions
Try clicking the link.
**Currently the link won't work due to the `preventDefault` in closeOnOutsideClick.ts which is removed in #1249**
## 📸 Screenshots

-   ### Before
![image](https://github.com/user-attachments/assets/6c7cd986-2e2e-4deb-a0f5-1b1016d5dfb5)
-   ### After
![image](https://github.com/user-attachments/assets/0fed6cf1-8b7d-4386-a2d3-472733fc50b4)