### PR TITLE
fix: allow updating only new name locale

### DIFF
--- a/components/ModEditFacilityOrProfessionalTopbar.vue
+++ b/components/ModEditFacilityOrProfessionalTopbar.vue
@@ -216,6 +216,10 @@ const healthcareProfessionalHasUnsavedChanges = () => {
     // Compare each field in the `healthcareProfessionalSectionFields` object with the original data.
     const areThereUnsavedHealthcareProfessionalChanges
 = !arraysAreEqual(
+    healthcareProfessionalSections.names,
+    originalHealthcareProfessional.names
+)
+|| !arraysAreEqual(
     healthcareProfessionalSections.acceptedInsurance,
     originalHealthcareProfessional.acceptedInsurance
 )


### PR DESCRIPTION
✅ Resolves #1247 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

In the edit healthcare professional section of the moderation panel, if you only want to change or add a name locale to the professional, the update button would not be enabled

This PR addresses this bug and allows a mod to only update the name locale if they wish


## 🧪 Testing instructions

First, on the main branch, confirm what I stated above and see if you are able to only update a healthcare professionals name from the mod panel (you should not be able to on main)

Next, pull this PR branch and try again. You should be able to only update the professionals name


## 📸 Screenshots

-   ### Before

#### Original Professional Data

![Screenshot 2025-06-05 104235](https://github.com/user-attachments/assets/812046ab-dc18-49eb-a4a6-41fd328392f9)


#### Update Button disabled with only name change

![IMG_5603](https://github.com/user-attachments/assets/f5af3436-ab31-44eb-9bec-d5afe9edd863)



-   ### After

#### Button enabled with only name change

![IMG_5604](https://github.com/user-attachments/assets/31ed98ac-3cfb-4359-9107-3b36b1bd085b)


#### Successfully only updated name

![Screenshot 2025-06-05 104714](https://github.com/user-attachments/assets/50fb2ced-1c68-476e-b1bb-1ebde002d542)
