### PR TITLE
fix: declare $t to resolve incorrect TypeScript error message for translatable strings

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -9,14 +9,14 @@
                 to="/"
                 class="self-center ml-8 mr-2 hover:text-primary-hover transition-colors"
             >© {{ new
-                Date().getUTCFullYear() }} {{ $t('footer.copyright') }}</NuxtLink>
+                Date().getUTCFullYear() }} {{ t('footer.copyright') }}</NuxtLink>
             <span class="self-center">·</span>
             <nav class="flex mx-2">
                 <NuxtLink
                     to="/privacypolicy"
                     class="self-center hover:text-primary-hover transition-colors"
                     data-testid="privacy-link"
-                >{{ $t('footer.privacy') }}</NuxtLink>
+                >{{ t('footer.privacy') }}</NuxtLink>
             </nav>
             <span class="self-center">·</span>
             <nav class="flex mx-2">
@@ -24,11 +24,11 @@
                     to="/terms"
                     class="self-center hover:text-primary-hover transition-colors"
                     data-testid="terms-link"
-                >{{ $t('footer.terms') }}</NuxtLink>
+                >{{ t('footer.terms') }}</NuxtLink>
             </nav>
         </div>
         <div class="middle-footer-section flex flex-1 align-middle justify-center sm:self-center">
-            <span class="self-center">{{ $t('footer.poweredBy') }}</span>
+            <span class="self-center">{{ t('footer.poweredBy') }}</span>
             <nav class="flex mx-2 self-center">
                 <NuxtLink
                     to="https://www.netlify.com/"
@@ -47,7 +47,7 @@
                     class="flex flex-col flex-wrap"
                     data-testid="github-link"
                 >
-                    <div>{{ $t('footer.contribute') }}</div>
+                    <div>{{ t('footer.contribute') }}</div>
                     <div class="self-center">
                         GitHub
                     </div>
@@ -55,14 +55,18 @@
             </div>
             <span class="self-center">·</span>
             <div class="flex flex-col flex-wrap hover:text-primary-hover transition-colors">
-                <span>{{ $t('footer.feedback') }}</span>
+                <span>{{ t('footer.feedback') }}</span>
                 <NuxtLink
                     to="https://forms.gle/4E763qfaq46kEsn99"
                     target="_blank"
                     class="px-2 mx-auto underline font-bold"
                     data-testid="feedback-link"
-                >{{ $t('footer.clickHere') }}</NuxtLink>
+                >{{ t('footer.clickHere') }}</NuxtLink>
             </div>
         </div>
     </div>
 </template>
+
+<script setup lang="ts">
+const { t } = useI18n()
+</script>

--- a/components/HamburgerMenu.vue
+++ b/components/HamburgerMenu.vue
@@ -35,7 +35,7 @@
                                 data-testid="logo"
                             >
                                 <div class="text-lg font-semibold text-primary-text group-hover:text-primary-hover">
-                                    {{ $t('hamburgerMenu.copyright') }}
+                                    {{ t('hamburgerMenu.copyright') }}
                                 </div>
                             </div>
                         </div>
@@ -67,7 +67,7 @@
                         data-testid="hamburger-menu-language-section"
                         class="flex px-5 mt-2"
                     >
-                        <span class="self-center mr-2 text-primary-text">{{ $t('hamburgerMenu.languageDropdownTitle')
+                        <span class="self-center mr-2 text-primary-text">{{ t('hamburgerMenu.languageDropdownTitle')
                         }}</span>
                         <LocaleSelector class="py-1.5 text-primary-text bg-primary-bg" />
                     </div>
@@ -77,12 +77,12 @@
                     >
                         <NuxtLink to="/">
                             <div @click="closeMenu()">
-                                {{ $t('hamburgerMenu.home') }}
+                                {{ t('hamburgerMenu.home') }}
                             </div>
                         </NuxtLink>
                         <NuxtLink to="/about">
                             <div @click="closeMenu()">
-                                {{ $t('hamburgerMenu.about') }}
+                                {{ t('hamburgerMenu.about') }}
                             </div>
                         </NuxtLink>
                         <NuxtLink
@@ -90,12 +90,12 @@
                             target="_blank"
                         >
                             <div @click="closeMenu()">
-                                {{ $t('hamburgerMenu.contact') }}
+                                {{ t('hamburgerMenu.contact') }}
                             </div>
                         </NuxtLink>
                         <NuxtLink to="/submit">
                             <div @click="closeMenu()">
-                                {{ $t('hamburgerMenu.submit') }}
+                                {{ t('hamburgerMenu.submit') }}
                             </div>
                         </NuxtLink>
                         <div
@@ -115,12 +115,12 @@
                             </div>
                             <NuxtLink to="/moderation">
                                 <div @click="closeMenu()">
-                                    {{ $t('hamburgerMenu.moderation') }}
+                                    {{ t('hamburgerMenu.moderation') }}
                                 </div>
                             </NuxtLink>
                             <NuxtLink to="/">
                                 <div @click="logout()">
-                                    {{ $t('hamburgerMenu.logout') }}
+                                    {{ t('hamburgerMenu.logout') }}
                                 </div>
                             </NuxtLink>
                         </div>
@@ -133,7 +133,7 @@
                 >
                     <div data-testid="hamburger-menu-theme-switcher">
                         <p class="mb-1">
-                            {{ $t('hamburgerMenu.theme') }}: {{ convertStringToTitleCase(currentTheme) }}
+                            {{ t('hamburgerMenu.theme') }}: {{ convertStringToTitleCase(currentTheme) }}
                         </p>
                         <div class="flex">
                             <div
@@ -198,7 +198,7 @@
                             data-testid="hamburger-menu-footer-legal-terms"
                         >
                             <span @click="closeMenu()">
-                                {{ $t('footer.terms') }}
+                                {{ t('footer.terms') }}
                             </span>
                         </NuxtLink>
                         <NuxtLink
@@ -206,7 +206,7 @@
                             data-testid="hamburger-menu-footer-legal-privacy"
                         >
                             <span @click="closeMenu()">
-                                {{ $t('footer.privacy') }}
+                                {{ t('footer.privacy') }}
                             </span>
                         </NuxtLink>
                     </div>
@@ -242,7 +242,7 @@
                         class="text-xs text-primary-text-muted"
                     >
                         <div>
-                            © {{ new Date().getUTCFullYear() }} {{ $t('hamburgerMenu.copyright') }}
+                            © {{ new Date().getUTCFullYear() }} {{ t('hamburgerMenu.copyright') }}
                         </div>
                         <div
                             data-testid="hamburger-menu-footer-legal"
@@ -268,7 +268,7 @@
                                     to="https://docs.google.com/spreadsheets/d/1CafQoHn1NNNoRy35QSt_nUZcgKL8QN2M"
                                     target="_blank"
                                     class="underline"
-                                >{{ $t('hamburgerMenu.balancesheet') }}
+                                >{{ t('hamburgerMenu.balancesheet') }}
                                 </NuxtLink>
                             </span>
                         </div>
@@ -293,6 +293,8 @@ const authStore = useAuthStore()
 const isMenuOpen = ref(false)
 
 const currentTheme = ref('orange')
+
+const { t } = useI18n()
 
 function openMenu() {
     isMenuOpen.value = true

--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -11,7 +11,7 @@
             class="h-8"
         />
         <span>
-            {{ $t('login.redirectingtoauth0') }}...
+            {{ t('login.redirectingtoauth0') }}...
         </span>
     </h1>
 </template>
@@ -21,6 +21,8 @@ import SVGLoadingIcon from '~/assets/icons/loading.svg'
 import { useAuthStore } from '~/stores/authStore'
 
 const authStore = useAuthStore()
+
+const { t } = useI18n()
 
 // since the login is a redirection, let's go there right away
 await authStore.login()

--- a/components/ModCreateFacilityOrProfessionalTopbar.vue
+++ b/components/ModCreateFacilityOrProfessionalTopbar.vue
@@ -9,7 +9,7 @@
                 @click="createFacilityOrHealthcareProfessional"
             >
                 <span>
-                    {{ $t('modCreateFacilityOrHPTopbar.create') }}
+                    {{ t('modCreateFacilityOrHPTopbar.create') }}
                 </span>
             </button>
             <button
@@ -20,7 +20,7 @@
                 @click="openExitConfirmation"
             >
                 <span>
-                    {{ $t('modCreateFacilityOrHPTopbar.exit') }}
+                    {{ t('modCreateFacilityOrHPTopbar.exit') }}
                 </span>
             </button>
         </div>
@@ -35,7 +35,7 @@
                     <span
                         class="font-bold text-3xl"
                     >
-                        {{ $t('modCreateFacilityOrHPTopbar.unsavedChangesMessage') }}
+                        {{ t('modCreateFacilityOrHPTopbar.unsavedChangesMessage') }}
                     </span>
                     <button
                         class="bg-primary p-4 rounded-full my-8 font-semibold text-xl"
@@ -43,7 +43,7 @@
                         @click="navigateBackToDashboardWithoutCreation"
                     >
                         {{
-                            $t('modCreateFacilityOrHPTopbar.confirmExit') }}
+                            t('modCreateFacilityOrHPTopbar.confirmExit') }}
                     </button>
                 </div>
             </Modal>

--- a/components/ModCreateFacilitySection.vue
+++ b/components/ModCreateFacilitySection.vue
@@ -3,82 +3,82 @@
     <div v-if="isFacilitySectionInitialized">
         <div class="mod-facility-section">
             <h2 class="mb-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal">
-                {{ $t('modFacilitySection.facilityHeading') }}
+                {{ t('modFacilitySection.facilityHeading') }}
             </h2>
             <div class="input-fields flex flex-col my-4">
                 <ModInputField
                     v-model="facilityStore.createFacilityFields.nameEn"
                     data-testid="mod-facility-section-nameEn"
-                    :label="$t('modFacilitySection.labelFacilityNameEn')"
+                    :label="t('modFacilitySection.labelFacilityNameEn')"
                     type="text"
-                    :placeholder="$t('modFacilitySection.placeholderTextFacilityNameEn')"
+                    :placeholder="t('modFacilitySection.placeholderTextFacilityNameEn')"
                     :required="true"
                     :input-validation-check="validateNameEn"
-                    :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityNameEn')"
+                    :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityNameEn')"
                 />
                 <ModInputField
                     v-model="facilityStore.createFacilityFields.nameJa"
                     data-testid="mod-facility-section-nameJa"
-                    :label="$t('modFacilitySection.labelFacilityNameJa')"
+                    :label="t('modFacilitySection.labelFacilityNameJa')"
                     type="text"
-                    :placeholder="$t('modFacilitySection.placeholderTextFacilityNameJa')"
+                    :placeholder="t('modFacilitySection.placeholderTextFacilityNameJa')"
                     :required="true"
                     :input-validation-check="validateNameJa"
-                    :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityNameJa')"
+                    :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityNameJa')"
                 />
                 <ModInputField
                     v-model="facilityStore.createFacilityFields.contact.phone"
                     data-testid="mod-facility-section-phone"
-                    :label="$t('modFacilitySection.labelFacilityPhoneNumber')"
+                    :label="t('modFacilitySection.labelFacilityPhoneNumber')"
                     type="text"
-                    :placeholder="$t('modFacilitySection.placeholderTextFacilityPhoneNumber')"
+                    :placeholder="t('modFacilitySection.placeholderTextFacilityPhoneNumber')"
                     :required="true"
                     :input-validation-check="validatePhoneNumber"
-                    :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityPhoneNumber')"
+                    :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityPhoneNumber')"
                 />
                 <ModInputField
                     v-model="facilityStore.createFacilityFields.contact.email"
                     data-testid="mod-facility-section-email"
-                    :label="$t('modFacilitySection.labelFacilityEmail')"
+                    :label="t('modFacilitySection.labelFacilityEmail')"
                     type="email"
-                    :placeholder="$t('modFacilitySection.placeholderTextFacilityEmail')"
+                    :placeholder="t('modFacilitySection.placeholderTextFacilityEmail')"
                     :required="false"
                     :input-validation-check="validateEmail"
-                    :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityEmail')"
+                    :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityEmail')"
                 />
                 <ModInputField
                     v-model="facilityStore.createFacilityFields.contact.website"
                     data-testid="mod-facility-section-website"
-                    :label="$t('modFacilitySection.labelFacilityWebsite')"
+                    :label="t('modFacilitySection.labelFacilityWebsite')"
                     type="url"
-                    :placeholder="$t('modFacilitySection.placeholderTextFacilityWebsite')"
+                    :placeholder="t('modFacilitySection.placeholderTextFacilityWebsite')"
                     :required="false"
                     :input-validation-check="validateWebsite"
-                    :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityWebsite')"
+                    :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityWebsite')"
                 />
 
                 <div
                     class="mod-facility-address-section"
                 >
                     <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-                        {{ $t('modFacilitySection.addresses') }}
+                        {{ t('modFacilitySection.addresses') }}
                     </span>
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.contact.address.postalCode"
                         data-testid="mod-facility-section-postalCode"
-                        :label="$t('modFacilitySection.labelFacilityPostalCode')"
+                        :label="t('modFacilitySection.labelFacilityPostalCode')"
                         type="text"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityPostalCode')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityPostalCode')"
                         :required="true"
                         :input-validation-check="validatePostalCode"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityPostalCode')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityPostalCode')"
                     />
                     <div class="flex flex-col mt-4">
                         <label
                             for="mod-create-facility-section-prefecture-select-en"
                             class="mb-2 text-primary-text text-sm font-bold font-sans"
                         >
