### PR TITLE
fix: `SlidingRightPanel` stays open when selecting a different pin on the map or search result

### DIFF
--- a/components/MapContainer.vue
+++ b/components/MapContainer.vue
@@ -14,6 +14,7 @@
             :center="currentLocation"
             :zoom="currentZoom"
             :gesture-handling="'greedy'"
+            @click="handleMapClick"
             @drag="handleMapMovement"
             @zoom_changed="handleZoomChanged"
         >
@@ -26,7 +27,7 @@
                         lng: location.mapLongitude ?? defaultLocation.lng,
                     },
                 }"
-                @click="handlePinClick(location.id)"
+                @click="(event: MouseEvent) => handlePinClick(location.id, event)"
             >
                 <div style="text-align: center">
                     <SVGMapPin
@@ -72,7 +73,9 @@ const isMapMovingFromSearchResults = ref(false)
 // Emit events for map movement
 const emit = defineEmits(['map-moved'])
 
-const handlePinClick = (resultId: string) => {
+const handlePinClick = (resultId: string, event?: MouseEvent) => {
+    event?.stopPropagation() // Prevent the map click event
+
     //Let's show the result details
     searchResultsStore.setActiveFacility(resultId)
     bottomSheetStore.showBottomSheet(BottomSheetType.SearchResultDetails)
@@ -82,6 +85,14 @@ const handlePinClick = (resultId: string) => {
     nextTick(() => {
         setLocation(currentLocation.value.lat, currentLocation.value.lng)
     })
+}
+
+const handleMapClick = (_event: google.maps.MapMouseEvent) => {
+    // Close the panel if a facility is active
+    if (searchResultsStore.activeFacilityId) {
+        bottomSheetStore.showBottomSheet(BottomSheetType.SearchResultsList)
+        searchResultsStore.clearActiveSearchResult()
+    }
 }
 
 onMounted(() => {

--- a/components/SlidingRightPanel.vue
+++ b/components/SlidingRightPanel.vue
@@ -2,7 +2,6 @@
     <Transition name="slide-left">
         <div
             v-if="shouldShowPanel"
-            v-close-on-outside-click="closePanelHandler"
             class="absolute left-96 inset-y-24 ml-1 bg-primary-bg
             border-l border-secondary-bg/40 shadow-lg z-10 rounded-lg"
             :class="[
@@ -50,7 +49,6 @@ import SearchResultDetails from '~/components/SearchResultDetails.vue'
 import FiltersPanel from '~/components/FiltersPanel.vue'
 import { BottomSheetType, useBottomSheetStore } from '~/stores/bottomSheetStore'
 import { useSearchResultsStore } from '~/stores/searchResultsStore'
-import { vCloseOnOutsideClick } from '~/composables/closeOnOutsideClick'
 
 const bottomSheetStore = useBottomSheetStore()
 const searchResultsStore = useSearchResultsStore()


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
- Selecting a marker on the map while `SlidingRightPanel.vue` is already open will not close the panel. It will stay open.
- The same goes for selecting a search result from `SearchResultList.vue`.
- When clicking on the map (not on a marker), the panel closes, the same way it did before the changes above.
