### PR TITLE
fix: top nav items overflow before hamburger

### DIFF
--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -32,7 +32,7 @@
             <!-- Selected Languages -->
             <div class="search-language flex-1 landscape:flex-1">
                 <span
-                    class="block text-start pl-2 max-w-full landscape:max-w-full overflow-hidden text-ellipsis
+                    class="block text-start pl-2 max-w-full landscape:hidden overflow-hidden text-ellipsis
                            whitespace-nowrap"
                 >
                     {{ selectedLanguageText }}
@@ -41,7 +41,7 @@
             <!-- Selected Specialties -->
             <div class="search-specialty flex-1 landscape:flex-1">
                 <span
-                    class="block text-start pl-2 max-w-full landscape:max-w-full overflow-hidden text-ellipsis
+                    class="block text-start pl-2 max-w-full landscape:hidden overflow-hidden text-ellipsis
                            whitespace-nowrap"
                 >
                     • {{ selectedSpecialtyText }}
@@ -50,7 +50,7 @@
             <!-- Selected Locations -->
             <div class="search-location flex-1 landscape:flex-1">
                 <span
-                    class="block text-start pl-2 max-w-full landscape:max-w-full overflow-hidden text-ellipsis
+                    class="block text-start pl-2 max-w-full landscape:hidden overflow-hidden text-ellipsis
                            whitespace-nowrap"
                 >
                     • {{ selectedLocationText }}
@@ -60,8 +60,7 @@
         <!-- Results count -->
         <span
             class="block text-sm text-center
-                   text-primary-text-muted self-center
-                   landscape:ml-auto"
+                   text-primary-text-muted self-center"
         >
             {{ t('searchBar.resultsFound', searchResultsStore.totalResults) }}
         </span>

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         data-testid="top-nav"
-        class="flex flex-col mt-2 landscape:px-5 landscape:py-1 portrait:px-5 portrait:py-1  bg-primary-bg/90 rounded-lg"
+        class="flex flex-col mt-2 landscape:px-3 landscape:py-1 portrait:px-5 portrait:py-1  bg-primary-bg/90 rounded-lg"
     >
         <div
             class="flex justify-between items-center"
@@ -43,47 +43,50 @@
                     </div>
                 </Transition>
             </div>
-            <!-- Desktop Site Icon -->
-            <div
-                id="desktop-site-icon"
-                class="portrait:hidden w-52 font-semibold text-xl
+            <!-- Desktop Left Section -->
+            <div class="flex">
+                <!-- Desktop Site Icon -->
+                <div
+                    id="desktop-site-icon"
+                    class="portrait:hidden mr-5 w-50 font-semibold text-xl
                 group transition-colors items-start p-2 rounded-2xl"
-            >
-                <NuxtLink
-                    class="flex"
-                    to="/"
                 >
-                    <SVGSiteLogo
-                        role="img"
-                        title="site icon"
-                        class="mr-1 w-10 h-10 flex-shrink-0 align-middle fill-primary group-hover:fill-primary-hover"
-                    />
-                    <!-- Find a Doc, Japan Logo Text -->
-                    <div
-                        class="title-text flex flex-col flex-shrink-0"
-                        data-testid="landscape-logo"
+                    <NuxtLink
+                        class="flex"
+                        to="/"
                     >
-                        <div class="text-lg text-primary group-hover:text-primary-hover">
-                            Find a Doc
+                        <SVGSiteLogo
+                            role="img"
+                            title="site icon"
+                            class="mr-1 w-10 h-10 flex-shrink-0 align-middle fill-primary group-hover:fill-primary-hover"
+                        />
+                        <!-- Find a Doc, Japan Logo Text -->
+                        <div
+                            class="title-text flex flex-col flex-shrink-0"
+                            data-testid="landscape-logo"
+                        >
+                            <div class="text-lg text-primary group-hover:text-primary-hover">
+                                Find a Doc
+                            </div>
+                            <div class="text-sm text-primary leading-none group-hover:text-primary-hover">
+                                Japan
+                            </div>
                         </div>
-                        <div class="text-sm text-primary leading-none group-hover:text-primary-hover">
-                            Japan
-                        </div>
-                    </div>
-                </NuxtLink>
+                    </NuxtLink>
+                </div>
+                <!-- Search Bar -->
+                <div v-if="isLandscape">
+                    <SearchBar />
+                </div>
             </div>
-            <!-- Search Bar -->
-            <div v-if="isLandscape">
-                <SearchBar class="mx-4" />
-            </div>
-            <!-- Right Section -->
+            <!-- Desktop Right Section -->
             <div
                 id="right-section"
                 class="flex"
             >
                 <nav
                     id="desktop-menu-items"
-                    class="portrait:hidden flex gap-4 mx-6 self-center items-center whitespace-nowrap"
+                    class="portrait:hidden flex gap-3 mx-6 self-center items-center whitespace-nowrap"
                 >
                     <!-- About Link -->
                     <NuxtLink


### PR DESCRIPTION
✅ Resolves #1557 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

With the new search bar and filter info in the navbar, the navbar items started to overflow before the hamburger menu change if the screen size width was reduced. I adjusted some style settings to make items fit better and removed the filter information since that can be visible anyway if the search bar is clicked. Results found is still there though

## 🧪 Testing instructions

pull this branch, and change your screen size to see how the navbar adjusts. Also, try using the search bar in desktop and mobile to make sure both still work (they should)

## 📸 Screenshots

-   ### Before

![chrome-capture-2025-10-23](https://github.com/user-attachments/assets/f025cf6c-028e-46c3-b9e3-0d9d18b58edf)


-   ### After

![chrome-capture-2025-10-23 (1)](https://github.com/user-attachments/assets/61b07cad-c8f6-44a5-9bcc-deb5d491ac59)



