### PR TITLE
refactor: update umami click tracking to be directly in click function

### DIFF
--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -53,9 +53,7 @@
                             ? 'bg-secondary/10 hover:bg-secondary/30 border-2 border-secondary/10'
                             : 'bg-primary-bg hover:bg-primary-hover/50',
                     ]"
-                    data-umami-event="Search results list item"
-                    :data-umami-event-hp="getLocalizedName(searchResult.professional.names)"
-                    @click="resultClicked(searchResult.professional.id)"
+                    @click="resultClicked(searchResult.professional.id, getLocalizedName(searchResult.professional.names))"
                 >
                     <SearchResultsListItem
                         :name="getLocalizedName(searchResult.professional.names)"
@@ -95,6 +93,7 @@ import { Locale } from '~/typedefs/gqlTypes.js'
 import SVGLoadingIcon from '~/assets/icons/loading.svg'
 import SVGNoSearchResults from '~/assets/icons/no-search-results-graphic.svg'
 import { useScreenOrientation } from '~/composables/useScreenOrientation'
+import { useUmami } from '~/composables/useUmamiTracking'
 
 const { t } = useI18n()
 
@@ -103,6 +102,7 @@ const localeStore = useLocaleStore()
 const loadingStore = useLoadingStore()
 const bottomSheetStore = useBottomSheetStore()
 const { isPortrait } = useScreenOrientation()
+const { track } = useUmami()
 
 const hasResults = computed(() => resultsStore.searchResultsList.length > 0)
 const resultsContainerRef = ref<HTMLElement | null>(null)
@@ -118,9 +118,11 @@ function handleScroll() {
     emit('scrolled')
 }
 
-function resultClicked(resultId: string) {
+function resultClicked(resultId: string, hp: string) {
     resultsStore.setActiveSearchResult(resultId)
     bottomSheetStore.showBottomSheet(BottomSheetType.SearchResultDetails)
+
+    track('Search results list item', { hp })
 }
 
 function getLocalizedName(

--- a/composables/useUmamiTracking.ts
+++ b/composables/useUmamiTracking.ts
@@ -1,0 +1,11 @@
+export function useUmami() {
+    function track(eventName: string, data?: Record<string, unknown>): void {
+        if (typeof window !== 'undefined' && typeof window.umami?.track === 'function') {
+            window.umami.track(eventName, data)
+        } else {
+            console.warn('[umami] tracker not available')
+        }
+    }
+
+    return { track }
+}

--- a/global.d.ts
+++ b/global.d.ts
@@ -6,5 +6,9 @@ declare global {
     interface Window {
         // Declare the type for the Pinia store instance injected by Nuxt into `window` for testing purposes
         $pinia: Pinia
+        // Declare the type for umami events so we can track clicks
+        umami?: {
+            track: (eventName: string, data?: Record<string, unknown>) => void
+        }
     }
 }


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected
- [ ] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Trying a new way to track events that [tracker functions](https://umami.is/docs/tracker-functions) directly their click functions in order to be more direct and not rely on id tags that may or may not be tracked properly once rendered through vue and nuxt