-                            {{ $t('modFacilitySection.labelFacilityPrefectureEn') }}
+                            {{ t('modFacilitySection.labelFacilityPrefectureEn') }}
                         </label>
                         <select
                             id="mod-create-facility-section-prefecture-select-en"
@@ -99,39 +99,39 @@
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.contact.address.cityEn"
                         data-testid="mod-facility-section-cityEn"
-                        :label="$t('modFacilitySection.labelFacilityCityEn')"
+                        :label="t('modFacilitySection.labelFacilityCityEn')"
                         type="text"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityCityEn')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityCityEn')"
                         :required="true"
                         :input-validation-check="validateCityEn"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityCityEn')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityCityEn')"
                     />
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.contact.address.addressLine1En"
                         data-testid="mod-facility-section-addressLine1En"
-                        :label="$t('modFacilitySection.labelFacilityAddressLine1En')"
+                        :label="t('modFacilitySection.labelFacilityAddressLine1En')"
                         type="text"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine1En')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityAddressLine1En')"
                         :required="true"
                         :input-validation-check="validateAddressLineEn"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine1En')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityAddressLine1En')"
                     />
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.contact.address.addressLine2En"
                         data-testid="mod-facility-section-addressLine2En"
-                        :label="$t('modFacilitySection.labelFacilityAddressLine2En')"
+                        :label="t('modFacilitySection.labelFacilityAddressLine2En')"
                         type="text"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine2En')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityAddressLine2En')"
                         :required="true"
                         :input-validation-check="validateAddressLineEn"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine2En')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityAddressLine2En')"
                     />
                     <div class="flex flex-col mt-4">
                         <label
                             for="mod-create-facility-section-prefecture-select-ja"
                             class="mb-2 text-primary-text text-sm font-bold font-sans"
                         >
-                            {{ $t('modFacilitySection.labelFacilityPrefectureJa') }}
+                            {{ t('modFacilitySection.labelFacilityPrefectureJa') }}
                         </label>
                         <select
                             id="mod-create-facility-section-prefecture-select-ja"
@@ -152,70 +152,70 @@
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.contact.address.cityJa"
                         data-testid="mod-facility-section-cityJa"
-                        :label="$t('modFacilitySection.labelFacilityCityJa')"
+                        :label="t('modFacilitySection.labelFacilityCityJa')"
                         type="text"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityCityJa')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityCityJa')"
                         :required="true"
                         :input-validation-check="validateCityJa"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityCityJa')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityCityJa')"
                     />
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.contact.address.addressLine1Ja"
                         data-testid="mod-facility-section-addressLine1Ja"
-                        :label="$t('modFacilitySection.labelFacilityAddressLine1Ja')"
+                        :label="t('modFacilitySection.labelFacilityAddressLine1Ja')"
                         type="text"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine1Ja')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityAddressLine1Ja')"
                         :required="true"
                         :input-validation-check="validateAddressLineJa"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine1Ja')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityAddressLine1Ja')"
                     />
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.contact.address.addressLine2Ja"
                         data-testid="mod-facility-section-addressLine2Ja"
-                        :label="$t('modFacilitySection.labelFacilityAddressLine2Ja')"
+                        :label="t('modFacilitySection.labelFacilityAddressLine2Ja')"
                         type="text"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine2Ja')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityAddressLine2Ja')"
                         :required="true"
                         :input-validation-check="validateAddressLineJa"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine2Ja')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityAddressLine2Ja')"
                     />
                 </div>
                 <div
                     class="google-maps-section"
                 >
                     <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-                        {{ $t('modFacilitySection.googleMapsInformation') }}
+                        {{ t('modFacilitySection.googleMapsInformation') }}
                     </span>
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.contact.googleMapsUrl"
                         data-testid="mod-facility-section-google-maps"
-                        :label="$t('modFacilitySection.labelFacilityGoogleMapsUrl')"
+                        :label="t('modFacilitySection.labelFacilityGoogleMapsUrl')"
                         type="url"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityGoogleMapsUrl')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityGoogleMapsUrl')"
                         :required="true"
                         :input-validation-check="validateGoogleMapsUrlInput"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityGoogleMapsUrl')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityGoogleMapsUrl')"
                         :autofill="facilityStore.facilitySectionFields.googlemapsURL"
                     />
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.mapLatitude"
                         data-testid="mod-facility-section-mapLatitude"
-                        :label="$t('modFacilitySection.labelFacilityMapLatitude')"
+                        :label="t('modFacilitySection.labelFacilityMapLatitude')"
                         type="text"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityMapLatitude')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityMapLatitude')"
                         :required="true"
                         :input-validation-check="validateFloat"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityMapLatitude')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityMapLatitude')"
                     />
                     <ModInputField
                         v-model="facilityStore.createFacilityFields.mapLongitude"
                         data-testid="mod-facility-section-mapLongitude"
-                        :label="$t('modFacilitySection.labelFacilityMapLongitude')"
+                        :label="t('modFacilitySection.labelFacilityMapLongitude')"
                         type="text"
-                        :placeholder="$t('modFacilitySection.placeholderTextFacilityMapLongitude')"
+                        :placeholder="t('modFacilitySection.placeholderTextFacilityMapLongitude')"
                         :required="true"
                         :input-validation-check="validateFloat"
-                        :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityMapLongitude')"
+                        :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityMapLongitude')"
                     />
                 </div>
                 <div class="flex flex-col">
@@ -223,13 +223,13 @@
                         v-if="moderationScreenStore.createFacilityScreenIsActive()"
                         class="mb-1 text-primary-text text-2xl font-bold font-sans leading-normal"
                     >
-                        {{ $t('modFacilitySection.addHealthcareProfessional') }}
+                        {{ t('modFacilitySection.addHealthcareProfessional') }}
                     </span>
                     <ModSearchBar
                         v-model="healthcareProfessionalsToAddToFacility"
                         data-testid="mod-facility-section-doctor-search"
-                        :place-holder-text="$t('modFacilitySection.placeholderTextHealthcareProfessionalSearchbar')"
-                        :no-match-text="$t('modFacilitySection.noHealthcareProfessionalFound')"
+                        :place-holder-text="t('modFacilitySection.placeholderTextHealthcareProfessionalSearchbar')"
+                        :no-match-text="t('modFacilitySection.noHealthcareProfessionalFound')"
                         :fields-to-display-callback="healthcareProfessionalsToDisplayCallback"
                         :default-suggestions="defaultHealthcareProfessionalSuggestions"
                         @search-input-change="handleHealthcareProfessionalsInputChange"
@@ -237,7 +237,7 @@
                     <span
                         v-show="!healthcareProfessionalsToAddToFacility.length"
                         class="font-semibold my-3"
-                    >- {{ $t('modFacilitySection.noHPSelected') }}
+                    >- {{ t('modFacilitySection.noHPSelected') }}
                     </span>
                     <div
                         v-for="(healthcareProfessional, index) in healthcareProfessionalsToAddToFacility"
@@ -277,6 +277,8 @@ import {
 } from '~/utils/formValidations'
 import type { HealthcareProfessional } from '~/typedefs/gqlTypes'
 import { listPrefectureJapanEn, listPrefectureJapanJa } from '~/stores/locationsStore'
+
+const { t } = useI18n()
 
 const loadingStore = useLoadingStore()
 loadingStore.setIsLoading(true)

--- a/components/ModCreateHealthcareProfessionalSection.vue
+++ b/components/ModCreateHealthcareProfessionalSection.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="mod-healthcare-professional-section">
         <h2 class="mb-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal">
-            {{ $t('modHealthcareProfessionalSection.healthcareProfessionalNameHeading') }}
+            {{ t('modHealthcareProfessionalSection.healthcareProfessionalNameHeading') }}
         </h2>
         <div class="input-fields flex flex-col my-4">
             <Transition
@@ -22,32 +22,32 @@
                     <ModInputField
                         v-model="nameLocaleInputs.lastName"
                         data-testid="mod-healthcare-professional-section-lastName"
-                        :label="$t('modHealthcareProfessionalSection.labelHealthcareProfessionalLastName')"
+                        :label="t('modHealthcareProfessionalSection.labelHealthcareProfessionalLastName')"
                         type="text"
-                        :placeholder="$t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalLastName')"
+                        :placeholder="t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalLastName')"
                         :required="true"
                     />
                     <ModInputField
                         v-model="nameLocaleInputs.firstName"
                         data-testid="mod-healthcare-professional-section-firstName"
-                        :label="$t('modHealthcareProfessionalSection.labelHealthcareProfessionalFirstName')"
+                        :label="t('modHealthcareProfessionalSection.labelHealthcareProfessionalFirstName')"
                         type="text"
-                        :placeholder="$t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalFirstName')"
+                        :placeholder="t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalFirstName')"
                         :required="true"
                     />
                     <ModInputField
                         v-model="nameLocaleInputs.middleName as string"
                         data-testid="mod-healthcare-professional-section-middleName"
-                        :label="$t('modHealthcareProfessionalSection.labelHealthcareProfessionalMiddleName')"
+                        :label="t('modHealthcareProfessionalSection.labelHealthcareProfessionalMiddleName')"
                         type="text"
-                        :placeholder="$t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalMiddleName')"
+                        :placeholder="t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalMiddleName')"
                         :required="false"
                     />
                     <label
                         for="mod-create-healthcare-professional-section-name-locales"
                         class="my-2 text-primary-text text-sm font-bold font-sans"
                     >
-                        {{ $t('modHealthcareProfessionalSection.labelHealthcareProfessionalNameLocale') }}
+                        {{ t('modHealthcareProfessionalSection.labelHealthcareProfessionalNameLocale') }}
                     </label>
                     <select
                         id="mod-create-healthcare-professional-section-name-locales"
@@ -74,7 +74,7 @@
                             type="button"
                             @click="handleAddLocalizedName"
                         >
-                            {{ $t('modHealthcareProfessionalSection.save') }}
+                            {{ t('modHealthcareProfessionalSection.save') }}
                         </button>
                         <button
                             class="bg-error text-primary-text-inverted font-bold py-2 px-4 my-2 rounded w-36"
@@ -82,7 +82,7 @@
                             type="button"
                             @click="handleCloseAddingNewLocalizedName"
                         >
-                            {{ $t('modHealthcareProfessionalSection.exit') }}
+                            {{ t('modHealthcareProfessionalSection.exit') }}
                         </button>
                     </div>
                     <div
@@ -94,14 +94,14 @@
                             type="button"
                             @click="handleUpdateExistingName"
                         >
-                            {{ $t('modHealthcareProfessionalSection.update') }}
+                            {{ t('modHealthcareProfessionalSection.update') }}
                         </button>
                         <button
                             class="bg-error text-primary-text-inverted font-bold py-2 px-4 my-2 rounded w-36"
                             type="button"
                             @click="handleDeleteExistingName"
                         >
-                            {{ $t('modHealthcareProfessionalSection.delete') }}
+                            {{ t('modHealthcareProfessionalSection.delete') }}
                         </button>
                     </div>
                 </div>
@@ -130,26 +130,26 @@
                 class="bg-tertiary text-primary-text-inverted font-bold py-2 px-4 my-2 rounded w-44"
                 @click="handleOpenAddNewNameWithReset"
             >
-                {{ $t('modHealthcareProfessionalSection.addHealthCareProfessionalLocaleName') }}
+                {{ t('modHealthcareProfessionalSection.addHealthCareProfessionalLocaleName') }}
             </button>
             <h2
                 class="mod-healthcare-professional-section
                      my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
             >
-                {{ $t('modHealthcareProfessionalSection.healthcareProfessionalMedicalInfoHeading') }}
+                {{ t('modHealthcareProfessionalSection.healthcareProfessionalMedicalInfoHeading') }}
             </h2>
             <label
                 for="accepted-insurances"
                 class="my-2 text-primary-text text-sm font-bold font-sans"
             >
-                {{ $t("modHealthcareProfessionalSection.selectInsurances") }}
+                {{ t("modHealthcareProfessionalSection.selectInsurances") }}
             </label>
             <ModSearchbar
                 v-if="createHealthcareProfessionalSectionFields.acceptedInsurance"
                 v-model="createHealthcareProfessionalSectionFields.acceptedInsurance"
                 data-testid="mod-healthcare-professional-section-accepted-insurances"
-                :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextAcceptedInsurances')"
-                :no-match-text="$t('modHealthcareProfessionalSection.noInsurancesWereFound')"
+                :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextAcceptedInsurances')"
+                :no-match-text="t('modHealthcareProfessionalSection.noInsurancesWereFound')"
                 :fields-to-display-callback="insurancesToDisplayCallback"
                 :default-suggestions="Object.values(Insurance)"
                 @search-input-change="handleInsuranceInputChange"
@@ -167,14 +167,14 @@
                 for="degrees"
                 class="my-2 text-primary-text text-sm font-bold font-sans"
             >
-                {{ $t("modHealthcareProfessionalSection.selectDegrees") }}
+                {{ t("modHealthcareProfessionalSection.selectDegrees") }}
             </label>
             <ModSearchbar
                 v-if="createHealthcareProfessionalSectionFields.degrees"
                 v-model="createHealthcareProfessionalSectionFields.degrees"
                 data-testid="mod-healthcare-professional-section-degrees"
-                :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextDegrees')"
-                :no-match-text="$t('modHealthcareProfessionalSection.noDegreesWereFound')"
+                :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextDegrees')"
+                :no-match-text="t('modHealthcareProfessionalSection.noDegreesWereFound')"
                 :fields-to-display-callback="degreesToDisplayCallback"
                 :default-suggestions="Object.values(Degree)"
                 @search-input-change="handleDegreeInputChange"
@@ -192,14 +192,14 @@
                 for="specialties"
                 class="my-2 text-primary-text text-sm font-bold font-sans"
             >
