### PR TITLE
fix: added missing `},` for `modSubmissionListContainer` locale section

### DIFF
--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -377,6 +377,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
+    },
   "errorPage": {
     "title": "404 - 诊断：页面未找到",
     "description": "此页面未通过健康检查。让我们带您到一个健康的页面吧！",

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -377,7 +377,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
-    },
+  },
   "errorPage": {
     "title": "404 - 诊断：页面未找到",
     "description": "此页面未通过健康检查。让我们带您到一个健康的页面吧！",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -377,6 +377,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
+    },
   "errorPage": {
     "title": "404 - Diagnose: Seite nicht gefunden",
     "description": "Diese Seite hat ihre Gesundheitsprüfung nicht bestanden. Lassen Sie uns Sie stattdessen zu einer gesunden Seite bringen!",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -377,7 +377,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
-    },
+  },
   "errorPage": {
     "title": "404 - Diagnose: Seite nicht gefunden",
     "description": "Diese Seite hat ihre Gesundheitsprüfung nicht bestanden. Lassen Sie uns Sie stattdessen zu einer gesunden Seite bringen!",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -376,7 +376,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
-    },
+  },
   "errorPage": {
     "title": "404 - Diagnostic : Page non trouvée",
     "description": "Cette page n'a pas réussi son examen de santé. Dirigeons-vous vers une page saine à la place !",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -376,6 +376,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
+    },
   "errorPage": {
     "title": "404 - Diagnostic : Page non trouvée",
     "description": "Cette page n'a pas réussi son examen de santé. Dirigeons-vous vers une page saine à la place !",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -376,7 +376,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Risultati per pagagina"
-    },
+  },
   "errorPage": {
     "title": "404 - Diagnosi: Pagina non trovata",
     "description": "Questa pagina non ha superato il suo esame di salute. Portiamoti invece a una pagina sana!",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -376,6 +376,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Risultati per pagagina"
+    },
   "errorPage": {
     "title": "404 - Diagnosi: Pagina non trovata",
     "description": "Questa pagina non ha superato il suo esame di salute. Portiamoti invece a una pagina sana!",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -377,6 +377,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
+  },
   "errorPage": {
     "title": "404 - 診断：ページが見つかりません",
     "description": "このページは健康診断に合格しませんでした。代わりに健康なページにご案内します！",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -377,6 +377,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
+    },
   "errorPage": {
     "title": "404 - Diagnóstico: Página não encontrada",
     "description": "Esta página não passou no seu exame de saúde. Vamos levá-lo a uma página saudável!",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -377,7 +377,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
-    },
+  },
   "errorPage": {
     "title": "404 - Diagnóstico: Página não encontrada",
     "description": "Esta página não passou no seu exame de saúde. Vamos levá-lo a uma página saudável!",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -377,7 +377,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
-    },
+  },
   "errorPage": {
     "title": "404 - Диагноз: Страница не найдена",
     "description": "Эта страница не прошла медосмотр. Давайте направим вас на здоровую страницу!",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -377,6 +377,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
+    },
   "errorPage": {
     "title": "404 - Диагноз: Страница не найдена",
     "description": "Эта страница не прошла медосмотр. Давайте направим вас на здоровую страницу!",

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -376,7 +376,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
-    },
+  },
   "errorPage": {
     "title": "404 - Diagnosis: Hindi Nahanap ang Pahina",
     "description": "Hindi nakapasa ang pahinang ito sa wellness exam. Dalhin ka namin sa malusog na pahina!",

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -376,6 +376,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
+    },
   "errorPage": {
     "title": "404 - Diagnosis: Hindi Nahanap ang Pahina",
     "description": "Hindi nakapasa ang pahinang ito sa wellness exam. Dalhin ka namin sa malusog na pahina!",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -376,6 +376,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
+    },
   "errorPage": {
     "title": "404 - Chẩn đoán: Không tìm thấy trang",
     "description": "Trang này đã không vượt qua kiểm tra sức khỏe. Hãy để chúng tôi đưa bạn đến một trang khỏe mạnh!",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -376,7 +376,7 @@
   },
   "modSubmissionListContainer": {
     "resultsPerPage": "Results per page"
-    },
+  },
   "errorPage": {
     "title": "404 - Chẩn đoán: Không tìm thấy trang",
     "description": "Trang này đã không vượt qua kiểm tra sức khỏe. Hãy để chúng tôi đưa bạn đến một trang khỏe mạnh!",

--- a/stores/facilitiesStore.ts
+++ b/stores/facilitiesStore.ts
@@ -93,25 +93,25 @@ export const useFacilitiesStore = defineStore('facilitiesStore', () => {
     function initializeFacilitySectionValues(data: Facility | undefined) {
         if (!data) return
 
-            facilitySectionFields.nameEn = data.nameEn
-            facilitySectionFields.nameJa = data.nameJa
-            facilitySectionFields.phone = data?.contact?.phone
-            facilitySectionFields.email = data?.contact?.email || undefined
-            facilitySectionFields.website = data?.contact?.website || undefined
-            facilitySectionFields.postalCode = data.contact?.address.postalCode
-            facilitySectionFields.prefectureEn = data?.contact?.address?.prefectureEn
-            facilitySectionFields.cityEn = data?.contact?.address?.cityEn
-            facilitySectionFields.addressLine1En = data?.contact?.address?.addressLine1En
-            facilitySectionFields.addressLine2En = data?.contact?.address?.addressLine2En ?? ''
-            facilitySectionFields.prefectureJa = data?.contact?.address?.prefectureJa
-            facilitySectionFields.cityJa = data?.contact?.address?.cityJa
-            facilitySectionFields.addressLine1Ja = data?.contact?.address?.addressLine1Ja
-            facilitySectionFields.addressLine2Ja = data?.contact?.address?.addressLine2Ja ?? ''
-            facilitySectionFields.googlemapsURL = data?.contact?.googleMapsUrl
-            facilitySectionFields.healthcareProfessionalIds = data.healthcareProfessionalIds
-            facilitySectionFields.mapLatitude = data.mapLatitude.toString()
-            facilitySectionFields.mapLongitude = data.mapLongitude.toString()
-        }
+        facilitySectionFields.nameEn = data.nameEn
+        facilitySectionFields.nameJa = data.nameJa
+        facilitySectionFields.phone = data?.contact?.phone
+        facilitySectionFields.email = data?.contact?.email || undefined
+        facilitySectionFields.website = data?.contact?.website || undefined
+        facilitySectionFields.postalCode = data.contact?.address.postalCode
+        facilitySectionFields.prefectureEn = data?.contact?.address?.prefectureEn
+        facilitySectionFields.cityEn = data?.contact?.address?.cityEn
+        facilitySectionFields.addressLine1En = data?.contact?.address?.addressLine1En
+        facilitySectionFields.addressLine2En = data?.contact?.address?.addressLine2En ?? ''
+        facilitySectionFields.prefectureJa = data?.contact?.address?.prefectureJa
+        facilitySectionFields.cityJa = data?.contact?.address?.cityJa
+        facilitySectionFields.addressLine1Ja = data?.contact?.address?.addressLine1Ja
+        facilitySectionFields.addressLine2Ja = data?.contact?.address?.addressLine2Ja ?? ''
+        facilitySectionFields.googlemapsURL = data?.contact?.googleMapsUrl
+        facilitySectionFields.healthcareProfessionalIds = data.healthcareProfessionalIds
+        facilitySectionFields.mapLatitude = data.mapLatitude.toString()
+        facilitySectionFields.mapLongitude = data.mapLongitude.toString()
+    }
 
     function resetFacilitySectionFields() {
         facilitySectionFields.nameEn = ''


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## Problem
The `},` is missing between `modSubmissionListContainer` and `errorPage`, which results in the error seen on the screenshot below.

<img width="1566" height="429" alt="image" src="https://github.com/user-attachments/assets/e483ea4d-c840-4a30-bcc3-a5733f4ddf5b" />

## 🔧 What changed
Fixed a typo where the `modSubmissionListContainer` locale section in every language, except English, was missing a closing brace and comma, which resulted in an error every time you would interact with one of the locales.

