### PR TITLE
feat: added snapshot test for privacypolicy.vue

### DIFF
--- a/tests/vitest/snapshotTests/__snapshots__/privacypolicy.spec.ts.snap
+++ b/tests/vitest/snapshotTests/__snapshots__/privacypolicy.spec.ts.snap
@@ -1,0 +1,29 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`privacypolicy.vue > renders correctly 1`] = `
+"<div class="overflow-y-auto w-full px-10 md:px-32">
+  <div>
+    <h1 data-testid="privacy-heading" class="mb-20 text-black text-5xl font-bold font-sans">privacyPage.heading</h1>
+  </div>
+  <h2 data-testid="privacy-subheading" class="mb-10 text-black text-2xl font-normal font-sans">privacyPage.subheading</h2>
+  <div class="text-gray-500 text-lg font-normal font-sans">
+    <p class="mb-10">privacyPage.date</p>
+    <p class="mb-10">privacyPage.paragraph1</p>
+    <p class="mb-2 font-bold">privacyPage.paragraph2</p>
+    <p class="mb-10">privacyPage.paragraph3</p>
+    <p class="mb-2 font-bold">privacyPage.paragraph4</p>
+    <p class="mb-10">privacyPage.paragraph5</p>
+    <p class="mb-2 font-bold">privacyPage.paragraph6: </p>
+    <p class="mb-10">privacyPage.paragraph7</p>
+    <p class="mb-2 font-bold">privacyPage.paragraph8: </p>
+    <p class="mb-10">privacyPage.paragraph9</p>
+    <p class="mb-2 font-bold">privacyPage.paragraph10</p>
+    <p class="mb-10">privacyPage.paragraph11</p>
+    <p class="mb-2 font-bold">privacyPage.paragraph12</p>
+    <p class="mb-10">privacyPage.paragraph13</p>
+    <p class="mb-2 font-bold">privacyPage.paragraph14</p>
+    <p class="mb-10">privacyPage.paragraph15</p>
+    <p class="mb-10">privacyPage.paragraph16</p>
+  </div>
+</div>"
+`;

--- a/tests/vitest/snapshotTests/privacypolicy.spec.ts
+++ b/tests/vitest/snapshotTests/privacypolicy.spec.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, it, expect } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import PrivacyPolicy from '~/pages/privacypolicy.vue'
+
+beforeAll(() => {
+    class MockIntersectionObserver {
+        constructor(
+            public callback: IntersectionObserverCallback,
+            public options?: IntersectionObserverInit
+        ) {}
+
+        observe(_target: Element) {}
+        unobserve(_target: Element) {}
+        disconnect() {}
+    }
+
+    global.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver
+})
+
+const i18n = createI18n({
+    legacy: false,
+    locale: 'en-US',
+    messages: { 'en-US': {} }
+})
+
+describe('privacypolicy.vue', () => {
+    it('renders correctly', () => {
+        const wrapper = shallowMount(PrivacyPolicy, {
+            global: {
+                plugins: [i18n]
+            }
+        })
+        expect(wrapper.html()).toMatchSnapshot()
+    })
+})


### PR DESCRIPTION
✅ Resolves #1430
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected
- [x] @NabbeunNabi has been selected for preliminary review

## 🔧 What changed

- Created `privacypolicy.spec.ts` to run a snapshot test on the `privacypolicy.vue` page.

## 🧪 Testing instructions
1. Checkout this branch locally.
2. Run `yarn install` if needed.
3. Run Vitest with the snapshot test command: `yarn test:snapshot`.
4. Confirm the test for terms.vue passes and generates a snapshot file in `tests/vitest/snapshotTests/__snapshots__/privacypolicy.spect.ts.snap`. 

## 📸 Screenshots
<img width="1790" height="1012" alt="privacypolicy vue snapshot test passed" src="https://github.com/user-attachments/assets/08395c7f-9946-4b84-b93f-8ce3699d2252" />

Screenshot of VS Code terminal showing successful snapshot tests including `privacypolicy.vue`.

### Before

- There was no Vitest snapshot testing for `privacypolicy.vue`.

### After

- Added snapshot test for `privacypolicy.vue`, increasing test coverage and detecting unexpected UI changes. 