### PR TITLE
fix: landing page wave SVG shape and transition time

### DIFF
--- a/components/onboarding/WelcomeScreen.vue
+++ b/components/onboarding/WelcomeScreen.vue
@@ -77,10 +77,10 @@
                         <!-- Subtly morph the wave path when hovered -->
                         <path
                             :d="waveHover
-                                ? 'M375 0V56H0V25C50 33 125 70 187.5 50C250 30 320 -10 375 25Z'
+                                ? 'M375 0V56H0V30C56 13 123 8 195 27C263 42 322 40 375 11 Z'
                                 : 'M375 0V56H0V18.5C46.5 33 120 59 187.5 45C255 31 328.5 -13.5 375 18.5Z'"
                             class="fill-primary-bg"
-                            :style="{ transition: 'd 0.4s cubic-bezier(.6,0,.4,1)' }"
+                            :style="{ transition: 'd 0.8s cubic-bezier(.6,0,.4,1)' }"
                         />
                     </svg>
                 </div>


### PR DESCRIPTION
✅ Resolves #1534 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed
Changed the shape of the transformed SVG wave for a more noticeable transition upon hover.

## 🧪 Testing instructions
1. Visit landing page
2. Hover on the wave shape

## 📸 Screenshots

-   ### Before
<img width="2904" height="186" alt="image" src="https://github.com/user-attachments/assets/d2ff273b-0221-4274-ae7f-31ca0feb2afa" />


-   ### After
<img width="2940" height="168" alt="image" src="https://github.com/user-attachments/assets/60f8413a-4dd0-4741-8b21-21d496225085" />