-                {{ $t("modHealthcareProfessionalSection.selectSpecialties") }}
+                {{ t("modHealthcareProfessionalSection.selectSpecialties") }}
             </label>
             <ModSearchbar
                 v-if="createHealthcareProfessionalSectionFields.specialties"
                 v-model="createHealthcareProfessionalSectionFields.specialties"
                 data-testid="mod-healthcare-professional-section-specialties"
-                :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextSpecialties')"
-                :no-match-text="$t('modHealthcareProfessionalSection.noSpecialtiesWereFound')"
+                :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextSpecialties')"
+                :no-match-text="t('modHealthcareProfessionalSection.noSpecialtiesWereFound')"
                 :fields-to-display-callback="specialtiesToDisplayCallback"
                 :default-suggestions="Object.values(Specialty)"
                 @search-input-change="handleSpecialtyInputChange"
@@ -217,14 +217,14 @@
                 for="locales"
                 class="my-2 text-primary-text text-sm font-bold font-sans"
             >
-                {{ $t("modHealthcareProfessionalSection.selectLocales") }}
+                {{ t("modHealthcareProfessionalSection.selectLocales") }}
             </label>
             <ModSearchbar
                 v-if="createHealthcareProfessionalSectionFields.spokenLanguages"
                 v-model="createHealthcareProfessionalSectionFields.spokenLanguages"
                 data-testid="mod-healthcare-professional-section-spoken-locales"
-                :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextLocales')"
-                :no-match-text="$t('modHealthcareProfessionalSection.noLocalesWereFound')"
+                :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextLocales')"
+                :no-match-text="t('modHealthcareProfessionalSection.noLocalesWereFound')"
                 :fields-to-display-callback="localesToDisplayCallback"
                 :default-suggestions="Object.values(Locale)"
                 @search-input-change="handleLocaleInputChange"
@@ -243,13 +243,13 @@
             class="mod-healthcare-professional-section
                  my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
         >
-            {{ $t("modHealthcareProfessionalSection.facilities") }}
+            {{ t("modHealthcareProfessionalSection.facilities") }}
         </h2>
         <ModSearchbar
             v-model="selectedFacilities"
             data-testid="mod-healthcare-professional-section-facilities"
-            :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextFacilitySearchBar')"
-            :no-match-text="$t('modHealthcareProfessionalSection.noFacilitiesWereFound')"
+            :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextFacilitySearchBar')"
+            :no-match-text="t('modHealthcareProfessionalSection.noFacilitiesWereFound')"
             :fields-to-display-callback="facilitiesFieldsToDisplayCallback"
             :default-suggestions="currentFacilities"
             @search-input-change="handleFacilitySearchInputChange"

--- a/components/ModDashboardHealthProfessionalCard.vue
+++ b/components/ModDashboardHealthProfessionalCard.vue
@@ -53,7 +53,7 @@
                             >
                                 <div class="flex flex-col">
                                     <label class="font-semibold">
-                                        {{ $t('modDashboardHealthcareProfessionalCard.spokenLanguages') }}</label>
+                                        {{ t('modDashboardHealthcareProfessionalCard.spokenLanguages') }}</label>
                                     <div class="flex">
                                         <div
                                             v-for="(spokenLanguage, indexOfLocale)
@@ -85,7 +85,7 @@
                     >
                         <div class="flex flex-col mx-2">
                             <label class="font-semibold text-nowrap">
-                                {{ $t('modDashboardHealthcareProfessionalCard.lastName') }}</label>
+                                {{ t('modDashboardHealthcareProfessionalCard.lastName') }}</label>
                             <span
                                 data-testid="healthcare-professional-card-last-name"
                             >
@@ -93,20 +93,20 @@
                         </div>
                         <div class="flex flex-col mr-2">
                             <label class="font-semibold text-nowrap">
-                                {{ $t('modDashboardHealthcareProfessionalCard.firstName') }}</label>
+                                {{ t('modDashboardHealthcareProfessionalCard.firstName') }}</label>
                             <span>{{ healthcareProfessionalNameByLocale.firstName
                             }}</span>
                         </div>
                         <div class="flex flex-col mr-2">
                             <label class="font-semibold text-nowrap">
-                                {{ $t('modDashboardHealthcareProfessionalCard.middleName') }}</label>
+                                {{ t('modDashboardHealthcareProfessionalCard.middleName') }}</label>
                             <span v-show="healthcareProfessionalNameByLocale.middleName">
                                 {{ healthcareProfessionalNameByLocale.middleName }}
                             </span>
                         </div>
                     </div>
                     <div class="flex self-start mr-2 my-2">
-                        <label class="font-semibold mx-2">{{ $t('modDashboardHealthcareProfessionalCard.nameLocale') }}:</label>
+                        <label class="font-semibold mx-2">{{ t('modDashboardHealthcareProfessionalCard.nameLocale') }}:</label>
                         <span
                             id="healthcare-professional-name-locale"
                             class="w-24"
@@ -192,6 +192,8 @@ import {
     type LocalizedNameInput,
     type Relationship
 } from '~/typedefs/gqlTypes'
+
+const { t } = useI18n()
 
 const localeStore = useLocaleStore()
 const facilitiesStore = useFacilitiesStore()

--- a/components/ModDashboardLeftNavbar.vue
+++ b/components/ModDashboardLeftNavbar.vue
@@ -7,13 +7,13 @@
             @change="updateSelectedDashboardView"
         >
             <option :value="SelectedModerationListView.Submissions">
-                {{ $t("modDashboardLeftNav.submissions") }}
+                {{ t("modDashboardLeftNav.submissions") }}
             </option>
             <option :value="SelectedModerationListView.Facilities">
-                {{ $t("modDashboardLeftNav.facilities") }}
+                {{ t("modDashboardLeftNav.facilities") }}
             </option>
             <option :value="SelectedModerationListView.HealthcareProfessionals">
-                {{ $t("modDashboardLeftNav.healthcareProfessionals") }}
+                {{ t("modDashboardLeftNav.healthcareProfessionals") }}
             </option>
         </select>
         <div
@@ -27,7 +27,7 @@
                     class="flex flex-row items-center text-start p-1"
                     @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.ForReview)"
                 >
-                    {{ $t("modDashboardLeftNav.forReview") }} ({{ autofillStatusCount.forReviewCount }})
+                    {{ t("modDashboardLeftNav.forReview") }} ({{ autofillStatusCount.forReviewCount }})
                 </button>
             </div>
             <div class="flex w-4/5 justify-start items-center border-b-2 border-slate-200">
@@ -37,7 +37,7 @@
                     class="flex flex-row items-center text-start p-1 "
                     @click=" updateSubmissionListViewState(SelectedSubmissionListViewTab.Approved)"
                 >
-                    {{ $t("modDashboardLeftNav.approved") }} ({{ autofillStatusCount.approvedCount }})
+                    {{ t("modDashboardLeftNav.approved") }} ({{ autofillStatusCount.approvedCount }})
                 </button>
             </div>
             <div class="flex flex-row w-4/5 justify-start items-center ">
@@ -47,7 +47,7 @@
                     class="flex flex-row items-center text-start p-1"
                     @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.Rejected)"
                 >
-                    {{ $t("modDashboardLeftNav.rejected") }} ({{ autofillStatusCount.rejectedCount }})
+                    {{ t("modDashboardLeftNav.rejected") }} ({{ autofillStatusCount.rejectedCount }})
                 </button>
             </div>
         </div>
@@ -66,6 +66,8 @@ import {
     SelectedModerationListView
 } from '~/stores/moderationSubmissionsStore'
 import type { Submission } from '~/typedefs/gqlTypes'
+
+const { t } = useI18n()
 
 const moderationSubmissionsStore = useModerationSubmissionsStore()
 

--- a/components/ModDashboardTopbar.vue
+++ b/components/ModDashboardTopbar.vue
@@ -13,7 +13,7 @@
                 class="flex justify-center items-center rounded-full bg-secondary-bg border-primary p-1 border-2 w-40
                 font-semibold text-sm mr-2 overflow-hidden text-center hover:bg-currentColor"
             >
-                {{ $t('modDashboardTopbar.addHealthcareProfessional') }}
+                {{ t('modDashboardTopbar.addHealthcareProfessional') }}
             </NuxtLink>
             <NuxtLink
                 v-if="isFacility"
@@ -22,12 +22,12 @@
                 class="flex justify-center items-center rounded-full bg-secondary-bg border-primary p-1 border-2 w-40
                 font-semibold text-sm mr-2 overflow-hidden text-center hover:bg-currentColor"
             >
-                {{ $t('modDashboardTopbar.addFacility') }}
+                {{ t('modDashboardTopbar.addFacility') }}
             </NuxtLink>
             <div class="justify-start items-start flex">
                 <input
                     type="text"
-                    :placeholder="$t('modDashboardTopbar.placeholderText')"
+                    :placeholder="t('modDashboardTopbar.placeholderText')"
                     class=" px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                     text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                 >

--- a/components/ModEditFacilityOrProfessionalTopbar.vue
+++ b/components/ModEditFacilityOrProfessionalTopbar.vue
@@ -30,7 +30,7 @@
                 @click="exitWithoutSavingUpdates"
             >
                 {{
-                    $t('modEditFacilityOrHPTopbar.back') }}
+                    t('modEditFacilityOrHPTopbar.back') }}
             </button>
             <button
                 type="button"
@@ -41,7 +41,7 @@
                 @click="updateFacilityOrHealthcareProfessional"
             >
                 <span>
-                    {{ $t('modEditFacilityOrHPTopbar.update') }}
+                    {{ t('modEditFacilityOrHPTopbar.update') }}
                 </span>
             </button>
             <button
@@ -53,7 +53,7 @@
                 @click="updateFacilityOrHealthcareProfessionalAndExit"
             >
                 <span>
-                    {{ $t('modEditFacilityOrHPTopbar.updateAndExit') }}
+                    {{ t('modEditFacilityOrHPTopbar.updateAndExit') }}
                 </span>
             </button>
             <button
@@ -63,7 +63,7 @@
                 @click="openDeletionConfirmation"
             >
                 {{
-                    $t('modEditFacilityOrHPTopbar.delete') }}
+                    t('modEditFacilityOrHPTopbar.delete') }}
             </button>
         </div>
         <div
@@ -76,14 +76,14 @@
                 >
                     <div v-if="modalType === ModalType.UnsavedChanges">
                         <div class="font-bold text-3xl">
-                            {{ $t('modEditFacilityOrHPTopbar.hasUnsavedChanges') }}
+                            {{ t('modEditFacilityOrHPTopbar.hasUnsavedChanges') }}
                         </div>
                         <button
                             class="bg-primary p-4 rounded-full my-8 font-semibold text-xl"
                             type="button"
                             @click="handleNavigateToModerationScreen"
                         >
-                            {{ $t('modSubmissionForm.confirmationButton') }}
+                            {{ t('modSubmissionForm.confirmationButton') }}
                         </button>
                     </div>
                     <div v-if="modalType === ModalType.DeleteConfirmation">
@@ -91,8 +91,8 @@
                             v-show="moderationScreenStore.editFacilityScreenIsActive()"
                             class="font-bold text-3xl"
                         >
-                            {{ $t('modEditFacilityOrHPTopbar.deleteConfirmationFacility',
-                                  { id: selectedId, facility: facilitiesStore.selectedFacilityData?.nameEn }) }}
+                            {{ t('modEditFacilityOrHPTopbar.deleteConfirmationFacility',
+                                 { id: selectedId, facility: facilitiesStore.selectedFacilityData?.nameEn }) }}
                         </div>
                         <button
                             class="bg-primary p-4 rounded-full my-8 font-semibold text-xl"
@@ -100,7 +100,7 @@
                             @click="deleteFacilityOrHealthcareProfessional"
                         >
                             {{
-                                $t('modEditFacilityOrHPTopbar.deleteButtonText') }}
+                                t('modEditFacilityOrHPTopbar.deleteButtonText') }}
                         </button>
                     </div>
                 </div>

--- a/components/ModEditFacilitySection.vue
+++ b/components/ModEditFacilitySection.vue
@@ -8,84 +8,84 @@
                 v-if="moderationScreenStore.editFacilityScreenIsActive()"
                 class="mb-3.5 text-start text-primary-text text-3xl font-bold font-sans leading-normal"
             >
-                {{ $t('modFacilitySection.facilityHeading') }}
+                {{ t('modFacilitySection.facilityHeading') }}
             </h1>
             <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-                {{ $t('modFacilitySection.contactInformation') }}
+                {{ t('modFacilitySection.contactInformation') }}
             </span>
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.nameEn"
                 data-testid="mod-facility-section-nameEn"
-                :label="$t('modFacilitySection.labelFacilityNameEn')"
+                :label="t('modFacilitySection.labelFacilityNameEn')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityNameEn')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityNameEn')"
                 :required="true"
                 :input-validation-check="validateNameEn"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityNameEn')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityNameEn')"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.nameJa"
                 data-testid="mod-facility-section-nameJa"
-                :label="$t('modFacilitySection.labelFacilityNameJa')"
+                :label="t('modFacilitySection.labelFacilityNameJa')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityNameJa')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityNameJa')"
                 :required="true"
                 :input-validation-check="validateNameJa"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityNameJa')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityNameJa')"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.phone"
                 data-testid="mod-facility-section-phone"
-                :label="$t('modFacilitySection.labelFacilityPhoneNumber')"
+                :label="t('modFacilitySection.labelFacilityPhoneNumber')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityPhoneNumber')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityPhoneNumber')"
                 :required="true"
                 :input-validation-check="validatePhoneNumber"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityPhoneNumber')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityPhoneNumber')"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.email"
                 data-testid="mod-facility-section-email"
