### PR TITLE
fix: fix reset for adding a new name locale

### DIFF
--- a/components/moderation-panel/ModEditHealthcareProfessionalSection.vue
+++ b/components/moderation-panel/ModEditHealthcareProfessionalSection.vue
@@ -239,7 +239,7 @@
                     </li>
                 </ol>
                 <NoteInputField
-                    v-model="healthcareProfessionalsStore.healthcareProfessionalSectionFields.additionalInfoForPatients"
+                    v-model="healthcareProfessionalsStore.healthcareProfessionalSectionFields.additionalInfoForPatients as string"
                     :label="t('modHealthcareProfessionalSection.labelAdditionalNotesForPatients')"
                     :placeholder="t('modHealthcareProfessionalSection.placeholderAdditionalNotesForPatients')"
                     :required="false"
@@ -345,7 +345,7 @@ const handleCloseAddingNewLocalizedName = () => {
 // Opens the locale being added name inputs
 const handleOpenAddNewNameWithReset = () => {
     // Allows for the inputs to completely transition before resetting the fields
-    setTimeout(() => resetNameLocaleInputs, 300)
+    resetNameLocaleInputs()
     addingLocaleName.value = true
     // Makes sure both values cannot be true
     editingLocaleName.value = false
@@ -456,6 +456,7 @@ const handleDeleteExistingName = () => {
 }
 
 const handleAddLocalizedName = () => {
+    resetNameLocaleInputs()
     const localizedNameToAdd: LocalizedNameInput = {
         firstName: nameLocaleInputs.firstName,
         lastName: nameLocaleInputs.lastName,


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Before the fields were not clearing when someone tried to add a new name locale. Now it has been fixed. With a quick casting for a note input as well since that was throwing a linter error in the same file with the new types


