### PR TITLE
refactor: change submission secondary language to optional

### DIFF
--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -109,7 +109,7 @@
             </select>
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
-            >{{ t('submitPage.spokenLanguage2') }}</span>
+            >{{ t('submitPage.spokenLanguage2') + " (" + t('submitPage.optional') + ")" }}</span>
             <p
                 v-show="!isValidInput.secondarySpokenLanguage.value"
                 class="text-error text-xs font-sans"
@@ -122,7 +122,7 @@
                 class="mb-5 px-3 py-3.5 w-96 h-12 bg-primary-text-inverted rounded-lg border border-primary-text-muted
                         text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                 :placeholder="t('submitPage.selectLanguage2')"
-                @change="initialValidationCheck(selectLanguage1, 'secondaryLanguage')"
+                @change="selectLanguage2 ? initialValidationCheck(selectLanguage2, 'secondaryLanguage') : null"
             >
                 <option
                     v-for="(locale, index) in localeStore.localeDisplayOptions"
@@ -207,8 +207,9 @@ const validateFields = () => {
     validationCheckedPreviously.primarySpokenLangauge.value = true
     isValidInput.primarySpokenLangauge.value = validations.validateFirstSpokenLanguage(selectLanguage1.value)
     validationCheckedPreviously.secondarySpokenLanguage.value = true
-    isValidInput.secondarySpokenLanguage.value
-        = validations.validateUserSubmittedLastName(selectLanguage2.value)
+    isValidInput.secondarySpokenLanguage.value = selectLanguage2.value
+        ? validations.validateUserSubmittedLastName(selectLanguage2.value)
+        : true
 
     if (
         !isValidInput.googleMapsUrl.value


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Before two languages were optional. This seems unnecessary. To pass all medical exams and in all practical purposes, healthcare professionals must speak Japanese.