-                :label="$t('modFacilitySection.labelFacilityEmail')"
+                :label="t('modFacilitySection.labelFacilityEmail')"
                 type="email"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityEmail')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityEmail')"
                 :required="false"
                 :input-validation-check="validateEmail"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityEmail')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityEmail')"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.website"
                 data-testid="mod-facility-section-website"
-                :label="$t('modFacilitySection.labelFacilityWebsite')"
+                :label="t('modFacilitySection.labelFacilityWebsite')"
                 type="url"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityWebsite')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityWebsite')"
                 :required="false"
                 :input-validation-check="validateWebsite"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityWebsite')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityWebsite')"
             />
         </div>
         <div
             class="mod-facility-address-section"
         >
             <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-                {{ $t('modFacilitySection.addresses') }}
+                {{ t('modFacilitySection.addresses') }}
             </span>
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.postalCode"
                 data-testid="mod-facility-section-postalCode"
-                :label="$t('modFacilitySection.labelFacilityPostalCode')"
+                :label="t('modFacilitySection.labelFacilityPostalCode')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityPostalCode')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityPostalCode')"
                 :required="true"
                 :input-validation-check="validatePostalCode"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityPostalCode')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityPostalCode')"
             />
             <div class="flex flex-col mt-4">
                 <label
                     for="mod-edit-facility-section-prefecture-select-en"
                     class="mb-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t('modFacilitySection.labelFacilityPrefectureEn') }}
+                    {{ t('modFacilitySection.labelFacilityPrefectureEn') }}
                 </label>
                 <select
                     id="mod-edit-facility-section-prefecture-select-en"
@@ -106,39 +106,39 @@
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.cityEn"
                 data-testid="mod-facility-section-cityEn"
-                :label="$t('modFacilitySection.labelFacilityCityEn')"
+                :label="t('modFacilitySection.labelFacilityCityEn')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityCityEn')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityCityEn')"
                 :required="true"
                 :input-validation-check="validateCityEn"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityCityEn')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityCityEn')"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.addressLine1En"
                 data-testid="mod-facility-section-addressLine1En"
-                :label="$t('modFacilitySection.labelFacilityAddressLine1En')"
+                :label="t('modFacilitySection.labelFacilityAddressLine1En')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine1En')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityAddressLine1En')"
                 :required="true"
                 :input-validation-check="validateAddressLineEn"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine1En')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityAddressLine1En')"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.addressLine2En"
                 data-testid="mod-facility-section-addressLine2En"
-                :label="$t('modFacilitySection.labelFacilityAddressLine2En')"
+                :label="t('modFacilitySection.labelFacilityAddressLine2En')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine2En')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityAddressLine2En')"
                 :required="true"
                 :input-validation-check="validateAddressLineEn"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine2En')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityAddressLine2En')"
             />
             <div class="flex flex-col mt-4">
                 <label
                     for="mod-edit-facility-section-prefecture-select-ja"
                     class="mb-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t('modFacilitySection.labelFacilityPrefectureJa') }}
+                    {{ t('modFacilitySection.labelFacilityPrefectureJa') }}
                 </label>
                 <select
                     id="mod-edit-facility-section-prefecture-select-ja"
@@ -159,70 +159,70 @@
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.cityJa"
                 data-testid="mod-facility-section-cityJa"
-                :label="$t('modFacilitySection.labelFacilityCityJa')"
+                :label="t('modFacilitySection.labelFacilityCityJa')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityCityJa')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityCityJa')"
                 :required="true"
                 :input-validation-check="validateCityJa"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityCityJa')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityCityJa')"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.addressLine1Ja"
                 data-testid="mod-facility-section-addressLine1Ja"
-                :label="$t('modFacilitySection.labelFacilityAddressLine1Ja')"
+                :label="t('modFacilitySection.labelFacilityAddressLine1Ja')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine1Ja')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityAddressLine1Ja')"
                 :required="true"
                 :input-validation-check="validateAddressLineJa"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine1Ja')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityAddressLine1Ja')"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.addressLine2Ja"
                 data-testid="mod-facility-section-addressLine2Ja"
-                :label="$t('modFacilitySection.labelFacilityAddressLine2Ja')"
+                :label="t('modFacilitySection.labelFacilityAddressLine2Ja')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityAddressLine2Ja')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityAddressLine2Ja')"
                 :required="true"
                 :input-validation-check="validateAddressLineJa"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityAddressLine2Ja')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityAddressLine2Ja')"
             />
         </div>
         <div
             class="google-maps-section"
         >
             <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-                {{ $t('modFacilitySection.googleMapsInformation') }}
+                {{ t('modFacilitySection.googleMapsInformation') }}
             </span>
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.googlemapsURL"
                 data-testid="mod-facility-section-google-maps"
-                :label="$t('modFacilitySection.labelFacilityGoogleMapsUrl')"
+                :label="t('modFacilitySection.labelFacilityGoogleMapsUrl')"
                 type="url"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityGoogleMapsUrl')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityGoogleMapsUrl')"
                 :required="true"
                 :input-validation-check="validateGoogleMapsUrlInput"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityGoogleMapsUrl')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityGoogleMapsUrl')"
                 :autofill="facilityStore.facilitySectionFields.googlemapsURL"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.mapLatitude"
                 data-testid="mod-facility-section-mapLatitude"
-                :label="$t('modFacilitySection.labelFacilityMapLatitude')"
+                :label="t('modFacilitySection.labelFacilityMapLatitude')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityMapLatitude')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityMapLatitude')"
                 :required="true"
                 :input-validation-check="validateFloat"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityMapLatitude')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityMapLatitude')"
             />
             <ModInputField
                 v-model="facilityStore.facilitySectionFields.mapLongitude"
                 data-testid="mod-facility-section-mapLongitude"
-                :label="$t('modFacilitySection.labelFacilityMapLongitude')"
+                :label="t('modFacilitySection.labelFacilityMapLongitude')"
                 type="text"
-                :placeholder="$t('modFacilitySection.placeholderTextFacilityMapLongitude')"
+                :placeholder="t('modFacilitySection.placeholderTextFacilityMapLongitude')"
                 :required="true"
                 :input-validation-check="validateFloat"
-                :invalid-input-error-message="$t('modFacilitySection.inputErrorMessageFacilityMapLongitude')"
+                :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityMapLongitude')"
             />
         </div>
         <div
@@ -232,13 +232,13 @@
             <span
                 class="mb-1 text-primary-text text-2xl font-bold font-sans leading-normal"
             >
-                {{ $t('modFacilitySection.addHealthcareProfessional') }}
+                {{ t('modFacilitySection.addHealthcareProfessional') }}
             </span>
             <ModSearchBar
                 v-model="healthcareProfessionalsToAddToFacility"
                 data-testid="mod-facility-section-doctor-search"
-                :place-holder-text="$t('modFacilitySection.placeholderTextHealthcareProfessionalSearchbar')"
-                :no-match-text="$t('modFacilitySection.noHealthcareProfessionalFound')"
+                :place-holder-text="t('modFacilitySection.placeholderTextHealthcareProfessionalSearchbar')"
+                :no-match-text="t('modFacilitySection.noHealthcareProfessionalFound')"
                 :fields-to-display-callback="healthcareProfessionalsToDisplayCallback"
                 :default-suggestions="defaultHealthcareProfessionalSuggestions"
                 @search-input-change="handleHealthcareProfessionalsInputChange"
@@ -246,7 +246,7 @@
             <span
                 v-show="!healthcareProfessionalsToAddToFacility.length"
                 class="font-semibold my-3"
-            >- {{ $t('modFacilitySection.noHPSelected') }}
+            >- {{ t('modFacilitySection.noHPSelected') }}
             </span>
             <div
                 v-for="(healthcareProfessional, index) in healthcareProfessionalsToAddToFacility"
@@ -265,7 +265,7 @@
         v-if="moderationScreenStore.editFacilityScreenIsActive()"
     >
         <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-            {{ $t('modFacilitySection.existingHPHeading') }}
+            {{ t('modFacilitySection.existingHPHeading') }}
         </span>
         <div
             v-for="(healthcareProfessional, index) in healthcareProfessionalRelatedToFacilityFiltered"

--- a/components/ModEditHealthcareProfessionalSection.vue
+++ b/components/ModEditHealthcareProfessionalSection.vue
@@ -6,7 +6,7 @@
             class="mod-healthcare-professional-section"
         >
             <h2 class="mb-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal">
-                {{ $t('modHealthcareProfessionalSection.healthcareProfessionalNameHeading') }}
+                {{ t('modHealthcareProfessionalSection.healthcareProfessionalNameHeading') }}
             </h2>
             <div class="input-fields flex flex-col my-4">
                 <Transition
@@ -27,32 +27,32 @@
                         <ModInputField
                             v-model="nameLocaleInputs.lastName"
                             data-testid="mod-healthcare-professional-section-lastName"
-                            :label="$t('modHealthcareProfessionalSection.labelHealthcareProfessionalLastName')"
+                            :label="t('modHealthcareProfessionalSection.labelHealthcareProfessionalLastName')"
                             type="text"
-                            :placeholder="$t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalLastName')"
+                            :placeholder="t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalLastName')"
                             :required="true"
                         />
                         <ModInputField
                             v-model="nameLocaleInputs.firstName"
                             data-testid="mod-healthcare-professional-section-firstName"
-                            :label="$t('modHealthcareProfessionalSection.labelHealthcareProfessionalFirstName')"
+                            :label="t('modHealthcareProfessionalSection.labelHealthcareProfessionalFirstName')"
                             type="text"
-                            :placeholder="$t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalFirstName')"
+                            :placeholder="t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalFirstName')"
                             :required="true"
                         />
                         <ModInputField
                             v-model="nameLocaleInputs.middleName as string"
                             data-testid="mod-healthcare-professional-section-middleName"
-                            :label="$t('modHealthcareProfessionalSection.labelHealthcareProfessionalMiddleName')"
+                            :label="t('modHealthcareProfessionalSection.labelHealthcareProfessionalMiddleName')"
                             type="text"
-                            :placeholder="$t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalMiddleName')"
+                            :placeholder="t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalMiddleName')"
                             :required="false"
                         />
                         <label
                             for="mod-edit-healthcare-professional-section-select-name-locales"
                             class="my-2 text-primary-text text-sm font-bold font-sans"
                         >
-                            {{ $t('modHealthcareProfessionalSection.labelHealthcareProfessionalNameLocale') }}
+                            {{ t('modHealthcareProfessionalSection.labelHealthcareProfessionalNameLocale') }}
                         </label>
                         <select
                             id="mod-edit-healthcare-professional-section-select-name-locales"
@@ -78,14 +78,14 @@
                                 type="button"
                                 @click="handleAddLocalizedName"
                             >
-                                {{ $t('modHealthcareProfessionalSection.save') }}
+                                {{ t('modHealthcareProfessionalSection.save') }}
                             </button>
                             <button
                                 class="bg-error text-primary-text-inverted font-bold py-2 px-4 my-2 rounded w-36"
                                 type="button"
                                 @click="handleCloseAddingNewLocalizedName"
                             >
-                                {{ $t('modHealthcareProfessionalSection.exit') }}
+                                {{ t('modHealthcareProfessionalSection.exit') }}
                             </button>
                         </div>
                         <div
@@ -97,14 +97,14 @@
                                 type="button"
                                 @click="handleUpdateExistingName"
                             >
-                                {{ $t('modHealthcareProfessionalSection.update') }}
+                                {{ t('modHealthcareProfessionalSection.update') }}
                             </button>
                             <button
                                 class="bg-error text-primary-text-inverted font-bold py-2 px-4 my-2 rounded w-36"
                                 type="button"
                                 @click="handleDeleteExistingName"
                             >
-                                {{ $t('modHealthcareProfessionalSection.delete') }}
+                                {{ t('modHealthcareProfessionalSection.delete') }}
                             </button>
                         </div>
                     </div>
@@ -133,26 +133,26 @@
                     class="bg-tertiary text-primary-text-inverted font-bold py-2 px-4 my-2 rounded w-44"
                     @click="handleOpenAddNewNameWithReset"
                 >
-                    {{ $t('modHealthcareProfessionalSection.addHealthCareProfessionalLocaleName') }}
+                    {{ t('modHealthcareProfessionalSection.addHealthCareProfessionalLocaleName') }}
                 </button>
                 <h2
                     :id="ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalMedicalInfo"
                     class="mod-healthcare-professional-section
                      my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
                 >
-                    {{ $t('modHealthcareProfessionalSection.healthcareProfessionalMedicalInfoHeading') }}
+                    {{ t('modHealthcareProfessionalSection.healthcareProfessionalMedicalInfoHeading') }}
                 </h2>
                 <label
                     for="accepted-insurances"
                     class="my-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t("modHealthcareProfessionalSection.selectInsurances") }}
+                    {{ t("modHealthcareProfessionalSection.selectInsurances") }}
                 </label>
                 <ModSearchbar
                     v-model="healthcareProfessionalAcceptedInsurancesArray"
                     data-test-id="mod-healthcare-professional-section-accepted-insurances"
-                    :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextAcceptedInsurances')"
-                    :no-match-text="$t('modHealthcareProfessionalSection.noInsurancesWereFound')"
+                    :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextAcceptedInsurances')"
+                    :no-match-text="t('modHealthcareProfessionalSection.noInsurancesWereFound')"
                     :fields-to-display-callback="insurancesToDisplayCallback"
                     :default-suggestions="Object.values(Insurance)"
                     @search-input-change="handleInsuranceInputChange"
