### PR TITLE
feat: create linter error for hardcoded colors

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -48,7 +48,6 @@
     --color-error: /* #ef4444 */ 239 68 68;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
-    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
   }
 
   .theme-coral {
@@ -71,7 +70,6 @@
     --color-error: /* #d1523f */ 209 82 63;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
-    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
   }
 
   .theme-violet {
@@ -94,7 +92,6 @@
     --color-error: /* #d1523f */ 209 82 63;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
-    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
   }
 
   .theme-ocean {
@@ -117,7 +114,6 @@
     --color-error: /* #d1523f */ 209 82 63;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
-    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
   }
 
   .theme-neon {
@@ -140,7 +136,6 @@
     --color-error: /* #525252 */ 209 82 63;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
-    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
     }
 
     /* MARK: Accessible Themes */
@@ -168,7 +163,6 @@
   --color-error: /* #FF4500 */ 255 69 0;
   --color-warning: /* #f59e0b */ 245 158 11;
   --color-info: /* #3b82f6 */ 59 130 246;
-  --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
 }
 
 /* accessible r-g color blindness friendly theme (daltonism) */
@@ -194,6 +188,5 @@
   --color-error: /* #F97316 */ 249 115 22;
   --color-warning: /* #f59e0b */ 245 158 11;
   --color-info: /* #3b82f6 */ 59 130 246;
-  --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
 }
 }

--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -48,6 +48,7 @@
     --color-error: /* #ef4444 */ 239 68 68;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
+    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
   }
 
   .theme-coral {
@@ -70,6 +71,7 @@
     --color-error: /* #d1523f */ 209 82 63;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
+    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
   }
 
   .theme-violet {
@@ -92,6 +94,7 @@
     --color-error: /* #d1523f */ 209 82 63;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
+    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
   }
 
   .theme-ocean {
@@ -114,6 +117,7 @@
     --color-error: /* #d1523f */ 209 82 63;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
+    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
   }
 
   .theme-neon {
@@ -136,6 +140,7 @@
     --color-error: /* #525252 */ 209 82 63;
     --color-warning: /* #f59e0b */ 245 158 11;
     --color-info: /* #3b82f6 */ 59 130 246;
+    --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
     }
 
     /* MARK: Accessible Themes */
@@ -163,6 +168,7 @@
   --color-error: /* #FF4500 */ 255 69 0;
   --color-warning: /* #f59e0b */ 245 158 11;
   --color-info: /* #3b82f6 */ 59 130 246;
+  --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
 }
 
 /* accessible r-g color blindness friendly theme (daltonism) */
@@ -188,5 +194,6 @@
   --color-error: /* #F97316 */ 249 115 22;
   --color-warning: /* #f59e0b */ 245 158 11;
   --color-info: /* #3b82f6 */ 59 130 246;
+  --color-hyperlink: /* #1e293b */ 30 41 59 / 1;
 }
 }

--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -70,7 +70,7 @@
                             :href="addressLink"
                             target="_blank"
                             rel="noopener noreferrer"
-                            class="underline text-blue"
+                            class="underline text-hyperlink"
                         >
                             <div>{{ addressLine1 }}</div>
                             <div v-if="addressLine2">
@@ -91,7 +91,7 @@
                         :href="website"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="underline text-blue"
+                        class="underline text-hyperlink"
                     >{{ website }}</a>
                 </div>
                 <div class="phone flex my-4">
@@ -106,7 +106,7 @@
                         :href="`tel:${phone}`"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="underline text-blue"
+                        class="underline text-hyperlink"
                     >{{ phone }}</a>
                 </div>
                 <div
@@ -123,7 +123,7 @@
                         :href="`mailto:${email}`"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="underline text-blue"
+                        class="underline text-hyperlink"
                     >{{ email }}</a>
                 </div>
                 <div class="mr-3 mb-1 flex flex-row-reverse text-sm text-primary-text-muted">

--- a/components/SearchResultDetails.vue
+++ b/components/SearchResultDetails.vue
@@ -70,7 +70,7 @@
                             :href="addressLink"
                             target="_blank"
                             rel="noopener noreferrer"
-                            class="underline text-hyperlink"
+                            class="underline text-info"
                         >
                             <div>{{ addressLine1 }}</div>
                             <div v-if="addressLine2">
