### PR TITLE
fix: prevent `UnsavedChanges` modal from appearing when deleting a facility

### DIFF
--- a/components/moderation-panel/ModEditFacilityOrProfessionalTopbar.vue
+++ b/components/moderation-panel/ModEditFacilityOrProfessionalTopbar.vue
@@ -340,6 +340,8 @@ const deleteFacilityOrHealthcareProfessional = async () => {
             handleServerErrorMessaging(response.errors, toast, t)
             return response
         }
+        // Wipe the data of the now deleted facility from the ref to prevent the UnsavedChanges modal from triggering
+        originalFacilityRefsValue.value = undefined
 
         toast.success(t('modEditFacilityOrHPTopbar.facilityDeletedSuccessfully'))
         // Redirect to the dashboard since the facility no longer exists


### PR DESCRIPTION
✅ Resolves #1274 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Before, if you would delete a facility, the `UnsavedChanges` modal would appear after the `DeleteConfirmation` modal. Which makes no sense, because the facility is already deleted.
Now, 
1. `deleteFacilityOrHealthcareProfessional()` runs, and you confirm your choice on the `DeleteConfirmation` modal
2. The ref `originalFacilityRefsValue` turns to `undefined`-- all memory of the now deleted facility gets wiped
3. `facilityHasUnsavedChanges()` runs, but there is nothing to compare with anymore, resulting in the `UnsavedChanges` modal being skipped 
4. You return back to the facility overview page
