### PR TITLE
fix: remove validation for having English name when selected healthcare professional

### DIFF
--- a/components/moderation-panel/ModEditSubmissionForm.vue
+++ b/components/moderation-panel/ModEditSubmissionForm.vue
@@ -650,27 +650,32 @@ async function submitCompletedForm(e: Event) {
         return
     }
 
-    const isValidFacility = validateFacilityFields()
-    const isValidHealthcareProfessional = validateHealthcareProfessionalFields()
-    const hasEnglishName = validateHealthcareProfessionalEnglishName()
+    const faciliyAlreadyExistsInOurDatabase = currentFacilityRelations.value.length
+    const healthcareProfessionalAlreadyExistsInOurDatabase = currentExistingHealthcareProfessionals.value.length
 
     // This shows a toast and returns if the facility fields arent valid
-    if (!isValidFacility && !currentFacilityRelations.value.length) {
-        toast.error(t('modSubmissionForm.errorMessageFacilityInputsInvalid'))
-        await resetModalRefs()
-        return
+    if (!faciliyAlreadyExistsInOurDatabase) {
+        const isValidFacility = validateFacilityFields()
+        if (!isValidFacility) {
+            toast.error(t('modSubmissionForm.errorMessageFacilityInputsInvalid'))
+            await resetModalRefs()
+            return
+        }
     }
 
-    if (!isValidHealthcareProfessional && !currentExistingHealthcareProfessionals.value.length) {
-        toast.error(t('modSubmissionForm.errorMessageHealthcareInputsInvalid'))
-        await resetModalRefs()
-        return
-    }
-
-    if (!hasEnglishName) {
-        toast.error(t('modSubmissionForm.errorMessageEnglishNameRequired'))
-        await resetModalRefs()
-        return
+    if (!healthcareProfessionalAlreadyExistsInOurDatabase) {
+        const isValidHealthcareProfessional = validateHealthcareProfessionalFields()
+        if (!isValidHealthcareProfessional) {
+            toast.error(t('modSubmissionForm.errorMessageHealthcareInputsInvalid'))
+            await resetModalRefs()
+            return
+        }
+        const hasEnglishName = validateHealthcareProfessionalEnglishName()
+        if (!hasEnglishName) {
+            toast.error(t('modSubmissionForm.errorMessageEnglishNameRequired'))
+            await resetModalRefs()
+            return
+        }
     }
 
     try {


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
This only validates the names if there aren't existing healthcare professionals selected for the facility