@@ -91,7 +91,7 @@
                         :href="website"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="underline text-hyperlink"
+                        class="underline text-info"
                     >{{ website }}</a>
                 </div>
                 <div class="phone flex my-4">
@@ -106,7 +106,7 @@
                         :href="`tel:${phone}`"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="underline text-hyperlink"
+                        class="underline text-info"
                     >{{ phone }}</a>
                 </div>
                 <div
@@ -123,7 +123,7 @@
                         :href="`mailto:${email}`"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="underline text-hyperlink"
+                        class="underline text-info"
                     >{{ email }}</a>
                 </div>
                 <div class="mr-3 mb-1 flex flex-row-reverse text-sm text-primary-text-muted">

--- a/eslint-rules/no-forbidden-color.js
+++ b/eslint-rules/no-forbidden-color.js
@@ -1,0 +1,64 @@
+// eslint-rules/no-forbidden-color.js
+// Importa l'oggetto AST da vue-eslint-parser se hai bisogno dei tipi
+// import { AST } from "vue-eslint-parser"; // Se stai usando TypeScript per la regola stessa
+
+export default {
+    meta: {
+        type: 'suggestion', // o 'problem' o 'layout'
+        docs: {
+            description: 'Disallow hardcoded colors in templates',
+            category: 'Best Practices',
+            recommended: false,
+            url: 'your-docs-url-if-any'
+        },
+        fixable: null, // o 'code' se vuoi renderla auto-fixable
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    forbiddenWords: {
+                        type: 'array',
+                        items: { type: 'string' }
+                    }
+                },
+                additionalProperties: false
+            }
+        ],
+        messages: {
+            forbiddenColor: 'Color "{{ color }}" is forbidden. Use design tokens or utility classes instead.'
+        }
+    },
+    create(context) {
+        const options = context.options[0] || {}
+        const forbiddenWords = options.forbiddenWords || []
+
+        if (!context.sourceCode.parserServices || !context.sourceCode.parserServices.defineTemplateBodyVisitor) {
+            // Fallback for files not-Vue or parser not 'vue-eslint-parser'
+            return {}
+        }
+
+        //use defineTemplateBodyVisitor per detecting template
+        return context.sourceCode.parserServices.defineTemplateBodyVisitor(
+            {
+                // VAttribute is an AST template node that is and HTML attribute
+                VAttribute(node) {
+                    // (es. class, :style, style, v-bind:class, ecc.)
+                    if (node.value && typeof node.value.value === 'string') {
+                        const attributeValue = node.value.value
+
+                        forbiddenWords.forEach(forbiddenColor => {
+                            if (attributeValue.toLowerCase().includes(forbiddenColor.toLowerCase())) {
+                                context.report({
+                                    node: node,
+                                    messageId: 'forbiddenColor',
+                                    data: { color: forbiddenColor }
+                                })
+                            }
+                        })
+                    }
+                }
+            }
+        )
+    }
+}
+

--- a/eslint-rules/no-forbidden-color.js
+++ b/eslint-rules/no-forbidden-color.js
@@ -1,64 +1,193 @@
 // eslint-rules/no-forbidden-color.js
-// Importa l'oggetto AST da vue-eslint-parser se hai bisogno dei tipi
-// import { AST } from "vue-eslint-parser"; // Se stai usando TypeScript per la regola stessa
 
