### PR TITLE
fix: mod edit submission form autofill

### DIFF
--- a/components/moderation-panel/ModEditSubmissionForm.vue
+++ b/components/moderation-panel/ModEditSubmissionForm.vue
@@ -423,7 +423,7 @@ function initializeSubmissionFormValues(submissionData: Submission | undefined) 
               {
                   firstName: submittedHealthcareProfessionalName[0] || '',
                   lastName: submittedHealthcareProfessionalName[1] || '',
-                  locale: submissionData?.spokenLanguages?.[0] ?? Locale.Und
+                  locale: Locale.Und
               }
           ]
           : submittedHealthcareProfessionalName.length === 3
@@ -432,7 +432,7 @@ function initializeSubmissionFormValues(submissionData: Submission | undefined) 
                       firstName: submittedHealthcareProfessionalName[0] || '',
                       middleName: submittedHealthcareProfessionalName[1] || '',
                       lastName: submittedHealthcareProfessionalName[2] || '',
-                      locale: submissionData?.spokenLanguages?.[0] ?? Locale.Und
+                      locale: Locale.Und
                   }
               ]
               : [])


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
remove DataSubmission reference from `initializeSubmissionFormValues` in modeditSubmission



