### PR TITLE
feat: show search suggestions on input focus in ModSearchBar component

### DIFF
--- a/components/ModCreateFacilitySection.vue
+++ b/components/ModCreateFacilitySection.vue
@@ -231,6 +231,7 @@
                         :place-holder-text="$t('modFacilitySection.placeholderTextHealthcareProfessionalSearchbar')"
                         :no-match-text="$t('modFacilitySection.noHealthcareProfessionalFound')"
                         :fields-to-display-callback="healthcareProfessionalsToDisplayCallback"
+                        :default-suggestions="defaultHealthcareProfessionalSuggestions"
                         @search-input-change="handleHealthcareProfessionalsInputChange"
                     />
                     <span
@@ -290,8 +291,11 @@ const healthcareProfessionalsRelatedToFacility: Ref<string[]>
 // This keeps track of the existing healthcare professionals we are adding to the new facility
 const healthcareProfessionalsToAddToFacility: Ref<HealthcareProfessional[]> = ref([])
 
+const defaultHealthcareProfessionalSuggestions: Ref<HealthcareProfessional[]> = ref([])
+
 const handleHealthcareProfessionalsInputChange = (filteredItems: Ref<HealthcareProfessional[]>, inputValue: string) => {
     const input = inputValue.toLowerCase().trim()
+
     filteredItems.value = healthcareProfessionalsStore.healthcareProfessionalsData.filter(
         (healthcareProfessional: HealthcareProfessional) => {
             const idMatches = healthcareProfessional.id.toLowerCase().startsWith(input)
@@ -331,6 +335,13 @@ onBeforeMount(async () => {
 
     // Set the active screen and ensure the UI state is consistent
     moderationScreenStore.setActiveScreen(ModerationScreen.CreateFacility)
+
+    // Fetch data first if not loaded yet
+    if (!healthcareProfessionalsStore.healthcareProfessionalsData) {
+        await healthcareProfessionalsStore.getHealthcareProfessionals()
+    }
+
+    defaultHealthcareProfessionalSuggestions.value = healthcareProfessionalsStore.healthcareProfessionalsData
 
     // Ensure UI updates are reflected with the autofill values
     await nextTick()

--- a/components/ModCreateHealthcareProfessionalSection.vue
+++ b/components/ModCreateHealthcareProfessionalSection.vue
@@ -151,6 +151,7 @@
                 :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextAcceptedInsurances')"
                 :no-match-text="$t('modHealthcareProfessionalSection.noInsurancesWereFound')"
                 :fields-to-display-callback="insurancesToDisplayCallback"
+                :default-suggestions="Object.values(Insurance)"
                 @search-input-change="handleInsuranceInputChange"
             />
             <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -175,6 +176,7 @@
                 :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextDegrees')"
                 :no-match-text="$t('modHealthcareProfessionalSection.noDegreesWereFound')"
                 :fields-to-display-callback="degreesToDisplayCallback"
+                :default-suggestions="Object.values(Degree)"
                 @search-input-change="handleDegreeInputChange"
             />
             <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -199,6 +201,7 @@
                 :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextSpecialties')"
                 :no-match-text="$t('modHealthcareProfessionalSection.noSpecialtiesWereFound')"
                 :fields-to-display-callback="specialtiesToDisplayCallback"
+                :default-suggestions="Object.values(Specialty)"
                 @search-input-change="handleSpecialtyInputChange"
             />
             <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -223,6 +226,7 @@
                 :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextLocales')"
                 :no-match-text="$t('modHealthcareProfessionalSection.noLocalesWereFound')"
                 :fields-to-display-callback="localesToDisplayCallback"
+                :default-suggestions="Object.values(Locale)"
                 @search-input-change="handleLocaleInputChange"
             />
             <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -247,6 +251,7 @@
             :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextFacilitySearchBar')"
             :no-match-text="$t('modHealthcareProfessionalSection.noFacilitiesWereFound')"
             :fields-to-display-callback="facilitiesFieldsToDisplayCallback"
+            :default-suggestions="currentFacilities"
             @search-input-change="handleFacilitySearchInputChange"
         />
         <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2 ">

--- a/components/ModEditFacilitySection.vue
+++ b/components/ModEditFacilitySection.vue
@@ -240,6 +240,7 @@
                 :place-holder-text="$t('modFacilitySection.placeholderTextHealthcareProfessionalSearchbar')"
                 :no-match-text="$t('modFacilitySection.noHealthcareProfessionalFound')"
                 :fields-to-display-callback="healthcareProfessionalsToDisplayCallback"
+                :default-suggestions="defaultHealthcareProfessionalSuggestions"
                 @search-input-change="handleHealthcareProfessionalsInputChange"
             />
             <span
@@ -314,6 +315,7 @@ const healthcareProfessionalsRelatedToFacility: Ref<string[]>
 const healthcareProfessionalRelatedToFacilityFiltered: Ref<HealthcareProfessional[]> = ref([])
 // This keeps track of the existing healthcare professionals we are adding to an existing facility
 const healthcareProfessionalsToAddToFacility: Ref<HealthcareProfessional[]> = ref([])
+const defaultHealthcareProfessionalSuggestions: Ref<HealthcareProfessional[]> = ref([])
 
 const syncHealthcareProfessionalsRelatedToFacility = () => {
     if (healthcareProfessionalsStore.healthcareProfessionalsData
@@ -409,6 +411,9 @@ onBeforeMount(async () => {
 
     facilityStore.setSelectedFacilityData(facilityStore.selectedFacilityId)
     facilityStore.initializeFacilitySectionValues(facilityStore.selectedFacilityData)
+
+    defaultHealthcareProfessionalSuggestions.value = healthcareProfessionalsStore.healthcareProfessionalsData
+
     // Ensure UI updates are reflected with the autofill values
     await nextTick()
     syncHealthcareProfessionalsRelatedToFacility()

--- a/components/ModEditHealthcareProfessionalSection.vue
+++ b/components/ModEditHealthcareProfessionalSection.vue
@@ -154,6 +154,7 @@
                     :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextAcceptedInsurances')"
                     :no-match-text="$t('modHealthcareProfessionalSection.noInsurancesWereFound')"
                     :fields-to-display-callback="insurancesToDisplayCallback"
+                    :default-suggestions="Object.values(Insurance)"
                     @search-input-change="handleInsuranceInputChange"
                 />
                 <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -177,6 +178,7 @@
                     :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextDegrees')"
                     :no-match-text="$t('modHealthcareProfessionalSection.noDegreesWereFound')"
                     :fields-to-display-callback="degreesToDisplayCallback"
+                    :default-suggestions="Object.values(Degree)"
                     @search-input-change="handleDegreeInputChange"
                 />
                 <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -200,6 +202,7 @@
                     :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextSpecialties')"
                     :no-match-text="$t('modHealthcareProfessionalSection.noSpecialtiesWereFound')"
                     :fields-to-display-callback="specialtiesToDisplayCallback"
+                    :default-suggestions="Object.values(Specialty)"
                     @search-input-change="handleSpecialtyInputChange"
                 />
                 <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -223,6 +226,7 @@
                     :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextLocales')"
                     :no-match-text="$t('modHealthcareProfessionalSection.noLocalesWereFound')"
                     :fields-to-display-callback="localesToDisplayCallback"
+                    :default-suggestions="Object.values(Locale)"
                     @search-input-change="handleLocaleInputChange"
                 />
                 <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -248,6 +252,7 @@
                     :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextFacilitySearchBar')"
                     :no-match-text="$t('modHealthcareProfessionalSection.noFacilitiesWereFound')"
                     :fields-to-display-callback="facilitiesFieldsToDisplayCallback"
+                    :default-suggestions="currentFacilities"
                     @search-input-change="handleFacilitySearchInputChange"
                 />
                 <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2 ">

--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -445,6 +445,7 @@
                     :place-holder-text="$t('modSubmissionForm.placeholderTextAcceptedInsurances')"
                     :no-match-text="$t('modSubmissionForm.noInsurancesWereFound')"
                     :fields-to-display-callback="insurancesToDisplayCallback"
+                    :default-suggestions="Object.values(Insurance)"
                     @search-input-change="handleInsuranceInputChange"
                 />
                 <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -468,6 +469,7 @@
                     :place-holder-text="$t('modSubmissionForm.placeholderTextDegrees')"
                     :no-match-text="$t('modSubmissionForm.noDegreesWereFound')"
                     :fields-to-display-callback="degreesToDisplayCallback"
+                    :default-suggestions="Object.values(Degree)"
                     @search-input-change="handleDegreeInputChange"
                 />
                 <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -491,6 +493,7 @@
                     :place-holder-text="$t('modSubmissionForm.placeholderTextSpecialties')"
                     :no-match-text="$t('modSubmissionForm.noSpecialtiesWereFound')"
                     :fields-to-display-callback="specialtiesToDisplayCallback"
+                    :default-suggestions="Object.values(Specialty)"
                     @search-input-change="handleSpecialtyInputChange"
                 />
                 <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">
@@ -514,6 +517,7 @@
                     :place-holder-text="$t('modSubmissionForm.placeholderTextLocales')"
                     :no-match-text="$t('modSubmissionForm.noLocalesWereFound')"
                     :fields-to-display-callback="localesToDisplayCallback"
+                    :default-suggestions="Object.values(Locale)"
                     @search-input-change="handleLocaleInputChange"
                 />
                 <ol class="list-disc text-primary-text/60 font-semibold my-2 px-2">

--- a/components/ModSearchBar.vue
+++ b/components/ModSearchBar.vue
@@ -25,9 +25,10 @@
                 @keydown.up="handleSearchInputArrowUp"
                 @keydown.enter="handleSearchInputEnter"
                 @input="handleSearchInputChange"
+                @focus="handleSearchInputFocus"
             >
             <span
-                v-if="searchResultCount > 0"
+                v-if="isInputFocused && searchResultCount > 0"
                 class="pl-2"
             >
                 {{ searchResultCount }}
@@ -45,7 +46,7 @@
         </div>
         <div class="container relative">
             <ul
-                v-if="searchInputValue.trim() !== ''"
+                v-if="isInputFocused"
                 id="search-list"
                 class="bg-primary-bg shadow-md border-2 border-primary/50 rounded-lg absolute
                 w-full flex flex-col divide-y-2 max-h-64 overflow-y-auto overflow-x-hidden
@@ -138,18 +139,20 @@ type Props = {
     noMatchText: string
     // Callback to display the desired output
     fieldsToDisplayCallback: (item: ArrayType<T>) => string[]
+    defaultSuggestions: ArrayType<T>[]
 
     //Optional test id for testing the component
     dataTestId?: string
 }
 
-const { placeHolderText, noMatchText, fieldsToDisplayCallback } = defineProps<Props>()
+const { placeHolderText, noMatchText, fieldsToDisplayCallback, defaultSuggestions } = defineProps<Props>()
 
 const searchInputElement = ref<HTMLInputElement>()
 const searchInputValue = ref('')
 const filteredItems = ref<ArrayType<T>[]>([])
 const selectedItemIndex = ref(0)
 const searchResultCount = ref(0)
+const isInputFocused = ref(false)
 
 const handleListScroll = () => {
     const selectedElement = document.getElementById(`search-list-item-${selectedItemIndex.value}`)
@@ -190,10 +193,15 @@ const handleListItemMouseDown = (event: MouseEvent) => {
     event.preventDefault()
 }
 
-const handleSearchInputBlur = (event: Event) => {
-    if (!searchInputElement.value) return
-    searchInputElement.value.value = ''
-    handleSearchInputChange(event)
+const handleSearchInputBlur = () => {
+    isInputFocused.value = false
+
+    if (searchInputElement.value) {
+        searchInputElement.value.value = ''
+    }
+
+    searchInputValue.value = ''
+    filteredItems.value = defaultSuggestions
     emit('searchInputBlur')
 }
 
@@ -231,7 +239,7 @@ const handleSearchInputChange = (event: Event) => {
     selectedItemIndex.value = 0
 
     if (inputValue.trim() === '') {
-        filteredItems.value = []
+        filteredItems.value = defaultSuggestions
         return
     }
 
@@ -242,6 +250,11 @@ const handleSearchInputChange = (event: Event) => {
         define this variable as Ref<ArrayType<T>[]>.
     */
     emit('searchInputChange', filteredItems as Ref<ArrayType<T>[]>, inputValue)
+}
+
+const handleSearchInputFocus = (event: Event) => {
+    isInputFocused.value = true
+    handleSearchInputChange(event)
 }
 
 // Displays the dropdown above the searchInputElement if its position is greater than window.innerHeight / 1.5


### PR DESCRIPTION
✅ Resolves #1248 
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [X] PR assignee has been selected
- [X] PR label has been selected
- [X] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Previously, clicking on the input field in the `ModSearchBar` component did not show any search suggestions unless the user started typing.  
Now, default suggestions are displayed as soon as the input is focused, improving discoverability and UX.

## 🧪 Testing instructions

1. Navigate to a page using the `ModSearchBar`.
2. Click on the search input field.
3. Verify that a list of suggestions appears even before typing.
4. Try typing to see the suggestions filter in real-time.
5. Blur and focus the input again to confirm consistent behavior.

## 📸 Screenshots

https://github.com/user-attachments/assets/2454684f-db32-4d76-8989-7e4c7515bf5e