@@ -170,13 +170,13 @@
                     for="degrees"
                     class="my-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t("modHealthcareProfessionalSection.selectDegrees") }}
+                    {{ t("modHealthcareProfessionalSection.selectDegrees") }}
                 </label>
                 <ModSearchbar
                     v-model="healthcareProfessionalDegreesArray"
                     data-test-id="mod-healthcare-professional-section-degrees"
-                    :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextDegrees')"
-                    :no-match-text="$t('modHealthcareProfessionalSection.noDegreesWereFound')"
+                    :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextDegrees')"
+                    :no-match-text="t('modHealthcareProfessionalSection.noDegreesWereFound')"
                     :fields-to-display-callback="degreesToDisplayCallback"
                     :default-suggestions="Object.values(Degree)"
                     @search-input-change="handleDegreeInputChange"
@@ -194,13 +194,13 @@
                     for="specialties"
                     class="my-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t("modHealthcareProfessionalSection.selectSpecialties") }}
+                    {{ t("modHealthcareProfessionalSection.selectSpecialties") }}
                 </label>
                 <ModSearchbar
                     v-model="healthcareProfessionalSpecialtiesArray"
                     data-test-id="mod-healthcare-professional-section-specialties"
-                    :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextSpecialties')"
-                    :no-match-text="$t('modHealthcareProfessionalSection.noSpecialtiesWereFound')"
+                    :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextSpecialties')"
+                    :no-match-text="t('modHealthcareProfessionalSection.noSpecialtiesWereFound')"
                     :fields-to-display-callback="specialtiesToDisplayCallback"
                     :default-suggestions="Object.values(Specialty)"
                     @search-input-change="handleSpecialtyInputChange"
@@ -218,13 +218,13 @@
                     for="locales"
                     class="my-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t("modHealthcareProfessionalSection.selectLocales") }}
+                    {{ t("modHealthcareProfessionalSection.selectLocales") }}
                 </label>
                 <ModSearchbar
                     v-model="healthcareProfessionalSpokenLanguages"
                     data-test-id="mod-healthcare-professional-section-spoken-locales"
-                    :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextLocales')"
-                    :no-match-text="$t('modHealthcareProfessionalSection.noLocalesWereFound')"
+                    :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextLocales')"
+                    :no-match-text="t('modHealthcareProfessionalSection.noLocalesWereFound')"
                     :fields-to-display-callback="localesToDisplayCallback"
                     :default-suggestions="Object.values(Locale)"
                     @search-input-change="handleLocaleInputChange"
@@ -245,12 +245,12 @@
                     class="mod-healthcare-professional-section
                  my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
                 >
-                    {{ $t("modHealthcareProfessionalSection.facilities") }}
+                    {{ t("modHealthcareProfessionalSection.facilities") }}
                 </h2>
                 <ModSearchbar
                     v-model="selectedFacilities"
-                    :place-holder-text="$t('modHealthcareProfessionalSection.placeholderTextFacilitySearchBar')"
-                    :no-match-text="$t('modHealthcareProfessionalSection.noFacilitiesWereFound')"
+                    :place-holder-text="t('modHealthcareProfessionalSection.placeholderTextFacilitySearchBar')"
+                    :no-match-text="t('modHealthcareProfessionalSection.noFacilitiesWereFound')"
                     :fields-to-display-callback="facilitiesFieldsToDisplayCallback"
                     :default-suggestions="currentFacilities"
                     @search-input-change="handleFacilitySearchInputChange"

--- a/components/ModEditSubmissionForm.vue
+++ b/components/ModEditSubmissionForm.vue
@@ -11,14 +11,14 @@
                 class="flex flex-col aspect-square h-96 items-center justify-around bg-primary-inverted p-10 rounded"
             >
                 <span class="font-bold text-3xl">
-                    {{ $t('modSubmissionForm.submissionConfirmationMessage') }}
+                    {{ t('modSubmissionForm.submissionConfirmationMessage') }}
                 </span>
                 <button
                     type="button"
                     class="bg-primary p-4 rounded-full my-8 font-semibold text-xl"
                     @click="submitCompletedForm"
                 >
-                    {{ $t('modSubmissionForm.submissionConfirmationAcceptanceButton') }}
+                    {{ t('modSubmissionForm.submissionConfirmationAcceptanceButton') }}
                 </button>
             </div>
             <div
@@ -27,7 +27,7 @@
                 class="flex flex-col aspect-square h-96 items-center justify-around bg-primary-inverted p-10 rounded"
             >
                 <span class="font-bold text-3xl">
-                    {{ $t('modSubmissionForm.rejectSubmissionConfirmationMessage') }}
+                    {{ t('modSubmissionForm.rejectSubmissionConfirmationMessage') }}
                 </span>
                 <button
                     data-testid="reject-submission-confirmation-btn"
@@ -35,21 +35,21 @@
                     class="bg-primary p-4 rounded-full my-8 font-semibold text-xl"
                     @click="rejectSubmission"
                 >
-                    {{ $t('modSubmissionForm.rejectSubmissionConfirmationButton') }}
+                    {{ t('modSubmissionForm.rejectSubmissionConfirmationButton') }}
                 </button>
             </div>
             <div
                 v-if="formHasUnsavedChanges"
                 class="flex flex-col aspect-square h-96 items-center justify-around bg-primary-inverted p-10 rounded"
             >
-                <span class="font-bold text-3xl">{{ $t('modSubmissionForm.hasUnsavedChanges') }}</span>
+                <span class="font-bold text-3xl">{{ t('modSubmissionForm.hasUnsavedChanges') }}</span>
                 <button
                     type="button"
                     data-testid="submission-unsaved-confirmation-btn"
                     class="bg-secondary p-4 rounded-full my-8 font-semibold text-xl hover:bg-primary"
                     @click="handleNavigateToModerationScreen"
                 >
-                    {{ $t('modSubmissionForm.confirmationButton') }}
+                    {{ t('modSubmissionForm.confirmationButton') }}
                 </button>
             </div>
         </Modal>
@@ -65,60 +65,60 @@
             <h1
                 class="mb-3.5 text-start text-primary-text text-3xl font-bold font-sans leading-normal"
             >
-                {{ $t('modSubmissionForm.facilityHeading') }}
+                {{ t('modSubmissionForm.facilityHeading') }}
             </h1>
             <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-                {{ $t('modSubmissionForm.contactInformation') }}
+                {{ t('modSubmissionForm.contactInformation') }}
             </span>
             <ModInputField
                 v-model="submissionFormFields.nameEn"
                 data-testid="submission-form-nameEn"
-                :label="$t('modSubmissionForm.labelFacilityNameEn')"
+                :label="t('modSubmissionForm.labelFacilityNameEn')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityNameEn')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityNameEn')"
                 :required="true"
                 :input-validation-check="validateNameEn"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityNameEn')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityNameEn')"
             />
             <ModInputField
                 v-model="submissionFormFields.nameJa"
                 data-testid="submission-form-nameJa"
-                :label="$t('modSubmissionForm.labelFacilityNameJa')"
+                :label="t('modSubmissionForm.labelFacilityNameJa')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityNameJa')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityNameJa')"
                 :required="true"
                 :input-validation-check="validateNameJa"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityNameJa')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityNameJa')"
             />
             <ModInputField
                 v-model="submissionFormFields.phone"
                 data-testid="submission-form-phone"
-                :label="$t('modSubmissionForm.labelFacilityPhoneNumber')"
+                :label="t('modSubmissionForm.labelFacilityPhoneNumber')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityPhoneNumber')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityPhoneNumber')"
                 :required="true"
                 :input-validation-check="validatePhoneNumber"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityPhoneNumber')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityPhoneNumber')"
             />
             <ModInputField
                 v-model="submissionFormFields.email"
                 data-testid="submission-form-email"
-                :label="$t('modSubmissionForm.labelFacilityEmail')"
+                :label="t('modSubmissionForm.labelFacilityEmail')"
                 type="email"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityEmail')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityEmail')"
                 :required="false"
                 :input-validation-check="validateEmail"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityEmail')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityEmail')"
             />
             <ModInputField
                 v-model="submissionFormFields.website"
                 data-testid="submission-form-website"
-                :label="$t('modSubmissionForm.labelFacilityWebsite')"
+                :label="t('modSubmissionForm.labelFacilityWebsite')"
                 type="url"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityWebsite')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityWebsite')"
                 :required="false"
                 :input-validation-check="validateWebsite"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityWebsite')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityWebsite')"
             />
         </div>
 
@@ -127,24 +127,24 @@
             class="submission-form-section"
         >
             <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-                {{ $t('modSubmissionForm.addresses') }}
+                {{ t('modSubmissionForm.addresses') }}
             </span>
             <ModInputField
                 v-model="submissionFormFields.postalCode"
                 data-testid="submission-form-postalCode"
-                :label="$t('modSubmissionForm.labelFacilityPostalCode')"
+                :label="t('modSubmissionForm.labelFacilityPostalCode')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityPostalCode')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityPostalCode')"
                 :required="true"
                 :input-validation-check="validatePostalCode"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityPostalCode')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityPostalCode')"
             />
             <div class="flex flex-col mt-4">
                 <label
                     for="mod-edit-submission-form-prefecture-select-en"
                     class="mb-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t('modSubmissionForm.labelFacilityPrefectureEn') }}
+                    {{ t('modSubmissionForm.labelFacilityPrefectureEn') }}
                 </label>
                 <select
                     id="mod-edit-submission-form-prefecture-select-en"
@@ -165,39 +165,39 @@
             <ModInputField
                 v-model="submissionFormFields.cityEn"
                 data-testid="submission-form-cityEn"
-                :label="$t('modSubmissionForm.labelFacilityCityEn')"
+                :label="t('modSubmissionForm.labelFacilityCityEn')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityCityEn')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityCityEn')"
                 :required="true"
                 :input-validation-check="validateCityEn"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityCityEn')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityCityEn')"
             />
             <ModInputField
                 v-model="submissionFormFields.addressLine1En"
                 data-testid="submission-form-addressLine1En"
-                :label="$t('modSubmissionForm.labelFacilityAddressLine1En')"
+                :label="t('modSubmissionForm.labelFacilityAddressLine1En')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityAddressLine1En')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityAddressLine1En')"
                 :required="true"
                 :input-validation-check="validateAddressLineEn"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityAddressLine1En')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityAddressLine1En')"
             />
             <ModInputField
                 v-model="submissionFormFields.addressLine2En"
                 data-testid="submission-form-addressLine2En"
-                :label="$t('modSubmissionForm.labelFacilityAddressLine2En')"
+                :label="t('modSubmissionForm.labelFacilityAddressLine2En')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityAddressLine2En')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityAddressLine2En')"
                 :required="true"
                 :input-validation-check="validateAddressLineEn"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityAddressLine2En')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityAddressLine2En')"
             />
             <div class="flex flex-col mt-4">
                 <label
                     for="mod-edit-submission-form-prefecture-select-ja"
                     class="mb-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t('modSubmissionForm.labelFacilityPrefectureJa') }}
+                    {{ t('modSubmissionForm.labelFacilityPrefectureJa') }}
                 </label>
                 <select
                     id="mod-edit-submission-form-prefecture-select-ja"
@@ -218,32 +218,32 @@
             <ModInputField
                 v-model="submissionFormFields.cityJa"
                 data-testid="submission-form-cityJa"
-                :label="$t('modSubmissionForm.labelFacilityCityJa')"
+                :label="t('modSubmissionForm.labelFacilityCityJa')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityCityJa')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityCityJa')"
                 :required="true"
                 :input-validation-check="validateCityJa"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityCityJa')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityCityJa')"
             />
             <ModInputField
                 v-model="submissionFormFields.addressLine1Ja"
                 data-testid="submission-form-addressLine1Ja"
-                :label="$t('modSubmissionForm.labelFacilityAddressLine1Ja')"
+                :label="t('modSubmissionForm.labelFacilityAddressLine1Ja')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityAddressLine1Ja')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityAddressLine1Ja')"
                 :required="true"
                 :input-validation-check="validateAddressLineJa"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityAddressLine1Ja')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityAddressLine1Ja')"
             />
             <ModInputField
                 v-model="submissionFormFields.addressLine2Ja"
                 data-testid="submission-form-addressLine2Ja"
-                :label="$t('modSubmissionForm.labelFacilityAddressLine2Ja')"
+                :label="t('modSubmissionForm.labelFacilityAddressLine2Ja')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityAddressLine2Ja')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityAddressLine2Ja')"
                 :required="true"
                 :input-validation-check="validateAddressLineJa"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityAddressLine2Ja')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityAddressLine2Ja')"
             />
         </div>
         <div
@@ -251,38 +251,38 @@
             class="submission-form-section"
         >
             <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-                {{ $t('modSubmissionForm.googleMapsInformation') }}
+                {{ t('modSubmissionForm.googleMapsInformation') }}
             </span>
             <ModInputField
                 v-model="submissionFormFields.googlemapsURL"
                 data-testid="submission-form-google-maps"
-                :label="$t('modSubmissionForm.labelFacilityGoogleMapsUrl')"
+                :label="t('modSubmissionForm.labelFacilityGoogleMapsUrl')"
                 type="url"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityGoogleMapsUrl')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityGoogleMapsUrl')"
                 :required="true"
                 :input-validation-check="validateGoogleMapsUrlInput"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityGoogleMapsUrl')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityGoogleMapsUrl')"
                 :autofill-value="submissionFormFields.googlemapsURL"
             />
             <ModInputField
                 v-model="submissionFormFields.mapLatitude"
                 data-testid="submission-form-mapLatitude"
