### PR TITLE
feat: show additional info in SearchResultDetails

### DIFF
--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -33,7 +33,7 @@
                 <div class="ml-9 mt-2 font-bold text-sm">
                     <span>{{ t("searchResultsDetails.speaks") }}:</span>
                 </div>
-                <div class="result-tags flex flex-wrap w-64 mb-6 mt-1 ml-6 pl-2">
+                <div class="result-tags flex flex-wrap w-64 mb-2 mt-1 ml-6 pl-2">
                     <div
                         v-for="(spokenLanguage, index) in spokenLanguages"
                         :key="index"
@@ -42,6 +42,16 @@
                     >
                         {{ spokenLanguage }}
                     </div>
+                </div>
+            </div>
+            <div v-show="additionalInfoForPatients">
+                <div
+                    class="ml-9 mt-2 font-bold text-sm"
+                >
+                    <span>{{ t("searchResultsDetails.additionalInfo") }}:</span>
+                </div>
+                <div class="ml-9 mb-4 text-primary-text">
+                    <p>{{ additionalInfoForPatients }}</p>
                 </div>
             </div>
             <div class="about ml-4 pl-2">
@@ -191,6 +201,8 @@ const spokenLanguages = computed(() => {
 
     return languagesDisplayText
 })
+
+const additionalInfoForPatients = computed(() => resultsStore.activeResult?.professional.additionalInfoForPatients)
 
 const addressLine1 = computed(() => {
     const addressObj

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -100,7 +100,8 @@
   "searchResultsDetails": {
     "speaks": "这位医师可以说",
     "contact": "联系",
-    "lastUpdate": "Last updated"
+    "lastUpdate": "Last updated",
+    "additionalInfo": "Additional Info"
   },
   "thankYouPage": {
     "heading": "谢谢！",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -100,7 +100,8 @@
   "searchResultsDetails": {
     "speaks": "Dieser Arzt spricht",
     "contact": "Kontakt",
-    "lastUpdate": "Last updated"
+    "lastUpdate": "Last updated",
+    "additionalInfo": "Additional Info"
   },
   "thankYouPage": {
     "heading": "Vielen Dank!",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -95,6 +95,7 @@
         "noResultsSubtext": "Please try a different filter combination."
     },
     "searchResultsDetails": {
+        "additionalInfo": "Additional Info",
         "speaks": "This doctor speaks",
         "contact": "Contact",
         "lastUpdate": "Last updated"

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -99,7 +99,8 @@
   "searchResultsDetails": {
     "speaks": "Ce médecin parle",
     "contact": "Contact",
-    "lastUpdate": "Last updated"
+    "lastUpdate": "Last updated",
+    "additionalInfo": "Additional Info"
   },
   "thankYouPage": {
     "heading": "Merci !",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -106,7 +106,8 @@
   "searchResultsDetails": {
     "speaks": "Questo medico parla",
     "contact": "Contatta",
-    "lastUpdate": "Last updated"
+    "lastUpdate": "Last updated",
+    "additionalInfo": "Additional Info"
   },
   "thankYouPage": {
     "heading": "Grazie!",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -99,7 +99,8 @@
   "searchResultsDetails": {
     "speaks": "この医師は話す",
     "contact": "アクセス",
-    "lastUpdate": "Last updated"
+    "lastUpdate": "Last updated",
+    "additionalInfo": "Additional Info"
   },
   "thankYouPage": {
     "heading": "Thank you!",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -100,7 +100,8 @@
   "searchResultsDetails": {
     "speaks": "Este profissional fala",
     "contact": "Contato",
-    "lastUpdate": "Last updated"
+    "lastUpdate": "Last updated",
+    "additionalInfo": "Additional Info"
   },
   "thankYouPage": {
     "heading": "Obrigado!",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -99,7 +99,8 @@
   "searchResultsDetails": {
     "speaks": " Этот доктор говорит на ",
     "contact": "Связаться",
-    "lastUpdate": "Last updated"
+    "lastUpdate": "Last updated",
+    "additionalInfo": "Additional Info"
   },
   "thankYouPage": {
     "heading": "Спасибо!",

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -99,7 +99,8 @@
   "searchResultsDetails": {
     "speaks": "Itong Doktor ay nakakapagsalita ng",
     "contact": "Kontakt",
-    "lastUpdate": "Last updated"
+    "lastUpdate": "Last updated",
+    "additionalInfo": "Additional Info"
   },
   "thankYouPage": {
     "heading": "Maraming Salamat!",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -99,7 +99,8 @@
   "searchResultsDetails": {
     "speaks": "Bác sĩ này nói",
     "contact": "Liên hệ",
-    "lastUpdate": "Last updated"
+    "lastUpdate": "Last updated",
+    "additionalInfo": "Additional Info"
   },
   "thankYouPage": {
     "heading": "Cảm ơn bạn!",

--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -171,6 +171,7 @@ const searchProfessionalsQuery = gql`query searchHealthcareProfessionals($filter
         facilityIds
         spokenLanguages
         acceptedInsurance
+        additionalInfoForPatients
         createdDate
         updatedDate
     }


### PR DESCRIPTION
✅ Resolves #1360 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Currently, additional info for patients is shown in mod panel, but not to the user yet. This PR shows it in the search result details in the modal on the main page

## 🧪 Testing instructions

Pull this branch, add some additional info to a hp in the mod panel locally, and see if you can see that same additional info show up for that hp in the modal details 

## 📸 Screenshots

-   ### Before

![image](https://github.com/user-attachments/assets/6596e3de-95c6-4817-9504-7eecf0a53718)


-   ### After

![image](https://github.com/user-attachments/assets/9faf41ff-835b-4804-85dc-0fcc15b590c7)

