### PR TITLE
fix: rename i18n text file to match console log and gitignore

### DIFF
--- a/i18n/cleanUnusedLocaleKeys.js
+++ b/i18n/cleanUnusedLocaleKeys.js
@@ -149,7 +149,7 @@ const run = async () => {
         })
         .join('\n')
 
-    fs.writeFileSync('potentially_unused_locales_keys.txt', output, 'utf-8')
+    fs.writeFileSync('potentially_unused_keys.txt', output, 'utf-8')
     console.info('\n📝 Report saved to: potentially_unused_keys.txt\n')
 }
 


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Rename outputted txt file by the i18n linter to ensure it doesn't get added to the commit for updating unused translation keys

For example: https://github.com/ourjapanlife/findadoc-web/pull/1549

## 🧪 Testing instructions

Review linter PR when generated. No txt file should be in the commit.

## 📸 Screenshots

-   ### Before

-   ### After


