### PR TITLE
fix: hamburger closes on inside click

### DIFF
--- a/components/HamburgerMenu.vue
+++ b/components/HamburgerMenu.vue
@@ -21,6 +21,7 @@
             >
                 <div
                     v-show="isMenuOpen"
+                    @click.stop
                     data-testid="hamburger-menu"
                     class="fixed top-0 right-0 z-30 flex flex-col
                   justify-between w-2/3 h-dvh pt-6 pb-2 border-l-2 border-primary/20 rounded bg-primary-bg "


### PR DESCRIPTION
✅ Resolves #1493 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

There's a bug where the mobile hamburger menu is closing even when clicking within the hamburger menu. With the closeOnOutsideClick composable directive, this is not supposed to happen. 

It is likely due to the Teleport tag being used in the Hamburger menu to transition to the inner div menu. 

To solve this issue, I used `@click.stop` within that inner div. This seems to have fixed the issue

## 🧪 Testing instructions

Try pulling the branch and clicking within the menu. It should not close. It also should close when clicked outside or clicking the X in the top right corner

It should also be able to still go to other links (it was able to for me)

## 📸 Screenshots

-   ### Before

![hamburger-close-issue](https://github.com/user-attachments/assets/d040fb16-9abf-4c29-a859-6d539612fe15)


-   ### After


![fix-inside-menu-click-close](https://github.com/user-attachments/assets/64e65210-a167-4361-9488-aee57282e857)
