### PR TITLE
fix:  prevent the display of "undefined undefined" as the practitioner name

### DIFF
--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -124,6 +124,7 @@ import { useLocaleStore } from '~/stores/localeStore.js'
 import { useSpecialtiesStore } from '~/stores/specialtiesStore.js'
 import { useSearchResultsStore } from '~/stores/searchResultsStore'
 import { Locale } from '~/typedefs/gqlTypes.js'
+import { formatHealthcareProfessionalName } from '~/utils/nameUtils'
 
 const { t } = useI18n()
 
@@ -132,31 +133,13 @@ const localeStore = useLocaleStore()
 const specialtiesStore = useSpecialtiesStore()
 
 const healthcareProfessionalName = computed(() => {
-    const englishName
-        = resultsStore.$state.activeResult?.professional.names.find(
-            n => n.locale === Locale.EnUs
-        )
-    const japaneseName
-        = resultsStore.$state.activeResult?.professional.names.find(
-            n => n.locale === Locale.JaJp
-        )
-
-    const englishFullName = englishName?.firstName && englishName?.lastName 
-        ? `${englishName.firstName} ${englishName.lastName}`
-        : null
-    const japaneseFullName = japaneseName?.firstName && japaneseName?.lastName
-        ? `${japaneseName.lastName} ${japaneseName.firstName}`
-        : null
-        
-    switch (localeStore.locale.code) {
-        case Locale.EnUs:
-            return englishFullName || japaneseFullName || ''
-        case Locale.JaJp:
-            return japaneseFullName || englishFullName || ''
-        default:
-            return englishFullName || japaneseFullName || ''
-    }
-})
+    const name = formatHealthcareProfessionalName(
+        resultsStore.$state.activeResult?.professional.names,
+        localeStore.locale.code as Locale
+    )
+    return name;
+}
+)
 const healthcareProfessionalDegrees = computed(() => {
     const healthcareProfessionalDegreesText
         = resultsStore.$state.activeResult?.professional.degrees.join(', ')

--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -141,16 +141,20 @@ const healthcareProfessionalName = computed(() => {
             n => n.locale === Locale.JaJp
         )
 
-    const englishFullName = `${englishName?.firstName} ${englishName?.lastName}`
-    const japaneseFullName = `${japaneseName?.lastName} ${japaneseName?.firstName}`
-
+    const englishFullName = englishName?.firstName && englishName?.lastName 
+        ? `${englishName.firstName} ${englishName.lastName}`
+        : null
+    const japaneseFullName = japaneseName?.firstName && japaneseName?.lastName
+        ? `${japaneseName.lastName} ${japaneseName.firstName}`
+        : null
+        
     switch (localeStore.locale.code) {
         case Locale.EnUs:
-            return englishFullName ? englishFullName : japaneseFullName
+            return englishFullName || japaneseFullName || ''
         case Locale.JaJp:
-            return japaneseFullName ? japaneseFullName : englishFullName
+            return japaneseFullName || englishFullName || ''
         default:
-            return englishFullName ? englishFullName : japaneseFullName
+            return englishFullName || japaneseFullName || ''
     }
 })
 const healthcareProfessionalDegrees = computed(() => {

--- a/utils/nameUtils.ts
+++ b/utils/nameUtils.ts
@@ -1,0 +1,27 @@
+import { Locale, type LocalizedName } from '~/typedefs/gqlTypes.js'
+
+export const formatHealthcareProfessionalName = (
+    names: LocalizedName[] | undefined,
+    preferredLocale: Locale
+): string => {
+    if (!names?.length) return ''
+
+    const englishName = names.find(n => n.locale === Locale.EnUs)
+    const japaneseName = names.find(n => n.locale === Locale.JaJp)
+
+    const englishFullName = englishName?.firstName && englishName?.lastName
+        ? `${englishName.firstName} ${englishName.lastName}`
+        : null
+    const japaneseFullName = japaneseName?.firstName && japaneseName?.lastName
+        ? `${japaneseName.lastName} ${japaneseName.firstName}`
+        : null
+
+    switch (preferredLocale) {
+        case Locale.EnUs:
+            return englishFullName || japaneseFullName || ''
+        case Locale.JaJp:
+            return japaneseFullName || englishFullName || ''
+        default:
+            return englishFullName || japaneseFullName || ''
+    }
+} 


### PR DESCRIPTION
✅ Resolves #1262 
- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [X] PR assignee has been selected
- [X] PR label has been selected
- [X] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

- Refactored and extracted name formatting logic:
   - Moved the logic for building full practitioner names into a new utility function: `formatHealthcareProfessionalName` in `utils/nameUtils.ts`.
   - The function checks if both `firstName` and `lastName` exist before constructing the full name; otherwise, it returns null.
   - Uses logical fallbacks (`||`) to choose between English and Japanese names, and defaults to an empty string if both are missing.
- Updated `SearchResultDetails.vue`:
   - Replaced inline name formatting logic with the new utility function.

## 🧪 Testing instructions

1. Under **Doctors Nearby**, click on a practitioner to open the modal.
2. Verify that the practitioner's name is displayed correctly:
     - If both `firstName` and `lastName` exist for the selected locale, show the full name.
     - If the name is missing in the selected locale, fallback to the other locale’s name.
     - If both are missing, show an empty string (not "undefined undefined").
3. Switch locales:
     - Ensure names update accordingly based on available data.
     - Confirm fallback behavior works as expected when a name is missing in the selected locale.

## 📸 Screenshots

-   ### Before
![image](https://github.com/user-attachments/assets/3b23f23a-487b-4636-8364-d996fd452845)

-   ### After
![image](https://github.com/user-attachments/assets/82474a2a-8b35-4648-b64a-90a13ca78d59)
