### PR TITLE
fix: try to fix home.cy.ts error

### DIFF
--- a/components/MapContainer.vue
+++ b/components/MapContainer.vue
@@ -55,6 +55,7 @@
 
 <script setup lang="ts">
 import { ref, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { onBeforeRouteLeave } from 'vue-router'
 import { GoogleMap, AdvancedMarker, MarkerCluster } from 'vue3-google-map'
 import type { Renderer } from '@googlemaps/markerclusterer'
 import { useUmami } from '~/composables/useUmamiTracking'
@@ -402,14 +403,34 @@ const calculateZoomLevel = (coordinates: { lat: number, lng: number }[]) => {
     }
 }
 
-onBeforeUnmount(() => {
-  isUnmounting.value = true
+onBeforeRouteLeave(() => {
+    isUnmounting.value = true
 
-  nextTick(() => {
+    //eslint-disable-next-line
     const markerClusterInstance = (markerClusterRef.value as { markerCluster?: any })?.markerCluster
-    if (markerClusterInstance?.setMap) {
-      markerClusterInstance.setMap(null)
+    if (markerClusterInstance) {
+        try {
+            if (markerClusterInstance.setMap) {
+                markerClusterInstance.setMap(null)
+            }
+            if (markerClusterInstance.clearMarkers) {
+                markerClusterInstance.clearMarkers()
+            }
+        } catch (error) {
+            console.error(error)
+        }
     }
-  })
+})
+
+onBeforeUnmount(() => {
+    isUnmounting.value = true
+
+    nextTick(() => {
+        //eslint-disable-next-line
+        const markerClusterInstance = (markerClusterRef.value as { markerCluster?: any })?.markerCluster
+        if (markerClusterInstance?.setMap) {
+            markerClusterInstance.setMap(null)
+        }
+    })
 })
 </script>


### PR DESCRIPTION
✅ Resolves #[Issue number]

WIP

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed

Google Maps `MarkerClusterer` was still running async calculations (`getClusters`) while the component was unmounting during navigation. This caused a race condition where the clusterer tried to access properties `range` that no longer existed.
I've added `onBeforeRouteLeave` to destroy the `MarkerClusterer` before navigation starts.

On the first commit i've only added `onBeforeUnmount` but that one seems not to change the issues (strange i don't know why maybe i was cleaning the marker in the wrong way), still used but i think `onBeforeRouteLeave` is more strong in term destroy before starting Vue create that component, maybe more safe in term of race condition.

Feel free to reply to my doubt

## 🧪 Testing instructions

## 📸 Screenshots

- ### Before
- ### After
