### PR TITLE
feat: add ModInputField.vue component to Storybook.

### DIFF
--- a/.storybook/components/ModInputField.stories.ts
+++ b/.storybook/components/ModInputField.stories.ts
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ModInputField from '../../components/moderation-panel/ModInputField.vue'
+
+const meta = {
+    title: 'components/moderation-panel/ModInputField',
+    component: ModInputField,
+    tags: ['autodocs'],
+    argTypes: {
+        label: {
+            control: 'text',
+            description: 'Label text for the input field'
+        },
+        type: {
+            control: 'select',
+            options: ['text', 'email', 'password', 'tel', 'url'],
+            description: 'HTML input type'
+        },
+        placeholder: {
+            control: 'text',
+            description: 'Placeholder text for the input'
+        },
+        required: {
+            control: 'boolean',
+            description: 'Whether the field is required'
+        },
+        invalidInputErrorMessage: {
+            control: 'text',
+            description: 'Error message shown when validation fails'
+        },
+        inputValidationCheck: {
+            control: false,
+            description: 'Validation function: `(value: string | undefined) => boolean`. Returns true if valid, false otherwise.'
+        }
+    }
+} satisfies Meta<typeof ModInputField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+    args: {
+        label: 'Full Name',
+        type: 'text',
+        placeholder: 'Enter your name',
+        required: true
+    }
+}
+
+export const Optional: Story = {
+    args: {
+        label: 'Middle Name',
+        type: 'text',
+        placeholder: 'Enter middle name',
+        required: false
+    }
+}
+
+export const EmailWithValidation: Story = {
+    args: {
+        label: 'Email Address',
+        type: 'email',
+        placeholder: 'Enter your email',
+        required: true,
+        invalidInputErrorMessage: 'Please enter a valid email address',
+        inputValidationCheck: (value: string | undefined) => {
+            if (!value) return false
+            return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+        }
+    }
+}
+
+export const PasswordWithValidation: Story = {
+    args: {
+        label: 'Password',
+        type: 'password',
+        placeholder: 'Enter password',
+        required: true,
+        invalidInputErrorMessage: 'Password must be at least 8 characters',
+        inputValidationCheck: (value: string | undefined) => value ? value.length >= 8 : false
+    }
+}
+
+export const PhoneWithValidation: Story = {
+    args: {
+        label: 'Phone Number',
+        type: 'tel',
+        placeholder: '+81 123-4567-8900',
+        required: true,
+        invalidInputErrorMessage: 'Please enter a valid phone number',
+        inputValidationCheck: (value: string | undefined) => {
+            if (!value) return false
+            return /^\+?\d{10,}$/.test(value.replace(/[\s\-()]/g, ''))
+        }
+    }
+}


### PR DESCRIPTION
✅ Resolves #1657 

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed
- Added ModInputField.vue component to Storybook with multiple stories showing the input field in different states: default, optional, and with validations. 

## 🧪 Testing instructions
- Run `yarn storybook` to open Storybook in development on `http://localhost:6006` in the browser.
- See the `ModInputField.vue` component's docs and multiple stories inside Storybook. 
- Change the different prop values under the 'Controls' Menu.

## 📸 Screenshots
<img width="1790" height="905" alt="Storybook Screenshot" src="https://github.com/user-attachments/assets/225c8388-be78-47de-a66e-369d01773e22" />

### Before
- MondInputField.vue component did not exist inside Storybook.

### After
- MondInputField.vue component exists inside Storybook showing multiple stories and appropriate args. 