### PR TITLE
feat: add TransitionToSearchScreen.vue component to Storybook.

### DIFF
--- a/.storybook/components/TransitionToSearchScreen.stories.ts
+++ b/.storybook/components/TransitionToSearchScreen.stories.ts
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import TransitionToSearchScreen from '../../components/onboarding/TransitionToSearchScreen.vue'
+
+const meta = {
+    title: 'components/onboarding/TransitionToSearchScreen',
+    component: TransitionToSearchScreen,
+    tags: ['autodocs']
+} satisfies Meta<typeof TransitionToSearchScreen>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+    args: {}
+}


### PR DESCRIPTION
✅ Resolves #1637 

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed
- Added TransitionToSearchScreen.vue component to Storybook with a default story. 

## 🧪 Testing instructions
- Checkout this branch.
- Run `yarn storybook` to open storybook in development on `http://localhost:6006` in the browser.

## 📸 Screenshots
<img width="1790" height="905" alt="Screenshot 2569-01-14 at 13 36 10" src="https://github.com/user-attachments/assets/6198438e-0142-414a-8bac-6a9c33f20fb8" />

### Before
- TransitionToSearchScreen.vue component was not part of Storybook.

### After
- TransitionToSearchScreen.vue component is part of Storybook with a default story. 