### PR TITLE
fix: add missing last update locale in en.json

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -89,7 +89,8 @@
   },
   "searchResultsDetails": {
     "speaks": "This doctor speaks",
-    "contact": "Contact"
+    "contact": "Contact",
+    "lastUpdate": "Last updated"
   },
   "thankYouPage": {
     "heading": "Thank you!",


### PR DESCRIPTION
✅ Resolves 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Somehow, en.json was missing searchResultsDetails.lastUpdate. The other json files still have this key. I added it back into en.json

## 🧪 Testing instructions

## 📸 Screenshots

-   ### Before

<img width="1902" height="899" alt="image" src="https://github.com/user-attachments/assets/afbeb4e7-7197-40c9-9377-46f7781496fd" />


-   ### After

<img width="1125" height="901" alt="image" src="https://github.com/user-attachments/assets/67e0c658-75a0-4d5e-be5c-fa0ecf139968" />

