### PR TITLE
fix: locale of data should match active locale of app

### DIFF
--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -113,7 +113,6 @@ function getLocalizedName(
     const selectedName
     = names.find(name => name.locale === currentLocale)
       || names.find(name => name.locale.startsWith(localePrefix))
-      || names.find(name => name.locale === 'en')
       || names[0]
 
     return `${selectedName.firstName} ${selectedName.lastName}`


### PR DESCRIPTION
✅ Resolves #1309
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
I created a helper function that checks what locale the app is currently set to, and then checks if the healthcare professional has a name assigned to that locale. If not, use the first name that is included in the array of names.

## 🧪 Testing instructions
Create a healthcare professional from the moderation panel, and then switch locales on the homepage.

## 📸 Screenshots

-   ### After
From left to right, locale switched to English, Japanese and German.
<img width="325" height="150" alt="image" src="https://github.com/user-attachments/assets/957342f6-c0a7-4719-856f-ea54116f8d8f" />
<img width="244" height="149" alt="image" src="https://github.com/user-attachments/assets/af413427-41af-4a8b-9c39-dee61ad6469d" />
<img width="269" height="158" alt="image" src="https://github.com/user-attachments/assets/ae0c0fc4-793c-427a-8503-8ae6ff91ef41" />

