### PR TITLE
fix: new i18 on welcome screen

### DIFF
--- a/components/onboarding/WelcomeScreen.vue
+++ b/components/onboarding/WelcomeScreen.vue
@@ -22,7 +22,7 @@
                         <span class="block mt-2">Find a Doc, Japan!</span>
                     </h1>
                     <p class="landscape:text-2xl text-lg mt-3 max-w-md">
-                        {{ t('about.subheading') }}
+                        {{ t('about.heroSubheading') }}
                     </p>
                 </div>
                 <!-- Bouncing arrow button -->


### PR DESCRIPTION
✅ Resolves #1576
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

<img width="1855" height="915" alt="Screenshot 2025-11-10 092640" src="https://github.com/user-attachments/assets/5393f090-e3f0-4470-b379-18038a236b0b" />

After updating the about us page and the i18 on the about us page, this made one of the translatable strings stop working on the welcome screen. This PR fixes that

## 🧪 Testing instructions

Double check the locales json, but the new one (about.heroSubheading) should give the correct text (Connecting you to the healthcare services you need, in your language)

## 📸 Screenshots

-   ### Before

-   ### After


