### PR TITLE
fix: `spokenLanguages` not reflecting all languages in submission object and undefined when it should have values

### DIFF
--- a/components/moderation-panel/ModEditSubmissionForm.vue
+++ b/components/moderation-panel/ModEditSubmissionForm.vue
@@ -416,8 +416,10 @@ function initializeSubmissionFormValues(submissionData: Submission | undefined) 
             .filter((hp): hp is NonNullable<typeof hp> => hp !== undefined)
 
     // Healthcare Professionals fields
+    const hp = submissionData?.healthcareProfessionals?.[0]
+
     healthcareProfessionalSections.names
-    = submissionData?.healthcareProfessionals?.[0]?.names
+    = hp?.names
       ?? (submittedHealthcareProfessionalName.length === 2
           ? [
               {
@@ -437,11 +439,9 @@ function initializeSubmissionFormValues(submissionData: Submission | undefined) 
               ]
               : [])
 
-    const hpFacilityIds
-    = submissionData?.healthcareProfessionals?.[0]?.facilityIds ?? []
-    healthcareProfessionalSections.facilityIds = [...hpFacilityIds]
+    healthcareProfessionalSections.facilityIds = [...(hp?.facilityIds ?? [])]
     currentFacilityRelations.value
-    = hpFacilityIds
+        = healthcareProfessionalSections.facilityIds
             .map(facilityId =>
                 facilitiesStore.facilityData.find(facility => facility.id === facilityId))
             .filter((facility): facility is NonNullable<typeof facility> => facility !== undefined)
@@ -465,10 +465,11 @@ function initializeSubmissionFormValues(submissionData: Submission | undefined) 
     = submissionData.healthcareProfessionals[0].specialties
     }
 
-    if (submissionData?.healthcareProfessionals?.[0].spokenLanguages) {
-        healthcareProfessionalSections.spokenLanguages
-    = submissionData?.healthcareProfessionals?.[0].spokenLanguages
-    }
+    // Always include submissionData.spokenLanguages, append hp.spokenLanguages, remove duplicates
+    healthcareProfessionalSections.spokenLanguages = [
+        ...(submissionData?.spokenLanguages ?? []),
+        ...(hp?.spokenLanguages ?? [])
+    ].filter((value, index, self) => self.indexOf(value) === index)
 }
 
 // Assume you already have:


### PR DESCRIPTION
✅ Resolves #1481 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
- `spokenLanguages` now always combines the submission’s languages (at least 1) and the languages added afterwards through moderation into one list (array) without duplicates.

## 🧪 Testing instructions
Create a new submission. You have to add a required language, so when you go to the mod panel and look at the submission, you should be able to see the language you added earlier. Or, currently, you cannot even access this info because the page keeps loading for an infinite time.

## 📸 Screenshots

-   ### Before
Because of the `Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'spokenLanguages')` related error:
<img width="1032" height="689" alt="image" src="https://github.com/user-attachments/assets/9b4521e0-9856-4c98-ac2f-14c7b6da59fb" />

And if it would successfully load, there are no languages present:
<img width="423" height="127" alt="image" src="https://github.com/user-attachments/assets/c579cfd9-1126-4dac-acf6-32bc21e744b2" />