### PR TITLE
refactor: fetch only the required professionals during search

### DIFF
--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -150,13 +150,13 @@ Promise<HealthcareProfessional[]> {
     }
 }
 
-async function queryFacilities(searchCity?: string): Promise<Facility[]> {
+async function queryFacilities(searchCity?: string, heathcareProfessinalIDs?: string[]): Promise<Facility[]> {
     try {
         const searchFacilitiesData = {
             filters: {
                 limit: 1000,
                 offset: 0,
-                healthcareProfessionalIds: undefined,
+                healthcareProfessionalIds: heathcareProfessinalIDs ?? undefined,
                 contact: undefined,
                 createdDate: undefined,
                 healthcareProfessionalName: undefined,


### PR DESCRIPTION
✅ Resolves #1535 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected
- [ ] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Instead of fetching the entire database of professionals during a search, collect the matching facility professional IDs and fetch only those.

## 🧪 Testing instructions

1. click on "search and filter doctors"
2. pick all "All Specialties"
3. pick Minato City
4. click "Search" button


## 📸 Screenshots

No UI changes. 


