### PR TITLE
feat: enable tracking of clicked healthcare professional item with umami

### DIFF
--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -53,6 +53,7 @@
                             ? 'bg-secondary/10 hover:bg-secondary/30 border-2 border-secondary/10'
                             : 'bg-primary-bg hover:bg-primary-hover/50',
                     ]"
+                    data-umami-event="Search results list item"
                     @click="resultClicked(searchResult.professional.id)"
                 >
                     <SearchResultsListItem

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -54,6 +54,7 @@
                             : 'bg-primary-bg hover:bg-primary-hover/50',
                     ]"
                     data-umami-event="Search results list item"
+                    :data-umami-event-healthcareprofessional="getLocalizedName(searchResult.professional.names)"
                     @click="resultClicked(searchResult.professional.id)"
                 >
                     <SearchResultsListItem

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -54,7 +54,7 @@
                             : 'bg-primary-bg hover:bg-primary-hover/50',
                     ]"
                     data-umami-event="Search results list item"
-                    :data-umami-event-healthcareprofessional="getLocalizedName(searchResult.professional.names)"
+                    :data-umami-event-hp="getLocalizedName(searchResult.professional.names)"
                     @click="resultClicked(searchResult.professional.id)"
                 >
                     <SearchResultsListItem


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
This integrates a click event to be tracked on umami for when a search result item is clicked. It is simple for now as a test and we can add more in depth click events or other desired ones later

This follows the documentation from [umami track events](https://umami.is/docs/track-events)


