### PR TITLE
fix: added missing errorPage to en.json locale

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -382,6 +382,11 @@
     "of": "of",
     "results": "results"
   },
+  "errorPage": {
+      "title": "404 - Diagnosis : Page not Found",
+      "description": "This page has failed its health check. Let's head to a healthy page instead!",
+      "returnHome": "Return to Home"
+  },
   "modListContainer": {
     "resultsPerPage": "Results per page"
   },


### PR DESCRIPTION
✅ Resolves #[1454]
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected
- [ ] @NabbeunNabi has been selected for preliminary review

Did a quick check for the rest of the locales and all are set up 👍 
Home button is also working as expected.

## 🔧 What changed
Added `errorPage` to `i18n/locales/en.json` so correct error message is showing up in English.

## 🧪 Testing instructions
1. Head to a page that doesn't exist e.g. `http://localhost:3000/wwhwh`
2. Confirm that the correct error text is showing

## 📸 Screenshots

-   ### Before
<img width="658" height="846" alt="image" src="https://github.com/user-attachments/assets/9521ef6a-aefe-4b1b-bafc-b427114d1b96" />

-   ### After
<img width="826" height="716" alt="Screenshot 2025-08-15 at 14 29 29" src="https://github.com/user-attachments/assets/59e23762-8d9b-43f0-947c-dcee41c1b62b" />


