### PR TITLE
feat(style): conditionally render email only if it exists with redirect styling

### DIFF
--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -100,7 +100,7 @@
                     >{{ phone }}</a>
                 </div>
                 <div
-                    v-if="!excludedEmailAddresses.includes(email)"
+                    v-if="email && !excludedEmailAddresses.includes(email)"
                     class="email flex my-4"
                 >
                     <SVGEmailIcon
@@ -111,7 +111,9 @@
                     />
                     <a
                         :href="`mailto:${email}`"
-                        class="email-link"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="underline text-blue"
                     >{{ email }}</a>
                 </div>
             </div>


### PR DESCRIPTION
✅ Resolves #1323 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

- The email icon is now only displayed if an email address exists.
- The email is now styled as an underlined link to clearly indicate it's clickable.

## 🧪 Testing instructions

## 📸 Screenshots

-   ### Before
![Screenshot 2025-06-26 at 20 06 19](https://github.com/user-attachments/assets/57574954-14c0-4164-a57c-41ad73f231f0)

-   ### After
![Screenshot 2025-06-26 at 20 05 49](https://github.com/user-attachments/assets/4cf6ca25-e86f-4fae-b7a3-b99d2af5c460)
![Screenshot 2025-06-26 at 20 06 06](https://github.com/user-attachments/assets/e6148583-1049-4589-aaa7-de8e841a1446)



