### PR TITLE
fix: add additional notes to create healthcare with validation fix

### DIFF
--- a/components/moderation-panel/ModCreateFacilityOrProfessionalTopbar.vue
+++ b/components/moderation-panel/ModCreateFacilityOrProfessionalTopbar.vue
@@ -60,6 +60,7 @@ import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationS
 import { useModalStore } from '~/stores/modalStore'
 import { useModerationSubmissionsStore, SelectedModerationListView } from '~/stores/moderationSubmissionsStore'
 import { handleServerErrorMessaging } from '~/composables/handleServerErrorMessaging'
+import { Locale } from '~/typedefs/gqlTypes'
 
 const router = useRouter()
 
@@ -121,21 +122,36 @@ const validateFacilityFields = () => {
     return areAllTheFacilityFieldsValid
 }
 
+const validateHealthcareProfessionalFields = () => {
+    const healthcareProfessionalFields = healthcareProfessionalsStore.createHealthcareProfessionalSectionFields
+
+    const areFacilityIdsAdded = !!healthcareProfessionalFields.facilityIds.length
+    const areInsurancesSelected = !!healthcareProfessionalFields.acceptedInsurance!.length
+    const areDegreesSelected = !!healthcareProfessionalFields.degrees!.length
+    const areSpecialtiesSelected = !!healthcareProfessionalFields.spokenLanguages!.length
+    const areLocalesSelected = !!healthcareProfessionalFields.spokenLanguages!.length
+
+    const areAllFieldsValid = areFacilityIdsAdded
+      && areInsurancesSelected && areDegreesSelected
+      && areSpecialtiesSelected && areLocalesSelected
+
+    return areAllFieldsValid
+}
+
 const createFacilityOrHealthcareProfessional = async () => {
     if (moderationScreenStore.createHealthcareProfessionalScreenIsActive()) {
         const healthcareProfessionalCreationSectionFields = healthcareProfessionalsStore.createHealthcareProfessionalSectionFields
         const hasEnglishName
-            = healthcareProfessionalCreationSectionFields.names.some(name => name.locale === 'en_US')
+            = healthcareProfessionalCreationSectionFields.names.some(name => name.locale === Locale.EnUs)
 
-        const healthcareProfessionalCreationValues = Object.values(healthcareProfessionalCreationSectionFields)
-        const hasEmptyFields = healthcareProfessionalCreationValues.some(value => !value || !value.length)
+        const hasEmptyRequiredFields = validateHealthcareProfessionalFields()
 
         if (!hasEnglishName) {
             toast.error(t('modCreateFacilityOrHPTopbar.healthcareProfessionalEnglishNameRequired'))
             return
         }
 
-        if (hasEmptyFields) {
+        if (!hasEmptyRequiredFields) {
             toast.error(t('modCreateFacilityOrHPTopbar.hasEmptyFieldsHealthcareProfessional'))
             return
         }

--- a/components/moderation-panel/ModCreateHealthcareProfessionalSection.vue
+++ b/components/moderation-panel/ModCreateHealthcareProfessionalSection.vue
@@ -240,6 +240,12 @@
                 </li>
             </ol>
         </div>
+        <NoteInputField
+            v-model="createHealthcareProfessionalSectionFields.additionalInfoForPatients!"
+            :label="t('modHealthcareProfessionalSection.labelAdditionalNotesForPatients')"
+            :placeholder="t('modHealthcareProfessionalSection.placeholderAdditionalNotesForPatients')"
+            :required="false"
+        />
         <h2
             class="mod-healthcare-professional-section
                  my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"

--- a/stores/healthcareProfessionalsStore.ts
+++ b/stores/healthcareProfessionalsStore.ts
@@ -49,7 +49,8 @@ export const useHealthcareProfessionalsStore = defineStore(
             facilityIds: [] as string[],
             names: [] as LocalizedNameInput[],
             specialties: [] as Specialty[],
-            spokenLanguages: [] as Locale[]
+            spokenLanguages: [] as Locale[],
+            additionalInfoForPatients: ''
         })
 
         const selectedFacilities: Ref<Facility[]> = ref([])


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
There were no additional notes for creating a healthcare professional. Also the validation was failing do to using `Object.values` This makes our choice of validation more readable and distinct as to what fields are necessary.