-                :label="$t('modSubmissionForm.labelFacilityMapLatitude')"
+                :label="t('modSubmissionForm.labelFacilityMapLatitude')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityMapLatitude')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityMapLatitude')"
                 :required="true"
                 :input-validation-check="validateFloat"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityMapLatitude')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityMapLatitude')"
             />
             <ModInputField
                 v-model="submissionFormFields.mapLongitude"
                 data-testid="submission-form-mapLongitude"
-                :label="$t('modSubmissionForm.labelFacilityMapLongitude')"
+                :label="t('modSubmissionForm.labelFacilityMapLongitude')"
                 type="text"
-                :placeholder="$t('modSubmissionForm.placeholderTextFacilityMapLongitude')"
+                :placeholder="t('modSubmissionForm.placeholderTextFacilityMapLongitude')"
                 :required="true"
                 :input-validation-check="validateFloat"
-                :invalid-input-error-message="$t('modSubmissionForm.inputErrorMessageFacilityMapLongitude')"
+                :invalid-input-error-message="t('modSubmissionForm.inputErrorMessageFacilityMapLongitude')"
             />
         </div>
         <ModHealthcareProfessionalSearchbar data-testid="submission-form-doctor-search" />
@@ -290,7 +290,7 @@
             :id="ModSubmissionLeftNavbarSectionIDs.HealthcareProfessionalName"
             class="submission-form-section mb-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
         >
-            {{ $t('modSubmissionForm.healthcareProfessionalNameHeading') }}
+            {{ t('modSubmissionForm.healthcareProfessionalNameHeading') }}
         </h2>
         <div class="flex flex-col my-4">
             <div class="input-fields flex flex-col my-4">
@@ -314,35 +314,35 @@
                         <ModInputField
                             v-model="nameLocaleInputsToAddOrUpdate.lastName"
                             data-testid="mod-healthcare-professional-section-lastName"
-                            :label="$t('modHealthcareProfessionalSection.labelHealthcareProfessionalLastName')"
+                            :label="t('modHealthcareProfessionalSection.labelHealthcareProfessionalLastName')"
                             type="text"
                             :placeholder=
-                                "$t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalLastName')"
+                                "t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalLastName')"
                             :required="true"
                         />
                         <ModInputField
                             v-model="nameLocaleInputsToAddOrUpdate.firstName"
                             data-testid="mod-healthcare-professional-section-firstName"
-                            :label="$t('modHealthcareProfessionalSection.labelHealthcareProfessionalFirstName')"
+                            :label="t('modHealthcareProfessionalSection.labelHealthcareProfessionalFirstName')"
                             type="text"
                             :placeholder=
-                                "$t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalFirstName')"
+                                "t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalFirstName')"
                             :required="true"
                         />
                         <ModInputField
                             v-model="nameLocaleInputsToAddOrUpdate.middleName as string"
                             data-testid="mod-healthcare-professional-section-middleName"
-                            :label="$t('modHealthcareProfessionalSection.labelHealthcareProfessionalMiddleName')"
+                            :label="t('modHealthcareProfessionalSection.labelHealthcareProfessionalMiddleName')"
                             type="text"
                             :placeholder=
-                                "$t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalMiddleName')"
+                                "t('modHealthcareProfessionalSection.placeholderTextHealthcareProfessionalMiddleName')"
                             :required="false"
                         />
                         <label
                             for="mod-edit-submission-form-name-locales"
                             class="my-2 text-primary-text text-sm font-bold font-sans"
                         >
-                            {{ $t('modHealthcareProfessionalSection.labelHealthcareProfessionalNameLocale') }}
+                            {{ t('modHealthcareProfessionalSection.labelHealthcareProfessionalNameLocale') }}
                         </label>
                         <select
                             id="mod-edit-submission-form-name-locales"
@@ -368,14 +368,14 @@
                                 type="button"
                                 @click="handleAddLocalizedName"
                             >
-                                {{ $t('modHealthcareProfessionalSection.save') }}
+                                {{ t('modHealthcareProfessionalSection.save') }}
                             </button>
                             <button
                                 class="bg-error text-primary-text-inverted font-bold py-2 px-4 my-2 rounded w-36"
                                 type="button"
                                 @click="handleCloseAddingNewLocalizedName"
                             >
-                                {{ $t('modHealthcareProfessionalSection.exit') }}
+                                {{ t('modHealthcareProfessionalSection.exit') }}
                             </button>
                         </div>
                         <div
@@ -387,14 +387,14 @@
                                 type="button"
                                 @click="handleUpdateExistingName"
                             >
-                                {{ $t('modHealthcareProfessionalSection.update') }}
+                                {{ t('modHealthcareProfessionalSection.update') }}
                             </button>
                             <button
                                 class="bg-error text-primary-text-inverted font-bold py-2 px-4 my-2 rounded w-36"
                                 type="button"
                                 @click="handleDeleteExistingName"
                             >
-                                {{ $t('modHealthcareProfessionalSection.delete') }}
+                                {{ t('modHealthcareProfessionalSection.delete') }}
                             </button>
                         </div>
                     </div>
@@ -422,7 +422,7 @@
                     class="bg-tertiary text-primary-text-inverted font-bold py-2 px-4 my-2 rounded w-44"
                     @click="handleOpenAddNewNameWithReset"
                 >
-                    {{ $t('modHealthcareProfessionalSection.addHealthCareProfessionalLocaleName') }}
+                    {{ t('modHealthcareProfessionalSection.addHealthCareProfessionalLocaleName') }}
                 </button>
             </div>
             <div class="flex flex-col">
@@ -431,19 +431,19 @@
                     class="submission-form-section
                     my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
                 >
-                    {{ $t('modSubmissionForm.healthcareProfessionalMedicalInfoHeading') }}
+                    {{ t('modSubmissionForm.healthcareProfessionalMedicalInfoHeading') }}
                 </h2>
                 <label
                     for="accepted-insurances"
                     class="my-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t("modSubmissionForm.selectInsurances") }}
+                    {{ t("modSubmissionForm.selectInsurances") }}
                 </label>
                 <ModSearchBar
                     v-model="submissionFormFields.healthcareProfessionalAcceptedInsurances"
                     data-testid="submission-form-accepted-insurances"
-                    :place-holder-text="$t('modSubmissionForm.placeholderTextAcceptedInsurances')"
-                    :no-match-text="$t('modSubmissionForm.noInsurancesWereFound')"
+                    :place-holder-text="t('modSubmissionForm.placeholderTextAcceptedInsurances')"
+                    :no-match-text="t('modSubmissionForm.noInsurancesWereFound')"
                     :fields-to-display-callback="insurancesToDisplayCallback"
                     :default-suggestions="Object.values(Insurance)"
                     @search-input-change="handleInsuranceInputChange"
@@ -461,13 +461,13 @@
                     for="degrees"
                     class="my-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t("modSubmissionForm.selectDegrees") }}
+                    {{ t("modSubmissionForm.selectDegrees") }}
                 </label>
                 <ModSearchBar
                     v-model="submissionFormFields.healthcareProfessionalDegrees"
                     data-testid="submission-form-degrees"
-                    :place-holder-text="$t('modSubmissionForm.placeholderTextDegrees')"
-                    :no-match-text="$t('modSubmissionForm.noDegreesWereFound')"
+                    :place-holder-text="t('modSubmissionForm.placeholderTextDegrees')"
+                    :no-match-text="t('modSubmissionForm.noDegreesWereFound')"
                     :fields-to-display-callback="degreesToDisplayCallback"
                     :default-suggestions="Object.values(Degree)"
                     @search-input-change="handleDegreeInputChange"
@@ -485,13 +485,13 @@
                     for="specialties"
                     class="my-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t("modSubmissionForm.selectSpecialties") }}
+                    {{ t("modSubmissionForm.selectSpecialties") }}
                 </label>
                 <ModSearchBar
                     v-model="submissionFormFields.healthcareProfessionalSpecialties"
                     data-testid="submission-form-specialties"
-                    :place-holder-text="$t('modSubmissionForm.placeholderTextSpecialties')"
-                    :no-match-text="$t('modSubmissionForm.noSpecialtiesWereFound')"
+                    :place-holder-text="t('modSubmissionForm.placeholderTextSpecialties')"
+                    :no-match-text="t('modSubmissionForm.noSpecialtiesWereFound')"
                     :fields-to-display-callback="specialtiesToDisplayCallback"
                     :default-suggestions="Object.values(Specialty)"
                     @search-input-change="handleSpecialtyInputChange"
@@ -509,13 +509,13 @@
                     for="locales"
                     class="my-2 text-primary-text text-sm font-bold font-sans"
                 >
-                    {{ $t("modSubmissionForm.selectLocales") }}
+                    {{ t("modSubmissionForm.selectLocales") }}
                 </label>
                 <ModSearchBar
                     v-model="submissionFormFields.healthcareProfessionalLocales"
                     data-testid="submission-form-locales"
-                    :place-holder-text="$t('modSubmissionForm.placeholderTextLocales')"
-                    :no-match-text="$t('modSubmissionForm.noLocalesWereFound')"
+                    :place-holder-text="t('modSubmissionForm.placeholderTextLocales')"
+                    :no-match-text="t('modSubmissionForm.noLocalesWereFound')"
                     :fields-to-display-callback="localesToDisplayCallback"
                     :default-suggestions="Object.values(Locale)"
                     @search-input-change="handleLocaleInputChange"
@@ -535,7 +535,7 @@
                 class="bg-currentColor text-white font-bold py-2 px-4 my-2 rounded w-56"
                 @click="submitUpdatedSubmission"
             >
-                {{ $t('modSubmissionForm.updateButtonText') }}
+                {{ t('modSubmissionForm.updateButtonText') }}
             </button>
         </div>
     </form>

--- a/components/ModEditSubmissionTopbar.vue
+++ b/components/ModEditSubmissionTopbar.vue
@@ -31,7 +31,7 @@
                 @click="saveAndExit"
             >
                 <span>
-                    {{ $t('modEditSubmissionTopNav.saveAndExit') }}
+                    {{ t('modEditSubmissionTopNav.saveAndExit') }}
                 </span>
             </button>
             <button
@@ -41,7 +41,7 @@
                 @click="showRejectionConfirmation"
             >
                 {{
-                    $t('modEditSubmissionTopNav.reject') }}
+                    t('modEditSubmissionTopNav.reject') }}
             </button>
             <button
                 type="button"
@@ -49,7 +49,7 @@
                 @click="acceptSubmission"
             >
                 {{
-                    $t('modEditSubmissionTopNav.approve') }}
+                    t('modEditSubmissionTopNav.approve') }}
             </button>
         </div>
     </div>
@@ -61,6 +61,8 @@ import SVGCopyContent from '~/assets/icons/content-copy.svg'
 import SVGSuccessCheckMark from '~/assets/icons/checkmark-square.svg'
 import { useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
 import { useModalStore } from '~/stores/modalStore'
+
+const { t } = useI18n()
 
 const modalStore = useModalStore()
 const moderationSubmissionStore = useModerationSubmissionsStore()

--- a/components/ModHealthcareProfessionalLeftNavbar.vue
+++ b/components/ModHealthcareProfessionalLeftNavbar.vue
@@ -2,7 +2,7 @@
     <div class="flex flex-col">
         <h1 class="font-bold text-lg p-1 mb-2 text-ellipsis">
             {{ moderationSubmissionsStore.selectedSubmissionData?.facility?.nameEn
-                || $t("modPanelSubmissionLeftNavbar.facilityNameUnknown") }}
+                || t("modPanelSubmissionLeftNavbar.facilityNameUnknown") }}
         </h1>
         <div class="flex flex-col items-start">
             <button
@@ -15,7 +15,7 @@
                 class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
                 @click="handleNavClick(ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalName)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.healthcareProfessionalName") }}
+                {{ t("modPanelSubmissionLeftNavbar.healthcareProfessionalName") }}
             </button>
 
             <button
@@ -29,7 +29,7 @@
                 class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
                 @click="handleNavClick(ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalMedicalInfo)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.healthcareProfessionalMedicalInfo") }}
+                {{ t("modPanelSubmissionLeftNavbar.healthcareProfessionalMedicalInfo") }}
             </button>
 
             <button
@@ -44,7 +44,7 @@
                 @click="handleNavClick(
                     ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalFacilities)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.healthcareProfessionalFacilities") }}
+                {{ t("modPanelSubmissionLeftNavbar.healthcareProfessionalFacilities") }}
             </button>
         </div>
     </div>
