### PR TITLE
refactor: show toast for updating only when updating, not approving

### DIFF
--- a/components/moderation-panel/ModEditSubmissionForm.vue
+++ b/components/moderation-panel/ModEditSubmissionForm.vue
@@ -624,7 +624,9 @@ async function submitUpdatedSubmission(e: Event) {
 
     // This updates the submission in the form with the values stored in the db on success
     if (submissionResult) initializeSubmissionFormValues(submissionResult)
-    toast.success(t('modSubmissionForm.successMessageUpdated'))
+    if (!moderationSubmissionStore.approvingSubmissionFromTopBar) {
+        toast.success(t('modSubmissionForm.successMessageUpdated'))
+    }
     if (moderationSubmissionStore.updatingSubmissionFromTopBarAndExiting) {
         // reset all modal refs to prevent unintended side effects
         router.push('/moderation')


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Two toasts would show when approving. The update and the approve one. It really should just show the approve one since the update one runs secretly when clicking this button


