### PR TITLE
fix(style): change styling for modal on main page

### DIFF
--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -1,13 +1,13 @@
 <template>
     <div class="h-full w-full">
         <div
-            v-if="$viewport.isGreaterThan('tablet')"
+            v-if="!isPortrait"
             id="landscape-content"
             class="bg-secondary-bg/20 hover:shadow-inner hover:shadow-secondary-bg/90 h-full w-full relative"
         >
             <Loader />
             <Modal
-                class="max-h-[calc(100vh-12rem)] ml-8 mt-12 overflow-y-auto"
+                class="overflow-y-auto"
             >
                 <SearchResultDetails />
             </Modal>
@@ -36,7 +36,7 @@
 </template>
 
 <script lang="ts" setup>
-import { useNuxtApp } from '#app'
+import { useScreenOrientation } from '~/utils/useScreenOrientation'
 
-const { $viewport } = useNuxtApp()
+const { isPortrait } = useScreenOrientation()
 </script>

--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -9,8 +9,8 @@
             ref="modal"
             v-close-on-outside-click="hideModalAndEmitClosedEvent"
             class="absolute z-10 bg-primary-bg rounded-xl overflow-hidden
-            shadow-md shadow-primary-bg/50
-            hover:shadow-inner hover:shadow-secondary-bg/90"
+            shadow-lg shadow-primary
+            hover:shadow-inner hover:shadow-primary/90"
         >
             <button
                 type="button"

--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -2,12 +2,14 @@
     <div
         v-if="store.isOpen"
         data-testid="modal"
-        class="fixed top-0 left-0 flex items-center justify-center h-full w-full z-10 bg-secondary bg-opacity-40"
+        :class="`fixed top-0 left-0 flex items-center justify-center h-full w-full
+        z-10 ${stylingForSelectedHealthcareProfessionalMainPage}`"
     >
         <div
             ref="modal"
             v-close-on-outside-click="hideModalAndEmitClosedEvent"
             class="absolute z-10 bg-primary-bg rounded-xl overflow-hidden
+            shadow-md shadow-primary-bg/50
             hover:shadow-inner hover:shadow-secondary-bg/90"
         >
             <button
@@ -42,12 +44,19 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
+import { useRoute } from 'vue-router'
 import { vCloseOnOutsideClick } from '~/utils/closeOnOutsideClick'
 import { useModalStore } from '~/stores/modalStore'
 
 const modal = ref(null)
 const store = useModalStore()
+const route = useRoute()
+
+const stylingForSelectedHealthcareProfessionalMainPage = computed(() => route.path === '/'
+    ? ''
+    : 'bg-secondary bg-opacity-40')
+
 const emit = defineEmits(['modal-closed'])
 const hideModalAndEmitClosedEvent = () => {
     emit('modal-closed')


### PR DESCRIPTION


Remove pink background on main page and use our own utility for screen orientation

Mod panel
![image](https://github.com/user-attachments/assets/a8b70467-a234-4698-9a8b-3ced100a7ee1)


Main page. Path will need to be updated in @ermish ui redesign if he changes the page to `/search`
![image](https://github.com/user-attachments/assets/4045967e-472a-48c8-8f5e-93de066558cb)
