### PR TITLE
fix: isValidWebsite regex accepts multi-level domain url and other cases

### DIFF
--- a/utils/stringUtils.ts
+++ b/utils/stringUtils.ts
@@ -42,7 +42,7 @@ export function isValidPhoneNumber(phoneNumber: string) {
 }
 
 export function isValidWebsite(website: string) {
-    return /^((https?|ftp|smtp):\/\/)?(www.)?[a-z0-9-]+\.[a-zA-Z0-9-_#/]+$/g.test(website)
+    return /^((https?:\/\/)?([\w-]+\.)+[\w-]{2,}(\/[\w\-._~:/?#[\]@!$&'()*+,;=]*)?)?$/i.test(website)
 }
 
 export function isFloat(float: string) {


### PR DESCRIPTION
✅ Resolves #[1455]
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected
- [ ] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Regex for `isValidWebsite` in `utils/stringUtils.ts` previously accepted only single level domains.

Updated the RegEx to solve the issue as well as other potential edge cases. 

1. Accepts multi-level domain urls like `example.or.jp`
2. Rejects invalid TLD characters like `_#/`, e.g. `example.c#`
3. Accepts paths and queries `example.com/login`
4. Not case-sensitive (need clarification on this change, necessitates sanitization on backend(or front))
5. Also removed smtp and ftp protocol validation, I am assuming only web addresses i.e. https and http urls are accepted. Let me know if you want to keep them.

## 🧪 Testing instructions
1. Login to moderator dash and test creation of facility

Feel free to use https://regex101.com/ as well to stress test!

## 📸 Screenshots

-   ### Before
<img width="460" height="123" alt="Screenshot 2025-08-14 at 17 43 51" src="https://github.com/user-attachments/assets/71b69433-e145-4b14-adca-c2b709150f2c" />
<img width="432" height="131" alt="image" src="https://github.com/user-attachments/assets/69b30122-f57e-4735-bcc0-b64a694c2702" />

-   ### After
<img width="395" height="112" alt="Screenshot 2025-08-14 at 17 56 35" src="https://github.com/user-attachments/assets/9b4688c3-f32a-4c73-96cb-f5ae1d164007" />

<img width="412" height="108" alt="Screenshot 2025-08-14 at 17 58 29" src="https://github.com/user-attachments/assets/265bb155-d9f9-47c4-a495-52da206bda87" />


