### PR TITLE
fix: theme option corresponds to actual color change

### DIFF
--- a/components/HamburgerMenu.vue
+++ b/components/HamburgerMenu.vue
@@ -175,7 +175,7 @@
                                 <div
                                     class="w-10 h-10 mr-1"
                                     title="Original Theme"
-                                    style="background-color:#EB7100"
+                                    style="background-color:#0EB0C0"
                                     :class="getSelectedTheme('original')"
                                     @click="setTheme('original')"
                                 />
@@ -196,14 +196,14 @@
                                 <div
                                     class="w-10 h-10 mr-1"
                                     title="Ocean Theme"
-                                    style="background-color: #245A7D;"
+                                    style="background-color: #77A6CD;"
                                     :class="getSelectedTheme('ocean')"
                                     @click="setTheme('ocean')"
                                 />
                                 <div
                                     class="w-10 h-10 mr-1"
                                     title="Neon Theme"
-                                    style="background-color: #1bdb9b;"
+                                    style="background-color: #006D6A;"
                                     :class="getSelectedTheme('neon')"
                                     @click="setTheme('neon')"
                                 />


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Some of the colors displayed as options in the theme color changer weren`t corresponding to the actual color change (for ex, new main theme is blue, but still shows orange). I fixed it so that they match the primary color for the theme


## 🧪 Testing instructions

## 📸 Screenshots

-   ### Before

<img width="398" height="849" alt="Screenshot 2025-10-18 082040" src="https://github.com/user-attachments/assets/6935cda6-c2ef-47b7-87af-75b9016865c3" />

<img width="387" height="842" alt="image" src="https://github.com/user-attachments/assets/87f05b88-9c3f-4f7b-86a5-40dcc33fe878" />

<img width="383" height="837" alt="image" src="https://github.com/user-attachments/assets/757b1bb3-5eea-4537-9296-d8f0738b3264" />


-   ### After

<img width="408" height="867" alt="image" src="https://github.com/user-attachments/assets/f6c3eee4-921c-4a9a-8079-ce73b30aa7e0" />

<img width="412" height="873" alt="image" src="https://github.com/user-attachments/assets/9c540192-bff6-4a34-95dd-1c711f8fb019" />

<img width="390" height="856" alt="image" src="https://github.com/user-attachments/assets/116ee9b1-1112-4374-ba06-5edbc5f96011" />

