### PR TITLE
bug: storybook fix  to conditionally load the nuxt plugin

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,7 +16,7 @@ export default defineNuxtConfig({
         '@nuxt/eslint',
         '@nuxt/test-utils/module',
         'nuxt-gtag',
-        '@nuxtjs/storybook'
+        ...(process.env.STORYBOOK ? ['@nuxtjs/storybook'] as const : [])
     ],
 
     // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
         "test:e2e:ci": "cypress run --e2e",
         "test:snapshot": "vitest run tests/vitest/snapshotTests",
         "test:snapshot:update": "vitest run tests/vitest/snapshotTests --update",
-        "storybook": "storybook dev -p 6006",
-        "storybook:build": "storybook build"
+        "storybook": "STORYBOOK=true storybook dev -p 6007",
+        "storybook:build": "STORYBOOK=true storybook build"
     },
     "packageManager": "yarn@4.12.0",
     "engines": {


### PR DESCRIPTION
## 🔧 What changed
yarn dev was failing from storybook configuration. 

This might not be the most elegant fix, but it works. It just removes the storybook plugin from running entirely using an ENV variable if we're not planning to use storybook. 
