### PR TITLE
chore: update PR template to remove preliminary check requirement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
 ✅ Resolves #[Issue number]
+
 - [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
 - [ ] PR assignee has been selected
 - [ ] PR label has been selected
-- [ ] @NabbeunNabi has been selected for preliminary review
 
 ## 🔧 What changed
 
@@ -10,8 +10,5 @@
 
 ## 📸 Screenshots
 
--   ### Before
-
--   ### After
-
-
+- ### Before
+- ### After


### PR DESCRIPTION
✅ Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed
As discussed before in the frontend either @ermish or @NabbeunNabi can approve. So removed the extra step that also is not necessarily clear for newcomers


