### PR TITLE
refactor(style): change topnav logo transition style application

### DIFF
--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -25,8 +25,13 @@
                     />
                 </NuxtLink>
                 <Transition
-                    name="slide-left"
                     mode="out-in"
+                    enter-active-class="transition-transform transition-opacity duration-[400ms] ease-in-out"
+                    enter-from-class="-translate-x-10 opacity-0"
+                    enter-to-class="translate-x-0 opacity-100"
+                    leave-active-class="transition-opacity duration-[400ms] ease-in-out"
+                    leave-from-class="opacity-100"
+                    leave-to-class="opacity-0"
                 >
                     <!-- Find a Doc, Japan Logo Text -->
                     <div
@@ -236,25 +241,3 @@ async function logout() {
 }
 </script>
 
-<style scoped>
-.slide-left-enter-active,
-.slide-left-leave-active {
-  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-}
-.slide-left-enter-from {
-  transform: translateX(-40px);
-  opacity: 0;
-}
-.slide-left-enter-to {
-  transform: translateX(0);
-  opacity: 1;
-}
-.slide-left-leave-from {
-  transform: translateX(0);
-  opacity: 1;
-}
-.slide-left-leave-to {
-  transform: translateX(0);
-  opacity: 0;
-}
-</style>


### PR DESCRIPTION
 ## **No Issue attached as found while coding**

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed
This removes the style block for code quality and moves it into the built in Transition component in Vue that helps with transitions and animations

## 🧪 Testing instructions
1. Go to this branch.
2. Run the local server using `yarn:dev`. Local server is not necessary to test this though preferred to prevent production calls.
3. Use the dev console in the browser to make the view that of portrait view to get the mobile topnav
4. Click the logo on the home page to see the same behavior of the transition.

## 📸 Screenshots

**No Change**

-   ### Before

https://github.com/user-attachments/assets/fecf925d-f7f7-4f2e-997c-2d6846421747



-   ### After

https://github.com/user-attachments/assets/d57a7058-e642-4ccb-9e9a-5699167190d2