+// Export the ESLint rule definition.
 export default {
+    // --- Rule Meta Information ---
+    // The 'meta' property provides metadata about the rule.
     meta: {
-        type: 'suggestion', // o 'problem' o 'layout'
+        // 'type' indicates the type of rule: 'problem' (potential errors),
+        // 'suggestion' (possible improvements), or 'layout' (formatting issues).
+        type: 'suggestion',
+
+        // 'docs' provides documentation for the rule.
         docs: {
-            description: 'Disallow hardcoded colors in templates',
+            // A brief description of what the rule does.
+            // eslint-disable-next-line
+            description: 'Disallow direct use of generic Tailwind color utility classes and hardcoded hex/rgb/hsl colors in templates.',
+            // The category for the rule (e.g., 'Best Practices', 'Stylistic Issues').
             category: 'Best Practices',
+            // Indicates if the rule is recommended in ESLint configurations.
             recommended: false,
+            // A URL to more detailed documentation for the rule (optional).
             url: 'your-docs-url-if-any'
         },
-        fixable: null, // o 'code' se vuoi renderla auto-fixable
+
+        // 'fixable' indicates if ESLint can automatically fix issues reported by this rule.
+        // 'null' means it's not auto-fixable. 'code' means it is.
+        fixable: null,
+
+        // 'schema' defines the options that can be passed to the rule in the ESLint configuration.
+        // This rule accepts an array of strings as 'forbiddenWords'.
         schema: [
             {
                 type: 'object',
                 properties: {
+                    // 'forbiddenWords' will be an array of basic color names (e.g., 'red', 'blue', 'slate').
+                    // These are typically the generic Tailwind color names you want to avoid.
                     forbiddenWords: {
                         type: 'array',
                         items: { type: 'string' }
                     }
                 },
+                // 'additionalProperties: false' prevents passing any other unrecognized options.
                 additionalProperties: false
             }
         ],
+
+        // 'messages' defines the error messages to be reported.
+        // We use placeholders like '{{ color }}' which will be filled dynamically.
         messages: {
-            forbiddenColor: 'Color "{{ color }}" is forbidden. Use design tokens or utility classes instead.'
+            forbiddenColor: 'Color "{{ color }}" is forbidden. Use design tokens or semantic utility classes instead.',
+            forbiddenHardcodedHex: 'Hardcoded hex color "{{ color }}" in style attribute is forbidden. Use design tokens.',
+            forbiddenHardcodedRgb: 'Hardcoded RGB color "{{ color }}" in style attribute is forbidden. Use design tokens.',
+            forbiddenHardcodedHsl: 'Hardcoded HSL color "{{ color }}" in style attribute is forbidden. Use design tokens.'
         }
     },
+
+    // --- Rule Creation Logic ---
+    // The 'create' method returns an object of visitor functions for AST nodes.
     create(context) {
+        // Get options passed in the .eslintrc.js configuration.
         const options = context.options[0] || {}
         const forbiddenWords = options.forbiddenWords || []
 
+        // Check if `vue-eslint-parser` services are available.
         if (!context.sourceCode.parserServices || !context.sourceCode.parserServices.defineTemplateBodyVisitor) {
-            // Fallback for files not-Vue or parser not 'vue-eslint-parser'
+            // Meaning the rule won't run for this file.
             return {}
         }
 
-        //use defineTemplateBodyVisitor per detecting template
+        /* Regex for detecting forbidden Tailwind-like color classes.
+        *  This regex looks for:
+        *  - Optional variants (e.g., `hover:`, `md:`).
+        *  - Common Tailwind color prefixes (e.g., `text-`, `bg-`, `border-`).
+        *  - FOLLOWED BY a forbidden color name (captured in group 1).
+        *  - Optional shade number (e.g., `-500`, `-900`).
+        *  - OR directly a forbidden color name (captured in group 2) with optional shade.
+        *  `\b` ensures whole word matches. `i` makes it case-insensitive.
+        */
+        const forbiddenColorRegex = new RegExp(
+            `\\b(?:[a-z-]+:)?(?:text|bg|border|stroke|fill|ring|divide|shadow|accent)-(${forbiddenWords.join('|')})(?:-\\d{1,3})?\\b|\\b(${forbiddenWords.join('|')})(?:-\\d{1,3})?\\b`,
+            'i'
+        )
+
+        /* Regex for detecting ANY hardcoded HEX color values
+        *  (e.g., #RRGGBB, #RGB, #RRGGBBAA).
+        *  We don't list specific forbidden HEX values; any direct HEX is forbidden here.
+        */
+        const hexColorPattern = '#[0-9a-fA-F]{3,8}'
+        const hexColorRegex = new RegExp(hexColorPattern, 'g')
+
+        // Any direct RGB/RGBA is forbidden.
+        const rgbColorPattern = '(?:rgb|rgba)\\(\\s*\\d{1,3}\\s*,\\s*\\d{1,3}\\s*,\\s*\\d{1,3}(?:,\\s*(?:0?\\.\\d+|1)\\s*)?\\)'
+        const rgbColorRegex = new RegExp(rgbColorPattern, 'g')
+
+        // Any direct HSL/HSLA is forbidden.
+        // eslint-disable-next-line
+        const hslColorPattern = '(?:hsl|hsla)\\(\\s*(?:\\d{1,3}|\\d+\\.\\d+)(?:deg)?\\s*,\\s*(?:\\d{1,3}|\\d+\\.\\d+)%\\s*,\\s*(?:\\d{1,3}|\\d+\\.\\d+)%(?:,\\s*(?:0?\\.\\d+|1)\\s*)?\\)'
+        const hslColorRegex = new RegExp(hslColorPattern, 'g')
+
+        // `defineTemplateBodyVisitor` ensures we correctly traverse the Vue template structure.
         return context.sourceCode.parserServices.defineTemplateBodyVisitor(
             {
-                // VAttribute is an AST template node that is and HTML attribute
-                VAttribute(node) {
-                    // (es. class, :style, style, v-bind:class, ecc.)
-                    if (node.value && typeof node.value.value === 'string') {
-                        const attributeValue = node.value.value
+                // Visit 'VAttribute' nodes where the key is 'class' or is a bound 'class' (e.g., `:class`).
+                'VAttribute[key.name="class"], VAttribute[key.name.name="class"]'(node) {
+                    let classValue = ''
 
-                        forbiddenWords.forEach(forbiddenColor => {
-                            if (attributeValue.toLowerCase().includes(forbiddenColor.toLowerCase())) {
+                    // Handle static 'class="... "' attributes.
+                    if (node.value && node.value.type === 'VLiteral') {
+                        classValue = node.value.value
+                    } else if (node.value && node.value.type === 'VExpressionContainer' && node.value.expression) {
+                        // This currently focuses on simple strings or easily extractable values.
+                        classValue = context.getSourceCode().getText(node.value.expression)
+                    }
+
+                    if (classValue) {
+                        // Split the class string into individual class names.
+                        const classes = classValue.split(/\s+/).filter(Boolean)
+
+                        // Iterate over each class name found.
+                        classes.forEach(cls => {
+                            // Test the class name against our forbidden Tailwind color regex.
+                            const match = cls.match(forbiddenColorRegex)
+                            if (match) {
+                                // If a match is found, report the issue.
+                                // The captured color name is either in group 1 (with prefix) or group 2 (without prefix).
+                                const matchedColor = match[1] || match[2]
                                 context.report({
                                     node: node,
-                                    messageId: 'forbiddenColor',
-                                    data: { color: forbiddenColor }
+                                    messageId: 'forbiddenColor', // Use the message defined in meta.messages.
+                                    data: { color: matchedColor } // Pass data for the message placeholder.
                                 })
                             }
                         })
                     }
+                },
+                // If we never use 'style' maybe we don't wanna have this check
+                // Visit 'VAttribute' nodes where the key is 'style' or is a bound 'style' (e.g., `:style`).
+                'VAttribute[key.name="style"], VAttribute[key.name.name="style"]'(node) {
+                    let styleValue = ''
+                    if (node.value && node.value.type === 'VLiteral') {
+                        styleValue = node.value.value
+                    } else if (node.value && node.value.type === 'VExpressionContainer' && node.value.expression) {
+                        styleValue = context.getSourceCode().getText(node.value.expression)
+                    }
+
+                    if (styleValue) {
+                        // Check for hardcoded HEX colors.
+                        const hexMatches = styleValue.match(hexColorRegex)
+                        if (hexMatches) {
+                            hexMatches.forEach(hex => {
+                                context.report({
+                                    node: node,
+                                    messageId: 'forbiddenHardcodedHex',
+                                    data: { color: hex }
+                                })
+                            })
+                        }
+
+                        // Check for hardcoded RGB/RGBA colors.
+                        const rgbMatches = styleValue.match(rgbColorRegex)
+                        if (rgbMatches) {
+                            rgbMatches.forEach(rgb => {
+                                context.report({
+                                    node: node,
+                                    messageId: 'forbiddenHardcodedRgb',
+                                    data: { color: rgb }
+                                })
+                            })
+                        }
+
+                        // Check for hardcoded HSL/HSLA colors.
+                        const hslMatches = styleValue.match(hslColorRegex)
+                        if (hslMatches) {
+                            hslMatches.forEach(hsl => {
+                                context.report({
+                                    node: node,
+                                    messageId: 'forbiddenHardcodedHsl',
+                                    data: { color: hsl }
+                                })
+                            })
+                        }
+                    }
                 }
+
+                /* Note: Attributes like 'title' are NOT visited by this rule unless
+                *  a specific 'VAttribute[key.name="title"]' visitor is added.
+                *  This helps avoid false positives for non-color-related attributes.
+                *  This is used to prevend 'Violet Theme' on HamburgerMenu.vue
+                */
             }
         )
     }
 }
-

--- a/eslint-rules/no-forbidden-color.js
+++ b/eslint-rules/no-forbidden-color.js
@@ -47,10 +47,10 @@ export default {
         // 'messages' defines the error messages to be reported.
         // We use placeholders like '{{ color }}' which will be filled dynamically.
         messages: {
-            forbiddenColor: 'Color "{{ color }}" is forbidden. Use design tokens or semantic utility classes instead.',
-            forbiddenHardcodedHex: 'Hardcoded hex color "{{ color }}" in style attribute is forbidden. Use design tokens.',
-            forbiddenHardcodedRgb: 'Hardcoded RGB color "{{ color }}" in style attribute is forbidden. Use design tokens.',
-            forbiddenHardcodedHsl: 'Hardcoded HSL color "{{ color }}" in style attribute is forbidden. Use design tokens.'
+            forbiddenColor: 'Color "{{ color }}" is forbidden. Check our docs https://documentation.findadoc.jp/design/ui-ux-guides-and-rules/theme-colors.',
+            forbiddenHardcodedHex: 'Hardcoded hex color "{{ color }}" in style attribute is forbidden. Check our docs https://documentation.findadoc.jp/design/ui-ux-guides-and-rules/theme-colors.',
+            forbiddenHardcodedRgb: 'Hardcoded RGB color "{{ color }}" in style attribute is forbidden. Check our docs https://documentation.findadoc.jp/design/ui-ux-guides-and-rules/theme-colors.',
+            forbiddenHardcodedHsl: 'Hardcoded HSL color "{{ color }}" in style attribute is forbidden. Check our docs https://documentation.findadoc.jp/design/ui-ux-guides-and-rules/theme-colors.'
         }
     },
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,8 @@ import stylistic from '@stylistic/eslint-plugin'
 import pluginCypress from 'eslint-plugin-cypress/flat'
 import pluginVitest from '@vitest/eslint-plugin'
 import pluginVue from 'eslint-plugin-vue'
+import vueParser from 'vue-eslint-parser'
+import noForbiddenColor from './eslint-rules/no-forbidden-color.js'
 import withNuxt from './.nuxt/eslint.config.mjs'
 
 export default withNuxt(
@@ -94,6 +96,33 @@ export default withNuxt(
         rules: {
             'vue/multi-word-component-names': 'off',
             'vue/html-indent': ['error', 4]
+        }
+    },
+    {
+        files: ['**/*.vue'],
+        languageOptions: {
+            parser: vueParser,
+            parserOptions: {
+                parser: tseslint.parser,
+                project: true,
+                ecmaVersion: 'latest',
+                sourceType: 'module',
+                extraFileExtensions: ['.vue']
+            }
+        },
+        plugins: {
+            '@typescript-eslint': tseslint.plugin,
+            custom: { rules: { 'no-forbidden-color': noForbiddenColor } } // custom-plugin
+        },
+        rules: {
+            'custom/no-forbidden-color': ['error', {
+                forbiddenWords: [
+                    'gray', 'red', 'blue', 'green', 'yellow', 'indigo', 'purple', 'pink', 'orange',
+                    'teal', 'cyan', 'emerald', 'fuchsia', 'rose', 'sky', 'lime', 'violet',
+                    'zinc', 'stone', 'neutral', 'slate', 'black', 'white'
+                ]
+            }]
+            // ... altre regole vue/*
         }
     },
     // Linting for Cypress (https://www.npmjs.com/package/eslint-plugin-cypress)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -122,7 +122,6 @@ export default withNuxt(
                     'zinc', 'stone', 'neutral', 'slate', 'black', 'white'
                 ]
             }]
-            // ... altre regole vue/*
         }
     },
     // Linting for Cypress (https://www.npmjs.com/package/eslint-plugin-cypress)

--- a/layouts/errorLayout.vue
+++ b/layouts/errorLayout.vue
@@ -21,10 +21,12 @@
         />
         <SVGCharactersSachiQuestioning
             v-if="randomCharacter === CharacterOptions.SachiQuestioning"
-            class="mt-16 w-7/12 landscape:w-72 landscape:max-w-2xl" />
+            class="mt-16 w-7/12 landscape:w-72 landscape:max-w-2xl"
+        />
         <SVGCharactersChikoTherapyDogPrimary
             v-if="randomCharacter === CharacterOptions.ChikoTherapyDogPrimary"
-            class="mt-16 w-11/12 landscape:w-80 landscape:max-w-2xl" />
+            class="mt-16 w-11/12 landscape:w-80 landscape:max-w-2xl"
+        />
     </div>
 </template>
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "typescript-eslint": "^8.0.1",
         "vite": "^5.3.5",
         "vitest": "^2.1.3",
+        "vue-eslint-parser": "^10.2.0",
         "webpack": "^5.93.0"
     }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,7 +49,7 @@ module.exports = {
                 'rgb(var(--color-warning) / <alpha-value>)',
             info:
                 'rgb(var(--color-info) / <alpha-value>)',
-            blue: '#245A7D',
+            hyperlink: 'rgb(var(--color-hyperlink) / <alpha-value>)',
             neutral: colors.gray,
             black: colors.black,
             white: colors.white,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8268,6 +8268,7 @@ __metadata:
     vite: "npm:^5.3.5"
     vitest: "npm:^2.1.3"
     vue: "npm:^3.4.35"
+    vue-eslint-parser: "npm:^10.2.0"
     vue-gtag: "npm:^2.0.1"
     vue-router: "npm:^4.4.2"
     vue-server-renderer: "npm:^2.7.16"
@@ -15662,6 +15663,22 @@ __metadata:
   version: 0.1.0
   resolution: "vue-devtools-stub@npm:0.1.0"
   checksum: 10/a0b674b8758ba1ba0877ead8d55362906f2f29e79b0f2bd8149180284ae068920e1849fbb0d06bbc61fb8c525f61af047b88bef2f4718015868b57b1bcf6a45b
+  languageName: node
+  linkType: hard
+
+"vue-eslint-parser@npm:^10.2.0":
+  version: 10.2.0
+  resolution: "vue-eslint-parser@npm:10.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    eslint-scope: "npm:^8.2.0"
+    eslint-visitor-keys: "npm:^4.2.0"
+    espree: "npm:^10.3.0"
+    esquery: "npm:^1.6.0"
+    semver: "npm:^7.6.3"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+  checksum: 10/53673fd5df42e79e834809ce552f53972f2e03bae08ef7cc66e679e88e9ad3b939ac12f9332ed33e14c953649616ca17698169719670b6a752d219685015aa87
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
✅ Resolves [#1361](https://github.com/ourjapanlife/findadoc-web/issues/1361)
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected
- [ ] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Created an `eslint-rules` that enforce the use of colors from our theming system, What the rules do?

- Prohibition of "hardcoded" Tailwind colors: The rule prevents the direct use of generic Tailwind color utility classes (like text-blue, text-red etc.)

**What is changed inside files?**
`eslint.config.js`: Applied ESLint rules for `.vue` files. Use `vueParser` to properly parse the `<template> and <script>` sections of Vue components. It also enables our custom `no-forbidden-color` rule on these files, ensuring that hardcoded Tailwind colors are prohibited within Vue templates.
Inside this file, we use a new dependency, i know we probably might create our custom rule but the process seems so hard.
`vue-eslint-parser`, we need this one because without ESLint is designed for standar JS files but Vue has also `template` part, i've searched more about how the mechanism works ( https://github.com/vuejs/vue-eslint-parser ) and i think it's essential for our purpose.
`no-forbidden-color-js`: Check inside each `.vue` file if there are hardcoded colors.
`ErrorLayout.vue`: it seems there was an warning line code
`SearchResultDetails`: changed `text-blue` to `text-hyperlink`

## 🧪 Testing instructions

<img width="1764" height="1148" alt="image" src="https://github.com/user-attachments/assets/c10082e4-3b25-4103-85fa-4daccd3490a9" />


## 📸 Screenshots

-   ### Before

-   ### After


