### PR TITLE
feat: add MemberComponent.vue to Storybook.

### DIFF
--- a/.storybook/components/MemberComponent.stories.ts
+++ b/.storybook/components/MemberComponent.stories.ts
@@ -12,8 +12,8 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
     args: {
-        avatarImg: 'https://images.pexels.com/photos/1102341/pexels-photo-1102341.jpeg',
-        name: 'Samantha Carter',
+        avatarImg: '/public/avatars/andrew_leemhuis.jpg',
+        name: 'Andrew Leemhuis',
         title: 'Full stack developer',
         dataTestId: 1,
         githubUrl: '',


### PR DESCRIPTION
✅ Resolves #1638 

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed
- Added MemberComponent.vue to Storybook with a default story and appropriate args.

## 🧪 Testing instructions
- Checkout this branch.
- Run `yarn storybook` to open Storybook in development on `http://localhost:6006` in the browser.
- Under the 'Controls' menu inside Storybook, the args / props are adjustable in it's default story. 

## 📸 Screenshots
<img width="1790" height="905" alt="Screenshot 2569-01-14 at 13 34 26" src="https://github.com/user-attachments/assets/34d0feb2-4d6b-4e60-9d81-2dd49fdc25ab" />

### Before
- MemberComponent.vue did not exist inside Storybook.

### After
- MemberComponent.vue exists inside Storybook within it's default story and appropriate args. 