### PR TITLE
refactor: about scroll up button position

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -423,7 +423,9 @@
         >
             <a
                 v-show="showScrollUpButton"
-                class="fixed bottom-0 right-0 z-50 md:bottom-2"
+                class="fixed bottom-4 left-1/2 -translate-x-1/2
+                    md:bottom-4 md:left-auto md:right-6
+                     z-50"
             >
                 <SvgArrow
                     role="img"

--- a/test/jest/snapshot/__snapshots__/about.jest.test.ts.snap
+++ b/test/jest/snapshot/__snapshots__/about.jest.test.ts.snap
@@ -2485,7 +2485,7 @@ exports[`about.vue renders correctly 1`] = `
     persisted="true"
   >
     <a
-      class="fixed bottom-0 right-0 z-50 md:bottom-2"
+      class="fixed bottom-4 left-1/2 -translate-x-1/2 md:bottom-4 md:left-auto md:right-6 z-50"
       style="display: none;"
     >
       <!---->


### PR DESCRIPTION
✅ Resolves 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

Before, the scroll up button on the about page was always in the center. This makes the button hover cover other elements. So I made it bottom right corner for desktop, but still in the bottom center for mobile

## 🧪 Testing instructions

run the PR yourself to see or look at the screenshots

## 📸 Screenshots

-   ### Before

<img width="1900" height="929" alt="スクリーンショット 2025-11-14 085217" src="https://github.com/user-attachments/assets/3f45ae18-3434-4739-bf14-b9c3f0244dc8" />


<img width="399" height="873" alt="スクリーンショット 2025-11-14 085230" src="https://github.com/user-attachments/assets/d754b73b-786e-4998-8dab-5d699caf3946" />


-   ### After

<img width="1887" height="926" alt="スクリーンショット 2025-11-14 084652" src="https://github.com/user-attachments/assets/599449a0-cfc9-4e46-aa81-f11029aef73b" />


<img width="395" height="877" alt="スクリーンショット 2025-11-14 084723" src="https://github.com/user-attachments/assets/2cf21687-6c5c-487a-8397-00c9bd4f7cb8" />
