### PR TITLE
refactor: conditionally display "(optiona)"  based on `required` prop

### DIFF
--- a/components/ModInputField.vue
+++ b/components/ModInputField.vue
@@ -2,6 +2,7 @@
     <div class="flex flex-col mt-4">
         <label class="mb-2 text-primary-text text-sm font-bold font-sans">
             {{ label }}
+            <span v-if="!required" class="text-gray-500 ml-1 font-normal">(optional)</span>
         </label>
         <p
             v-if="!isTheInputValueValid"


### PR DESCRIPTION
✅ Resolves #1265 
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [X] PR assignee has been selected
- [X] PR label has been selected
- [X] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

- Updated the `ModInputField` logic to conditionally display the “(optional)” label text based on the value of the required prop

## 🧪 Testing instructions

1. Navigate to the Facility section in the Moderation panel.
2. Verify that “(optional)” is displayed next to fields that are not required.
3. Confirm that required fields do not show the “(optional)” label.

## 📸 Screenshots

-   ### Before
![image](https://github.com/user-attachments/assets/73681931-3ccb-45c7-8c1e-d94bf8a17f10)

-   ### After
![image](https://github.com/user-attachments/assets/cb44c7c1-de53-4ee0-8815-b620575a74ac)