@@ -55,6 +55,8 @@ import { ref, type Ref, onMounted, onUnmounted } from 'vue'
 import { useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
 import { ModHealthcareProfessionalsLeftNavbarSections } from '~/stores/moderationScreenStore'
 import { handleScroll, observeFormSections, scrollToSectionOfForm, type SectionInformation } from '~/utils/handleScroll'
+
+const { t } = useI18n()
 
 const moderationSubmissionsStore = useModerationSubmissionsStore()
 const activeSection: Ref<string> = ref(ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalName)

--- a/components/ModHealthcareProfessionalSearchbar.vue
+++ b/components/ModHealthcareProfessionalSearchbar.vue
@@ -1,14 +1,14 @@
 <template>
     <div>
         <span class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal">
-            {{ $t('modSubmissionForm.healthcareProfessionalId') }}
+            {{ t('modSubmissionForm.healthcareProfessionalId') }}
         </span>
         <div class="flex flex-col mt-4">
             <div class="justify-start items-start flex">
                 <input
                     v-model="searchValue"
                     type="text"
-                    :placeholder="$t('modSubmissionForm.placeholderTextHealthcareProfessionalSearchbar')"
+                    :placeholder="t('modSubmissionForm.placeholderTextHealthcareProfessionalSearchbar')"
                     class="px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                     text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                     @input="searchHealthcareProfessionalByIdOrName"
@@ -75,6 +75,8 @@ import { RelationshipAction, type HealthcareProfessional } from '~/typedefs/gqlT
 import { useHealthcareProfessionalsStore } from '~/stores/healthcareProfessionalsStore'
 import { useFacilitiesStore } from '~/stores/facilitiesStore'
 import { useModerationScreenStore } from '~/stores/moderationScreenStore'
+
+const { t } = useI18n()
 
 const healthcareProfessionalsStore = useHealthcareProfessionalsStore()
 const moderationScreenStore = useModerationScreenStore()

--- a/components/ModSubmissionLeftNavbar.vue
+++ b/components/ModSubmissionLeftNavbar.vue
@@ -2,7 +2,7 @@
     <div class="flex flex-col">
         <h1 class="font-bold text-lg p-1 mb-2 text-ellipsis">
             {{ moderationSubmissionsStore.selectedSubmissionData?.facility?.nameEn
-                || $t("modPanelSubmissionLeftNavbar.facilityNameUnknown") }}
+                || t("modPanelSubmissionLeftNavbar.facilityNameUnknown") }}
         </h1>
         <div class="flex flex-col items-start">
             <button
@@ -12,7 +12,7 @@
                 class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
                 @click="scrollToSectionOfForm(ModSubmissionLeftNavbarSectionIDs.ContactInformation)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.contactInformation") }}
+                {{ t("modPanelSubmissionLeftNavbar.contactInformation") }}
             </button>
             <button
                 data-testid="submission-form-leftnav-addresses"
@@ -21,7 +21,7 @@
                 class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
                 @click="scrollToSectionOfForm(ModSubmissionLeftNavbarSectionIDs.Addresses)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.addresses") }}
+                {{ t("modPanelSubmissionLeftNavbar.addresses") }}
             </button>
             <button
                 data-testid="submission-form-leftnav-google-maps-information"
@@ -30,7 +30,7 @@
                 class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
                 @click="scrollToSectionOfForm(ModSubmissionLeftNavbarSectionIDs.GoogleMapsInformation)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.googleMapsInformation") }}
+                {{ t("modPanelSubmissionLeftNavbar.googleMapsInformation") }}
             </button>
             <button
                 data-testid="submission-form-leftnav-healthcare-professional-ids"
@@ -39,7 +39,7 @@
                 class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
                 @click="scrollToSectionOfForm(ModSubmissionLeftNavbarSectionIDs.HealthcareProfessionalIds)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.healthcareProfessionalIds") }}
+                {{ t("modPanelSubmissionLeftNavbar.healthcareProfessionalIds") }}
             </button>
             <button
                 data-testid="submission-form-leftnav-change-log"
@@ -48,7 +48,7 @@
                 class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
                 @click="scrollToSectionOfForm(ModSubmissionLeftNavbarSectionIDs.ChangeLog)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.changeLog") }}
+                {{ t("modPanelSubmissionLeftNavbar.changeLog") }}
             </button>
             <button
                 data-testid="submission-form-leftnav-healthcare-professional-name"
@@ -57,7 +57,7 @@
                 class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
                 @click="scrollToSectionOfForm(ModSubmissionLeftNavbarSectionIDs.HealthcareProfessionalName)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.healthcareProfessionalName") }}
+                {{ t("modPanelSubmissionLeftNavbar.healthcareProfessionalName") }}
             </button>
             <button
                 data-testid="submission-form-leftnav-healthcare-professional-medical-info"
@@ -67,7 +67,7 @@
                 class="w-full py-4 my-2 text-sm text-start pl-2 rounded border-b-2 border-tertiary-bg"
                 @click="scrollToSectionOfForm(ModSubmissionLeftNavbarSectionIDs.HealthcareProfessionalMedicalInfo)"
             >
-                {{ $t("modPanelSubmissionLeftNavbar.healthcareProfessionalMedicalInfo") }}
+                {{ t("modPanelSubmissionLeftNavbar.healthcareProfessionalMedicalInfo") }}
             </button>
         </div>
     </div>
@@ -78,6 +78,8 @@ import { ref, type Ref, onMounted, onUnmounted } from 'vue'
 import { useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
 import { ModSubmissionLeftNavbarSectionIDs } from '~/stores/moderationScreenStore'
 import { handleScroll, observeFormSections, scrollToSectionOfForm, type SectionInformation } from '~/utils/handleScroll'
+
+const { t } = useI18n()
 
 const moderationSubmissionsStore = useModerationSubmissionsStore()
 const activeSection: Ref<string> = ref(ModSubmissionLeftNavbarSectionIDs.ContactInformation)

--- a/components/ModSubmissionListContainer.vue
+++ b/components/ModSubmissionListContainer.vue
@@ -7,13 +7,13 @@
             #
         </div>
         <div class="font-bold text-left p-1">
-            {{ $t("modPanelSubmissionList.name") }}
+            {{ t("modPanelSubmissionList.name") }}
         </div>
         <div class="font-bold text-left p-1">
-            {{ $t("modPanelSubmissionList.modified") }}
+            {{ t("modPanelSubmissionList.modified") }}
         </div>
         <div class="font-bold text-left p-1">
-            {{ $t("modPanelSubmissionList.submitted") }}
+            {{ t("modPanelSubmissionList.submitted") }}
         </div>
         <div
             v-if="hasSubmissions
@@ -36,7 +36,7 @@
                     >
                         <span class="text-start">{{ index + 1 }}</span>
                         <span class="text-start">
-                            {{ submission.healthcareProfessionalName || $t("modPanelSubmissionList.facilityNameUnknown") }}
+                            {{ submission.healthcareProfessionalName || t("modPanelSubmissionList.facilityNameUnknown") }}
                         </span>
                         <span class="text-start">{{ convertDateToLocalTime(submission.updatedDate) }}</span>
                         <span class="text-start">{{ convertDateToLocalTime(submission.createdDate) }}</span>
@@ -102,7 +102,7 @@
             </div>
         </div>
         <div v-else>
-            {{ $t("modPanelSubmissionList.noSubmissions") }}
+            {{ t("modPanelSubmissionList.noSubmissions") }}
         </div>
     </div>
 </template>
@@ -112,6 +112,8 @@ import { computed, onMounted } from 'vue'
 import { SelectedModerationListView, useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
 import { useHealthcareProfessionalsStore } from '~/stores/healthcareProfessionalsStore'
 import { useFacilitiesStore } from '~/stores/facilitiesStore'
+
+const { t } = useI18n()
 
 const modSubmissionsListStore = useModerationSubmissionsStore()
 const healthcareProfessionalsStore = useHealthcareProfessionalsStore()

--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -16,7 +16,7 @@
                         disabled
                         selected
                     >
-                        {{ $t('searchBar.selectSpecialty') }}
+                        {{ t('searchBar.selectSpecialty') }}
                     </option>
                     <option
                         v-for="(specialty) in specialtyDropdownOptions"
@@ -39,7 +39,7 @@
                         disabled
                         selected
                     >
-                        {{ $t('searchBar.selectLocation') }}
+                        {{ t('searchBar.selectLocation') }}
                     </option>
                     <option>{{ placeHolderTextDisplay }}</option>
                     <option
@@ -64,7 +64,7 @@
                         disabled
                         selected
                     >
-                        {{ $t('searchBar.selectLanguage') }}
+                        {{ t('searchBar.selectLanguage') }}
                     </option>
                     <option
                         v-for="(language) in languageDropdownOptions"
@@ -93,7 +93,7 @@
                     title="search icon"
                     class="search-icon w-5 h-5 mr-1 fill-primary-text-inverted"
                 />
-                <span class="self-center text-primary-text-inverted">{{ $t('searchBar.search') }}</span>
+                <span class="self-center text-primary-text-inverted">{{ t('searchBar.search') }}</span>
             </button>
         </div>
     </div>
@@ -107,6 +107,8 @@ import { useLocationsStore } from '~/stores/locationsStore.js'
 import { useSpecialtiesStore, type SpecialtyDisplayOption } from '~/stores/specialtiesStore.js'
 import type { Locale, Specialty } from '~/typedefs/gqlTypes.js'
 import { useLocaleStore, type LocaleDisplay } from '~/stores/localeStore.js'
+
+const { t } = useI18n()
 
 const localeStore = useLocaleStore()
 const locationsStore = useLocationsStore()

--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -31,7 +31,7 @@
             </div>
             <div>
                 <div class="ml-9 mt-2 font-bold text-sm">
-                    <span>{{ $t("searchResultsDetails.speaks") }}:</span>
+                    <span>{{ t("searchResultsDetails.speaks") }}:</span>
                 </div>
                 <div class="result-tags flex flex-wrap w-64 mb-6 mt-1 ml-6 pl-2">
                     <div
@@ -46,7 +46,7 @@
             </div>
             <div class="about ml-4 pl-2">
                 <span class="font-semibold">{{
-                    $t("searchResultsDetails.contact")
+                    t("searchResultsDetails.contact")
                 }}</span>
                 <div class="address flex my-4">
                     <SVGMapPinIcon
@@ -124,6 +124,8 @@ import { useLocaleStore } from '~/stores/localeStore.js'
 import { useSpecialtiesStore } from '~/stores/specialtiesStore.js'
 import { useSearchResultsStore } from '~/stores/searchResultsStore'
 import { Locale } from '~/typedefs/gqlTypes.js'
+
+const { t } = useI18n()
 
 const resultsStore = useSearchResultsStore()
 const localeStore = useLocaleStore()

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -4,7 +4,7 @@
     >
         <div class="results-header flex flex-row ml-9 mr-5 mb-6 pt-5">
             <span class="flex-1 w-1/2 font-bold self-center">
-                {{ $t('searchResultsList.doctorsNearby') }}
+                {{ t('searchResultsList.doctorsNearby') }}
             </span>
             <button
                 role="button"
@@ -19,7 +19,7 @@
                     class="fill-primary/50 h-5 w-5 self-center group-hover:fill-primary-text-inverted/50"
                 />
                 <span class="text-primary-text/50 pl-1 font-bold self-center group-hover:text-primary-text-inverted/50">
-                    {{ $t('searchResultsList.filters') }}
+                    {{ t('searchResultsList.filters') }}
                 </span>
             </button>
         </div>
@@ -75,9 +75,9 @@
             <div class="flex flex-col">
                 <SVGNoSearchResults class="portrait:px-4 h-12" />
                 <span class="text-primary-text px-1 font-bold self-center group-hover:text-primary-text-inverted/50">{{
-                    $t('searchResultsList.noResults') }}</span>
+                    t('searchResultsList.noResults') }}</span>
                 <span class="text-primary-text self-center text-center">{{
-                    $t('searchResultsList.noResultsSubtext') }}</span>
+                    t('searchResultsList.noResultsSubtext') }}</span>
             </div>
         </div>
     </div>
@@ -92,6 +92,8 @@ import { Locale } from '~/typedefs/gqlTypes.js'
 import SVGLoadingIcon from '~/assets/icons/loading.svg'
 import SVGNoSearchResults from '~/assets/icons/no-search-results-graphic.svg'
 import SVGHamburgerListIcon from '~/assets/icons/hamburger-list-icon.svg'
+
+const { t } = useI18n()
 
 const resultsStore = useSearchResultsStore()
 const localeStore = useLocaleStore()

--- a/components/SubmissionCompleted.vue
+++ b/components/SubmissionCompleted.vue
@@ -11,12 +11,12 @@
         <p
             class="mb-3.5 text-primary-text text-2xl font-bold font-sans leading-normal"
         >
-            {{ $t('thankYouPage.heading') }}
+            {{ t('thankYouPage.heading') }}
         </p>
         <p
             class="mb-20 text-center text-neutral-600 text-sm font-bold font-sans"
         >
-            {{ $t('thankYouPage.submission') }}
+            {{ t('thankYouPage.submission') }}
         </p>
         <div
             class="action-button-container flex flex-col"
@@ -26,7 +26,7 @@
         text-white text-base font-medium font-sans mb-2"
                 @click="resetFormCompleted"
             >
-                {{ $t('thankYouPage.submitAnotherDoctor') }}
+                {{ t('thankYouPage.submitAnotherDoctor') }}
             </button>
             <NuxtLink
                 class="flex"
@@ -35,7 +35,7 @@
                 <button
                     class="px-20 py-3 rounded-full bg-currentColor w-96 text-center
         text-white text-base font-medium font-sans"
-                >{{ $t('thankYouPage.home') }}</button>
+                >{{ t('thankYouPage.home') }}</button>
             </NuxtLink>
         </div>
     </div>
@@ -43,6 +43,8 @@
 
 <script setup lang="ts">
 import { useSubmissionStore } from '~/stores/submissionStore'
+
+const { t } = useI18n()
 
 const submissionStore = useSubmissionStore()
 

--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -9,17 +9,17 @@
                 data-testid="submit-heading"
                 class="mb-3.5 text-center text-primary-text text-2xl font-bold font-sans leading-normal"
             >
-                {{ $t('submitPage.heading') }}
+                {{ t('submitPage.heading') }}
             </h1>
             <p
                 data-testid="submit-subheading"
                 class="mb-10 w-96 text-center text-primary-text-muted text-sm font-normal font-sans"
             >
-                {{ $t('submitPage.subheading') }}
+                {{ t('submitPage.subheading') }}
             </p>
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
-            >{{ $t('submitPage.googleMaps') }}</span>
+            >{{ t('submitPage.googleMaps') }}</span>
 
             <input
                 v-model="location"
@@ -28,7 +28,7 @@
                 required
                 class="px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                 text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
