### PR TITLE
refactor: move checkIfLoggedIn to reusable function for other protected paths

### DIFF
--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -57,8 +57,8 @@
 </template>
 
 <script setup lang="ts">
-import { useRoute, useRouter } from 'vue-router'
-import { watch, ref, type Ref, onMounted } from 'vue'
+import { ref, type Ref, onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { useAuthStore } from '~/stores/authStore'
 import { definePageMeta, useI18n } from '#imports'
 
@@ -71,30 +71,10 @@ const { t } = useI18n()
 
 const authStore = useAuthStore()
 const route = useRoute()
-const router = useRouter()
-
 const doesTheUserHaveAccess: Ref<boolean> = ref(true)
 
-const checkIfUserIsLoggedIn = async () => {
-    // This promise is here to make the Suspense component work.
-    // It doesn't do anything, but <Suspense> requires an awaited setup method
-    await new Promise(resolve => {
-        //ignore if route change is unrelated to moderation
-        const needsRedirectDueToAccess = route.path.startsWith('/moderation') && !authStore.isLoggedIn && !authStore.isLoadingAuth
-        if (needsRedirectDueToAccess) {
-            // give the user a bit of time to read the message before redirecting
-            doesTheUserHaveAccess.value = false
-            setTimeout(() => {
-                // Redirect to login page if user is not logged in
-                router.push('/')
-            }, 10000)
-        }
+const redirectIfUnauthenticatedUser = authStore.redirectIfUnauthenticatedUser('/moderation', doesTheUserHaveAccess)
 
-        resolve(true)
-    })
-}
-
-watch(route, checkIfUserIsLoggedIn)
-
-onMounted(checkIfUserIsLoggedIn)
+watch(() => route.path, () => redirectIfUnauthenticatedUser)
+onMounted(() => redirectIfUnauthenticatedUser)
 </script>


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
This function to check login was changed to be in `authStore` so it can be used in protected paths for login and future we will need to use roles as well


