### PR TITLE
fix: fix regex japanese symbol 々

### DIFF
--- a/utils/stringUtils.ts
+++ b/utils/stringUtils.ts
@@ -4,7 +4,7 @@ export function hasSpecialCharacters(str: string) {
 }
 
 export function hasJapaneseCharacters(name: string) {
-    return /[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]+/g.test(name)
+    return /[\u3005\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]+/g.test(name)
 }
 
 export function hasLatinCharacters(name: string) {
@@ -24,7 +24,7 @@ export function hasOnlyValidJapaneseAndLatinCharacters(name: string): boolean {
         4. Spaces
         5. Digits
     */
-    const validChars = /^[A-Za-z0-9 \-\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]+$/
+    const validChars = /^[A-Za-z0-9 \-\u3005\u3040-\u309F\u30A0-\u30FF\u4E00-\u9FFF]+$/
     return validChars.test(normalized)
 }
 


### PR DESCRIPTION
✅ Resolves No Issue number
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected
- [ ] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Added `[\u3005] = 々` on both `hasJapaneseCharacters` and `hasOnlyValidJapaneseAndLatinCharacters` , i used on both for have everything aligned

## 🧪 Testing instructions

## 📸 Screenshots

-   ### Before

<img width="650" height="160" alt="image" src="https://github.com/user-attachments/assets/10c7a61a-01ef-42da-8176-e48715f6b52b" />

-   ### After

<img width="616" height="136" alt="image" src="https://github.com/user-attachments/assets/247a1954-a43c-44da-834c-fcdf921e407f" />