-                :placeholder="$t('submitPage.location')"
+                :placeholder="t('submitPage.location')"
                 @blur="initialValidationCheck(location, 'googleMaps')"
             >
             <div class="google-maps-validation-container flex text-error text-xs font-sans h-3 mt-1 mb-3">
@@ -36,12 +36,12 @@
                     v-show="!isValidInput.googleMapsUrl.value"
                     class="text-error text-xs font-sans"
                 >
-                    {{ $t('submitPage.googleMapsValidation') }}
+                    {{ t('submitPage.googleMapsValidation') }}
                 </span>
             </div>
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
-            >{{ $t('submitPage.healthcareProfessionalName') }}</span>
+            >{{ t('submitPage.healthcareProfessionalName') }}</span>
 
             <div>
                 <input
@@ -52,7 +52,7 @@
                     type="text"
                     required
                     maxlength="30"
-                    :placeholder="$t('submitPage.lastName')"
+                    :placeholder="t('submitPage.lastName')"
                     @blur="initialValidationCheck(lastName, 'lastName')"
                 >
                 <input
@@ -62,7 +62,7 @@
                 text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                     type="text"
                     maxlength="30"
-                    :placeholder="$t('submitPage.firstName')"
+                    :placeholder="t('submitPage.firstName')"
                     @blur="initialValidationCheck(firstName, 'firstName')"
                 >
             </div>
@@ -71,32 +71,32 @@
                     <span
                         v-show="!isValidInput.lastName.value"
                     >
-                        {{ $t('submitPage.lastNameValidation') }}
+                        {{ t('submitPage.lastNameValidation') }}
                     </span>
                 </div>
 
                 <div class="last-name-validation-container w-44">
                     <span
                         v-show="!isValidInput.firstName.value"
-                    >   {{ $t('submitPage.firstNameValidation') }}
+                    >   {{ t('submitPage.firstNameValidation') }}
                     </span>
                 </div>
             </div>
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
-            >{{ $t('submitPage.spokenLanguage1') }}</span>
+            >{{ t('submitPage.spokenLanguage1') }}</span>
             <p
                 v-show="!isValidInput.primarySpokenLangauge.value"
                 class="text-error text-xs font-sans"
             >
-                {{ $t('submitPage.spokenLanguageValidation') }}
+                {{ t('submitPage.spokenLanguageValidation') }}
             </p>
             <select
                 v-model="selectLanguage1"
                 data-testid="submit-select-language1"
                 class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                         text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
-                :placeholder="$t('submitPage.selectLanguage1')"
+                :placeholder="t('submitPage.selectLanguage1')"
                 @change="initialValidationCheck(selectLanguage1, 'primaryLanguage')"
             >
                 <option
@@ -109,19 +109,19 @@
             </select>
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
-            >{{ $t('submitPage.spokenLanguage2') }}</span>
+            >{{ t('submitPage.spokenLanguage2') }}</span>
             <p
                 v-show="!isValidInput.secondarySpokenLanguage.value"
                 class="text-error text-xs font-sans"
             >
-                {{ $t('submitPage.invalidOption') }}
+                {{ t('submitPage.invalidOption') }}
             </p>
             <select
                 v-model="selectLanguage2"
                 data-testid="submit-select-language2"
                 class="mb-5 px-3 py-3.5 w-96 h-12 bg-primary-text-inverted rounded-lg border border-primary-text-muted
                         text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
-                :placeholder="$t('submitPage.selectLanguage2')"
+                :placeholder="t('submitPage.selectLanguage2')"
                 @change="initialValidationCheck(selectLanguage1, 'secondaryLanguage')"
             >
                 <option
@@ -134,7 +134,7 @@
             </select>
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
-            >{{ $t('submitPage.otherNotes') }}({{ $t('submitPage.optional') }})</span>
+            >{{ t('submitPage.otherNotes') }}({{ t('submitPage.optional') }})</span>
             <textarea
                 v-model="otherNotes"
                 data-testid="submit-input-notes"
@@ -148,7 +148,7 @@
                  text-primary-inverted font-medium font-sans"
                 @click="submitNewSubmission"
             >
-                {{ $t('submitPage.submitButton') }}
+                {{ t('submitPage.submitButton') }}
             </button>
         </form>
         <div />

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -68,17 +68,17 @@
                 <NuxtLink
                     to="/about"
                     class="hover:text-primary-hover transition-colors"
-                >{{ $t('topNav.about') }}
+                >{{ t('topNav.about') }}
                 </NuxtLink>
                 <NuxtLink
                     to="/"
                     class="hover:text-primary-hover transition-colors"
-                >{{ $t('topNav.home') }}
+                >{{ t('topNav.home') }}
                 </NuxtLink>
                 <NuxtLink
                     to="/submit"
                     class="hover:text-primary-hover transition-colors"
-                >{{ $t('topNav.submit') }}
+                >{{ t('topNav.submit') }}
                 </NuxtLink>
                 <div
                     v-if="authStore.isLoggedIn"
@@ -90,7 +90,7 @@
                         class="hover:text-primary-hover transition-colors text-wrap mr-4"
                         data-testid="top-nav-mod-link"
                     >{{
-                        $t('topNav.moderation') }}
+                        t('topNav.moderation') }}
                     </NuxtLink>
                     <NuxtLink
                         to="/"
@@ -100,7 +100,7 @@
                             class="text-primary"
                             @click="logout()"
                         >
-                            {{ $t('topNav.logout') }}
+                            {{ t('topNav.logout') }}
                         </div>
                     </NuxtLink>
                     <SVGProfileIcon
@@ -127,6 +127,8 @@ import HamburgerMenu from './HamburgerMenu.vue'
 import SVGProfileIcon from '~/assets/icons/profile-icon.svg'
 import SVGSiteLogo from '~/assets/icons/site-logo.svg'
 import { useAuthStore } from '~/stores/authStore'
+
+const { t } = useI18n()
 
 const authStore = useAuthStore()
 const route = useRoute()

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -11,25 +11,25 @@
                 data-testid="about-heading"
                 class="mb-12 font-bold text-4xl"
             >
-                {{ $t("about.heading") }}
+                {{ t("about.heading") }}
             </h1>
             <p
                 data-testid="about-subheading"
                 class="mb-12 text-2xl"
             >
-                {{ $t("about.subheading") }}
+                {{ t("about.subheading") }}
             </p>
             <p
                 data-testid="about-paragraph1"
                 class="mb-6 text-md text-primary-text-muted"
             >
-                {{ $t("about.paragraph1") }}
+                {{ t("about.paragraph1") }}
             </p>
             <p
                 data-testid="about-paragraph2"
                 class="text-md text-primary-text-muted"
             >
-                {{ $t("about.paragraph2") }}
+                {{ t("about.paragraph2") }}
             </p>
         </div>
         <div
@@ -44,7 +44,7 @@
             >
                 <div class="flex-1 border-currentColor/70 border self-center" />
                 <div class="text-primary/80 text-xl font-semibold mx-4 p-2 whitespace-nowrap">
-                    {{ $t("about.members") }}
+                    {{ t("about.members") }}
                 </div>
                 <div class="flex-1 border-currentColor/70 border self-center" />
             </div>
@@ -83,4 +83,6 @@
 import data from '../member_directory/members.json'
 import MemberComponent from '~/components/MemberComponent.vue'
 import SvgHeartPlus from '~/assets/icons/heart-plus.svg'
+
+const { t } = useI18n()
 </script>

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -10,7 +10,7 @@
                     class="w-full h-full mt-16 mb-16 text-primary-text text-2xl font-bold
                 flex self-center justify-items-center justify-center text-center"
                 >
-                    {{ $t('login.checkingauth') }}
+                    {{ t('login.checkingauth') }}
                 </div>
                 <div
                     v-if="!doesTheUserHaveAccess && !authStore.isAdmin && !authStore.isModerator"
@@ -20,14 +20,14 @@
                         class="flex flex-col w-full h-full mt-16 mb-16 text-primary-text text-2xl font-bold
                     self-center justify-items-center justify-center text-center"
                     >
-                        <span>{{ $t('login.unauthorizedline1') }}</span>
-                        <span>{{ $t('login.unauthorizedline2') }}</span>
+                        <span>{{ t('login.unauthorizedline1') }}</span>
+                        <span>{{ t('login.unauthorizedline2') }}</span>
                         <NuxtLink
                             to="https://forms.gle/4E763qfaq46kEsn99"
                             target="_blank"
                             class="inline text-primary underline"
                         >
-                            {{ $t('login.unauthorizedline3') }}
+                            {{ t('login.unauthorizedline3') }}
                         </NuxtLink>
                     </div>
                 </div>
@@ -49,7 +49,7 @@
                     class="w-full h-full mt-16 mb-16 text-primary-text text-2xl font-bold
                 flex self-center justify-items-center justify-center text-center"
                 >
-                    {{ $t('login.checkingauth') }}
+                    {{ t('login.checkingauth') }}
                 </div>
             </template>
         </Suspense>
@@ -66,6 +66,8 @@ import { definePageMeta } from '#imports'
 definePageMeta({
     layout: 'moderationlayout'
 })
+
+const { t } = useI18n()
 
 const authStore = useAuthStore()
 const route = useRoute()

--- a/pages/privacypolicy.vue
+++ b/pages/privacypolicy.vue
@@ -5,67 +5,71 @@
                 data-testid="privacy-heading"
                 class="mb-20 text-black text-5xl font-bold font-sans"
             >
-                {{ $t("privacyPage.heading") }}
+                {{ t("privacyPage.heading") }}
             </h1>
         </div>
         <h2
             data-testid="privacy-subheading"
             class="mb-10 text-black text-2xl font-normal font-sans"
         >
-            {{ $t("privacyPage.subheading") }}
+            {{ t("privacyPage.subheading") }}
         </h2>
         <div class="text-gray-500 text-lg font-normal font-sans">
             <p class="mb-10">
-                {{ $t("privacyPage.date") }}
+                {{ t("privacyPage.date") }}
             </p>
             <p class="mb-10">
-                {{ $t("privacyPage.paragraph1") }}
+                {{ t("privacyPage.paragraph1") }}
             </p>
             <p class="mb-2 font-bold">
-                {{ $t("privacyPage.paragraph2") }}
+                {{ t("privacyPage.paragraph2") }}
             </p>
             <p class="mb-10">
-                {{ $t("privacyPage.paragraph3") }}
+                {{ t("privacyPage.paragraph3") }}
             </p>
             <p class="mb-2 font-bold">
-                {{ $t("privacyPage.paragraph4") }}
+                {{ t("privacyPage.paragraph4") }}
             </p>
             <p class="mb-10">
-                {{ $t("privacyPage.paragraph5") }}
+                {{ t("privacyPage.paragraph5") }}
             </p>
             <p class="mb-2 font-bold">
-                {{ $t("privacyPage.paragraph6") }}:
+                {{ t("privacyPage.paragraph6") }}:
             </p>
             <p class="mb-10">
-                {{ $t("privacyPage.paragraph7") }}
+                {{ t("privacyPage.paragraph7") }}
             </p>
             <p class="mb-2 font-bold">
-                {{ $t("privacyPage.paragraph8") }}:
+                {{ t("privacyPage.paragraph8") }}:
             </p>
             <p class="mb-10">
-                {{ $t("privacyPage.paragraph9") }}
+                {{ t("privacyPage.paragraph9") }}
             </p>
             <p class="mb-2 font-bold">
-                {{ $t("privacyPage.paragraph10") }}
+                {{ t("privacyPage.paragraph10") }}
             </p>
             <p class="mb-10">
-                {{ $t("privacyPage.paragraph11") }}
+                {{ t("privacyPage.paragraph11") }}
             </p>
             <p class="mb-2 font-bold">
-                {{ $t("privacyPage.paragraph12") }}
+                {{ t("privacyPage.paragraph12") }}
             </p>
             <p class="mb-10">
-                {{ $t("privacyPage.paragraph13") }}
+                {{ t("privacyPage.paragraph13") }}
             </p>
             <p class="mb-2 font-bold">
-                {{ $t("privacyPage.paragraph14") }}
+                {{ t("privacyPage.paragraph14") }}
             </p>
             <p class="mb-10">
-                {{ $t("privacyPage.paragraph15") }}
+                {{ t("privacyPage.paragraph15") }}
             </p>
             <p class="mb-10">
-                {{ $t("privacyPage.paragraph16") }}
+                {{ t("privacyPage.paragraph16") }}
             </p>
         </div>
     </div>
 </template>
+
+<script setup lang="ts">
+const { t } = useI18n()
+</script>


### PR DESCRIPTION
✅ Resolves #1252 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Declared the $t property in global.d.ts to fix the type error shown in components

Reason: Vue and TypeScript don't recognize the `$t` property by default, which causes a type error `'__VLS_ctx.$t' is of type 'unknown'` .  
I used `Composer['t']` because it's a translation function provided by Vue I18n. By declaring `$t` as `Composer['t']`, every `$t` property used in Vue components will be recognized by TypeScript as the translation function. 

## 🧪 Testing instructions

## 📸 Screenshots

-   ### Before
![448812882-1a000306-5840-4938-b098-e252acce3cc0](https://github.com/user-attachments/assets/0e2c89f3-9fd3-448c-b17d-7cbfb45ba63a)


-   ### After
<img width="1155" alt="Screenshot 2025-06-10 at 16 34 37" src="https://github.com/user-attachments/assets/bd11cf50-25ad-4b10-9467-5e9a7f0451ed" />

<img width="1299" alt="Screenshot 2025-06-10 at 16 32 04" src="https://github.com/user-attachments/assets/67eab44e-2516-453c-aa07-d989cf1cf745" />


