### PR TITLE
fix: location search results filtering

### DIFF
--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -91,7 +91,7 @@ Promise<HealthcareProfessional[]> {
     try {
         const searchProfessionalsData = {
             filters: {
-                limit: 100,
+                limit: 1000,
                 offset: 0,
                 specialties: searchSpecialties,
                 spokenLanguages: searchLanguages,
@@ -126,7 +126,7 @@ async function queryFacilities(healthcareProfessionalIds: string[], searchCity?:
     try {
         const searchFacilitiesData = {
             filters: {
-                limit: 100,
+                limit: 1000,
                 offset: 0,
                 healthcareProfessionalIds: healthcareProfessionalIds,
                 contact: undefined,


### PR DESCRIPTION
✅ Partially Resolves #1535 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected
- [ ] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Increased the number of professionals fetched to 1000, now we have more than 100 professionals and given the search filtering expects the data to be available, it was creating inconsistent search results. 

See filtering of professionals and facilities:

https://github.com/ourjapanlife/findadoc-web/blob/9738c1f4a8671e330a8dc7475eb192e594f8bce0/stores/searchResultsStore.ts#L41-L45



## 🧪 Testing instructions

1. click on "search and filter doctors"
2. pick all "All Specialties"
3. pick Minato City
4. click "Search" button

## 📸 Screenshots

-   ### Before

-   ### After

<img width="380" height="835" alt="localhost_3000_" src="https://github.com/user-attachments/assets/093973bb-e60e-418d-bc82-48aa35756529" />


