### PR TITLE
fix: add basic moderation layout fix to use  NuxtPage

### DIFF
--- a/layouts/moderationlayout.vue
+++ b/layouts/moderationlayout.vue
@@ -1,6 +1,6 @@
 <template>
     <div data-testid="moderation-app">
-        <slot />
+        <NuxtPage />
     </div>
 </template>
 


### PR DESCRIPTION

## 🔧 What changed
We should use `NuxtPage` instead of `slot`. This will help with routing and nuxt awareness. 
