### PR TITLE
fix: add whitespace to `SubmissionForm.vue` string

### DIFF
--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -134,7 +134,7 @@
             </select>
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
-            >{{ t('submitPage.otherNotes') }}({{ t('submitPage.optional') }})</span>
+            >{{ t('submitPage.otherNotes') }} ({{ t('submitPage.optional') }})</span>
             <textarea
                 v-model="otherNotes"
                 data-testid="submit-input-notes"


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Instead of "Other notes(optional)", a whitespace got added and now the string changed to "Other notes (optional)".

## 📸 Screenshots
#### Before
![image](https://github.com/user-attachments/assets/ef9b84fc-a630-42f3-86d5-4280cd99865e)
#### After
![image](https://github.com/user-attachments/assets/a7f4ca7c-a646-4e47-8c7d-203296a7b159)
