### PR TITLE
feat: filter specialties rework

### DIFF
--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -32,6 +32,25 @@
                             >
                             <span>{{ category.displayText }}</span>
                         </label>
+                        <button
+                            class="p-1 hover:bg-primary-bg/20 rounded"
+                            @click="toggleSpecialtySection(category.value)"
+                        >
+                            <svg
+                                class="w-4 h-4 text-primary-text transition-transform duration-200"
+                                :class="{ 'rotate-180': openSpecialtySection[category.value] }"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke="currentColor"
+                            >
+                                <path
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                    stroke-width="2"
+                                    d="M19 9l-7 7-7-7"
+                                />
+                            </svg>
+                        </button>
                     </div>
                     <!-- specialty -->
                     <div v-if="selectedCategory === category.value">
@@ -288,6 +307,7 @@ const selectedCity: Ref<string> = ref('')
 // Needed for toggling
 const openPrefectureSections: Ref<Record<string, boolean>> = ref({})
 const openCitySections: Ref<Record<string, boolean>> = ref({})
+const openSpecialtySection: Ref<Record<string, boolean>> = ref({})
 
 interface DropdownOption {
     displayText: string
@@ -411,6 +431,10 @@ function selectCity(city: string) {
 function selectCategory(category: SpecialtyCategory | '') {
     selectedCategory.value = category
     selectedSpecialty.value = ''
+    openSpecialtySection.value = {}
+    if (category) {
+        openSpecialtySection.value[category] = true
+    }
 }
 function selectSpecialty(specialty: string | '') {
     selectedSpecialty.value = specialty
@@ -422,6 +446,9 @@ function togglePrefectureSection(region: Region) {
 }
 function toggleCitySection(prefecture: Prefecture) {
     openCitySections.value[prefecture] = !openCitySections.value[prefecture]
+}
+function toggleSpecialtySection(category: string) {
+    openSpecialtySection.value[category] = !openSpecialtySection.value[category]
 }
 
 function createLanguageDropdownOptions() {

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -251,9 +251,11 @@ const specialtiesStore = useSpecialtiesStore()
 const bottomSheetStore = useBottomSheetStore()
 
 const locationDropdownOptions: Ref<LocationDropdownOption[]> = ref([])
+const categoryDropdownOptions: Ref<DropdownOption[]> = ref([])
 const specialtyDropdownOptions: Ref<DropdownOption[]> = ref([])
 const languageDropdownOptions: Ref<DropdownOption[]> = ref([])
 
+const selectedCategories: Ref<string> = ref('')
 const selectedSpecialties: Ref<string> = ref('')
 const selectedLanguages: Ref<string> = ref(localeStore.activeLocale.code)
 
@@ -280,6 +282,7 @@ onMounted(async () => {
     // Initialize locations when component is mounted. The dropdown options are reactive, so they will update automatically
     await createLocationDropdownOptions()
     createLanguageDropdownOptions()
+    createCategoryDropdownOptions()
     createSpecialtyDropdownOptions()
 })
 
@@ -388,6 +391,15 @@ function createLanguageDropdownOptions() {
     dropdownOptions.filter(locale => locale.value)
 
     languageDropdownOptions.value = dropdownOptions
+}
+
+function createCategoryDropdownOptions() {
+    const dropdownOptions = specialtiesStore.specialtyCategories.map(category => ({
+        displayText: category.displayText,
+        value: category.code
+    })) as DropdownOption[]
+
+    categoryDropdownOptions.value = dropdownOptions
 }
 
 function createSpecialtyDropdownOptions() {

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -263,7 +263,6 @@ import { Locale } from '~/typedefs/gqlTypes.js'
 import { BottomSheetType, useBottomSheetStore } from '~/stores/bottomSheetStore'
 import type { Region, Prefecture, City } from '~/typedefs/locationTypes'
 import { regionsEnum, getPrefecturesByRegion, getCitiesByPrefecture } from '~/typedefs/locationTypes'
-import { displayPartsToString } from 'typescript'
 
 const { t } = useI18n()
 
@@ -305,7 +304,6 @@ onMounted(async () => {
     await createLocationDropdownOptions()
     createLanguageDropdownOptions()
     createCategoryDropdownOptions()
-    createSpecialtyDropdownOptions()
 })
 
 // Region dropdowns
@@ -359,17 +357,14 @@ const specialtyDropdownOptions = computed(() => {
     const specialtiesInCategory = specialtiesStore.categoryToSpecialtyMap[selectedCategory.value as SpecialtyCategory]
     const specialtiesInCategorySet = new Set(specialtiesInCategory)
 
-    console.log(specialtiesInCategorySet)
-
-    const specialtyOptions = specialtiesStore.specialtyDisplayOptions
+    const finalSpecialtyOptions = specialtiesStore.specialtyDisplayOptions
         .filter(specialty => specialtiesInCategorySet.has(specialty.code))
         .map(selection => ({
             value: selection.code,
             displayText: selection.displayText
         }))
-    console.log(specialtyOptions)
 
-    return specialtyOptions
+    return finalSpecialtyOptions
 })
 
 // Watch statement to prevent prefectures and cities that dont match
@@ -450,17 +445,6 @@ function createCategoryDropdownOptions() {
     categoryDropdownOptions.value = dropdownOptions
 }
 
-function createSpecialtyDropdownOptions() {
-    const dropdownOptions = specialtiesStore.specialtyDisplayOptions.map(specialty => ({
-        displayText: specialty.displayText,
-        value: specialty.code
-    })) as DropdownOption[]
-
-    // Add the "All" option to the top of the list
-    // dropdownOptions.unshift({ displayText: t('searchBar.allSpecialties'), value: '' })
-
-    specialtyDropdownOptions.value = dropdownOptions
-}
 
 async function createLocationDropdownOptions(): Promise<void> {
     // Show an interim loading state while we fetch the locations

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -237,7 +237,7 @@ import { useSearchResultsStore } from '~/stores/searchResultsStore.js'
 import { useLocationsStore, regionDisplayName, prefectureDisplayName, cityDisplayName } from '~/stores/locationsStore.js'
 import { useSpecialtiesStore } from '~/stores/specialtiesStore.js'
 import { useLocaleStore } from '~/stores/localeStore.js'
-import { type Specialty, Locale } from '~/typedefs/gqlTypes.js'
+import { type Specialty, Locale, SpecialtyCategory } from '~/typedefs/gqlTypes.js'
 import { BottomSheetType, useBottomSheetStore } from '~/stores/bottomSheetStore'
 import type { Region, Prefecture, City } from '~/typedefs/locationTypes'
 import { regionsEnum, getPrefecturesByRegion, getCitiesByPrefecture } from '~/typedefs/locationTypes'
@@ -255,7 +255,7 @@ const categoryDropdownOptions: Ref<DropdownOption[]> = ref([])
 const specialtyDropdownOptions: Ref<DropdownOption[]> = ref([])
 const languageDropdownOptions: Ref<DropdownOption[]> = ref([])
 
-const selectedCategories: Ref<string> = ref('')
+const selectedCategories: Ref<SpecialtyCategory | ''> = ref('')
 const selectedSpecialties: Ref<string> = ref('')
 const selectedLanguages: Ref<string> = ref(localeStore.activeLocale.code)
 

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -42,7 +42,7 @@
                             <div
                                 id="specialty-boxes"
                                 class="flex justify-between py-2"
-                                @click="selectSpecialty()"
+                                @click="selectSpecialty(selectedSpecialty === specialty.value ? '' : specialty.value)"
                             >
                                 <label class="flex items-center justify-between gap-3 ml-2">
                                     <input
@@ -263,6 +263,7 @@ import { Locale } from '~/typedefs/gqlTypes.js'
 import { BottomSheetType, useBottomSheetStore } from '~/stores/bottomSheetStore'
 import type { Region, Prefecture, City } from '~/typedefs/locationTypes'
 import { regionsEnum, getPrefecturesByRegion, getCitiesByPrefecture } from '~/typedefs/locationTypes'
+import { displayPartsToString } from 'typescript'
 
 const { t } = useI18n()
 
@@ -274,7 +275,6 @@ const bottomSheetStore = useBottomSheetStore()
 
 const locationDropdownOptions: Ref<LocationDropdownOption[]> = ref([])
 const categoryDropdownOptions: Ref<DropdownOption[]> = ref([])
-const specialtyDropdownOptions: Ref<DropdownOption[]> = ref([])
 const languageDropdownOptions: Ref<DropdownOption[]> = ref([])
 
 const selectedCategory: Ref<string | ''> = ref('')
@@ -353,6 +353,18 @@ const cityDropdownOptions = computed(() => {
     return finalCityOptions
 })
 
+const specialtyDropdownOptions = computed(() => {
+    if (!selectedCategory.value) return []
+
+    const specialtiesAreInCategory = specialtiesStore.categoryToSpecialtyMap[selectedCategory.value as SpecialtyCategory]
+
+    const specialtyOptions = specialtiesAreInCategory.map(specialty => ({
+        value: specialty,
+        displayText: specialty
+    }))
+    return specialtyOptions
+})
+
 // Watch statement to prevent prefectures and cities that dont match
 watch(selectedRegion, () => {
     selectedPrefecture.value = ''
@@ -395,6 +407,10 @@ function selectCity(city: string) {
 }
 function selectCategory(category: SpecialtyCategory | '') {
     selectedCategory.value = category
+    selectedSpecialty.value = ''
+}
+function selectSpecialty(specialty: string | '') {
+    selectedSpecialty.value = specialty
 }
 
 // Toggle section visibility
@@ -434,7 +450,7 @@ function createSpecialtyDropdownOptions() {
     })) as DropdownOption[]
 
     // Add the "All" option to the top of the list
-    dropdownOptions.unshift({ displayText: t('searchBar.allSpecialties'), value: '' })
+    // dropdownOptions.unshift({ displayText: t('searchBar.allSpecialties'), value: '' })
 
     specialtyDropdownOptions.value = dropdownOptions
 }

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -14,27 +14,48 @@
                 <p class="w-full bg-primary/20 rounded px-4 py-1 mb-2 text-sm font-medium">
                     {{ t('searchBar.selectSpecialty') }}
                 </p>
-                <select
-                    v-model="selectedSpecialties"
-                    class="w-full px-1 py-1.5 border-2 border-primary/60 rounded-md text-primary-text
-                                    drop-shadow-md bg-primary-bg/10 transition-all"
+                <!-- category -->
+                <div
+                    v-for="category in categoryDropdownOptions"
+                    :key="category.value"
+                    class="border-b border-primary/20"
                 >
-                    <option
-                        value=""
-                        class="text-primary-text-muted hidden"
-                        disabled
-                        selected
+                    <div
+                        class="flex items-center justify-between py-2"
+                        @click="selectCategory(selectedCategory === category.value ? '' : category.value as SpecialtyCategory)"
                     >
-                        {{ t('searchBar.selectSpecialty') }}
-                    </option>
-                    <option
-                        v-for="(specialty) in specialtyDropdownOptions"
-                        :key="specialty.value"
-                        :value="specialty.value"
-                    >
-                        {{ specialty.displayText }}
-                    </option>
-                </select>
+                        <label class="flex items-center gap-3 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                :checked="selectedCategory === category.value"
+                                class="w-4 h-4"
+                            >
+                            <span>{{ category.displayText }}</span>
+                        </label>
+                    </div>
+                    <div v-if="selectedCategory === category.value">
+                        <div
+                            v-for="specialty in specialtyDropdownOptions"
+                            :key="specialty.value"
+                            class="border-b border-primary/20"
+                        >
+                            <div
+                                id="specialty-boxes"
+                                class="flex justify-between py-2"
+                                @click="selectSpecialty()"
+                            >
+                                <label class="flex items-center justify-between gap-3 ml-2">
+                                    <input
+                                        type="checkbox"
+                                        :checked="selectedSpecialty === specialty.value"
+                                        class="w-4 h-4"
+                                    >
+                                    <span>{{ specialty.displayText }}</span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div class="location-filters">
                 <p class="w-full bg-primary/20 rounded px-4 py-1 mb-2 text-sm font-medium">
@@ -237,7 +258,8 @@ import { useSearchResultsStore } from '~/stores/searchResultsStore.js'
 import { useLocationsStore, regionDisplayName, prefectureDisplayName, cityDisplayName } from '~/stores/locationsStore.js'
 import { useSpecialtiesStore } from '~/stores/specialtiesStore.js'
 import { useLocaleStore } from '~/stores/localeStore.js'
-import { type Specialty, Locale, SpecialtyCategory } from '~/typedefs/gqlTypes.js'
+import type { SpecialtyCategory, Specialty } from '~/typedefs/gqlTypes.js'
+import { Locale } from '~/typedefs/gqlTypes.js'
 import { BottomSheetType, useBottomSheetStore } from '~/stores/bottomSheetStore'
 import type { Region, Prefecture, City } from '~/typedefs/locationTypes'
 import { regionsEnum, getPrefecturesByRegion, getCitiesByPrefecture } from '~/typedefs/locationTypes'
@@ -255,8 +277,8 @@ const categoryDropdownOptions: Ref<DropdownOption[]> = ref([])
 const specialtyDropdownOptions: Ref<DropdownOption[]> = ref([])
 const languageDropdownOptions: Ref<DropdownOption[]> = ref([])
 
-const selectedCategories: Ref<SpecialtyCategory | ''> = ref('')
-const selectedSpecialties: Ref<string> = ref('')
+const selectedCategory: Ref<string | ''> = ref('')
+const selectedSpecialty: Ref<string> = ref('')
 const selectedLanguages: Ref<string> = ref(localeStore.activeLocale.code)
 
 // Locations search rework. cities is string for API call
@@ -371,6 +393,9 @@ function selectPrefecture(prefecture: Prefecture | '') {
 function selectCity(city: string) {
     selectedCity.value = city
 }
+function selectCategory(category: SpecialtyCategory | '') {
+    selectedCategory.value = category
+}
 
 // Toggle section visibility
 function togglePrefectureSection(region: Region) {
@@ -447,11 +472,11 @@ async function createLocationDropdownOptions(): Promise<void> {
     locationDropdownOptions.value = newLocationDropdownOptions
 }
 
-watch(selectedSpecialties, () => {
-    // If the selected specialty is empty, clear the selected specialties
-    searchResultsStore.selectedSpecialties = selectedSpecialties.value === ''
+watch(selectedSpecialty, () => {
+    // If the selected specialty is empty, clear the selected specialty
+    searchResultsStore.selectedSpecialties = selectedSpecialty.value === ''
         ? []
-        : [selectedSpecialties.value as Specialty]
+        : [selectedSpecialty.value as Specialty]
 })
 
 watch(selectedLanguages, () => {

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -33,11 +33,12 @@
                             <span>{{ category.displayText }}</span>
                         </label>
                     </div>
+                    <!-- specialty -->
                     <div v-if="selectedCategory === category.value">
                         <div
                             v-for="specialty in specialtyDropdownOptions"
                             :key="specialty.value"
-                            class="border-b border-primary/20"
+                            class="border-b border-primary/20 last:border-b-0"
                         >
                             <div
                                 id="specialty-boxes"
@@ -206,8 +207,8 @@
                         v-for="(language) in languageDropdownOptions"
                         :key="language.value"
                         :value="language.value"
-                        class="flex items-center gap-1.5 bg-primary/20 rounded cursor-pointer text-center px-2 py-1 min-h-[2rem]"
-                        :class="selectedLanguages === language.value ? 'bg-primary/40' : 'bg-primary/20'"
+                        class="flex items-center gap-1.5 rounded cursor-pointer text-center px-2 py-1 min-h-8"
+                        :class="selectedLanguages === language.value ? 'bg-primary/40' : 'bg-primary/10'"
                     >
                         <input
                             type="checkbox"
@@ -444,7 +445,6 @@ function createCategoryDropdownOptions() {
 
     categoryDropdownOptions.value = dropdownOptions
 }
-
 
 async function createLocationDropdownOptions(): Promise<void> {
     // Show an interim loading state while we fetch the locations

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -100,25 +100,21 @@
                             <span> {{ region.displayText }} </span>
                         </label>
                         <!-- dropdown arrow -->
-                        <button
-                            class="p-1 hover:bg-primary-bg/20 rounded"
-                            @click="togglePrefectureSection(region.value)"
+
+                        <svg
+                            class="w-4 h-4 text-primary-text transition-transform duration-200"
+                            :class="{ 'rotate-180': openPrefectureSections[region.value] }"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
                         >
-                            <svg
-                                class="w-4 h-4 text-primary-text transition-transform duration-200"
-                                :class="{ 'rotate-180': openPrefectureSections[region.value] }"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                            >
-                                <path
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    stroke-width="2"
-                                    d="M19 9l-7 7-7-7"
-                                />
-                            </svg>
-                        </button>
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M19 9l-7 7-7-7"
+                            />
+                        </svg>
                     </div>
                     <!-- prefecture dropdown -->
                     <div
@@ -149,25 +145,20 @@
                                     <span> {{ prefecture.displayText }} </span>
                                 </label>
                                 <!-- dropdown arrow -->
-                                <button
-                                    class="p-1 hover:bg-primary-bg/20 rounded"
-                                    @click="toggleCitySection(prefecture.value)"
+                                <svg
+                                    class="w-4 h-4 text-primary-text transition-transform duration-200"
+                                    :class="{ 'rotate-180': openCitySections[prefecture.value] }"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
                                 >
-                                    <svg
-                                        class="w-4 h-4 text-primary-text transition-transform duration-200"
-                                        :class="{ 'rotate-180': openCitySections[prefecture.value] }"
-                                        fill="none"
-                                        viewBox="0 0 24 24"
-                                        stroke="currentColor"
-                                    >
-                                        <path
-                                            stroke-linecap="round"
-                                            stroke-linejoin="round"
-                                            stroke-width="2"
-                                            d="M19 9l-7 7-7-7"
-                                        />
-                                    </svg>
-                                </button>
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        stroke-width="2"
+                                        d="M19 9l-7 7-7-7"
+                                    />
+                                </svg>
                             </div>
                             <!-- city dropdown -->
                             <div
@@ -433,14 +424,6 @@ function selectCategory(category: SpecialtyCategory | '') {
 }
 function selectSpecialty(specialty: string | '') {
     selectedSpecialty.value = specialty
-}
-
-// Toggle section visibility
-function togglePrefectureSection(region: Region) {
-    openPrefectureSections.value[region] = !openPrefectureSections.value[region]
-}
-function toggleCitySection(prefecture: Prefecture) {
-    openCitySections.value[prefecture] = !openCitySections.value[prefecture]
 }
 
 function createLanguageDropdownOptions() {

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -11,6 +11,9 @@
         >
             <!-- Specialty dropdown -->
             <div class="search-specialty col-span-1 w-full py-4">
+                <p class="w-full bg-primary/20 rounded px-4 py-1 mb-2 text-sm font-medium">
+                    {{ t('searchBar.selectSpecialty') }}
+                </p>
                 <select
                     v-model="selectedSpecialties"
                     class="w-full px-1 py-1.5 border-2 border-primary/60 rounded-md text-primary-text

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Filters panel -->
     <div
-        class="flex flex-col w-full landscape:h-full portrait:max-h-[70svh] pt-6"
+        class="flex flex-col w-full landscape:h-full portrait:max-h-[70svh]"
         data-testid="filters-panel-container"
     >
         <!-- Search fields -->

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -32,25 +32,20 @@
                             >
                             <span>{{ category.displayText }}</span>
                         </label>
-                        <button
-                            class="p-1 hover:bg-primary-bg/20 rounded"
-                            @click="toggleSpecialtySection(category.value)"
+                        <svg
+                            class="w-4 h-4 text-primary-text transition-transform duration-200"
+                            :class="{ 'rotate-180': openSpecialtySection[category.value] }"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
                         >
-                            <svg
-                                class="w-4 h-4 text-primary-text transition-transform duration-200"
-                                :class="{ 'rotate-180': openSpecialtySection[category.value] }"
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                            >
-                                <path
-                                    stroke-linecap="round"
-                                    stroke-linejoin="round"
-                                    stroke-width="2"
-                                    d="M19 9l-7 7-7-7"
-                                />
-                            </svg>
-                        </button>
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M19 9l-7 7-7-7"
+                            />
+                        </svg>
                     </div>
                     <!-- specialty -->
                     <div v-if="selectedCategory === category.value">
@@ -446,9 +441,6 @@ function togglePrefectureSection(region: Region) {
 }
 function toggleCitySection(prefecture: Prefecture) {
     openCitySections.value[prefecture] = !openCitySections.value[prefecture]
-}
-function toggleSpecialtySection(category: string) {
-    openSpecialtySection.value[category] = !openSpecialtySection.value[category]
 }
 
 function createLanguageDropdownOptions() {

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -356,11 +356,12 @@ const cityDropdownOptions = computed(() => {
 const specialtyDropdownOptions = computed(() => {
     if (!selectedCategory.value) return []
 
-    const specialtiesAreInCategory = specialtiesStore.categoryToSpecialtyMap[selectedCategory.value as SpecialtyCategory]
-
-    const specialtyOptions = specialtiesAreInCategory.map(specialty => ({
+    const specialtiesInCategory = specialtiesStore.categoryToSpecialtyMap[selectedCategory.value as SpecialtyCategory]
+    const specialtiesInCategorySet = new Set(specialtiesInCategory)
+    console.log(specialtiesInCategorySet)
+    const specialtyOptions = specialtiesInCategory.map(specialty => ({
         value: specialty,
-        displayText: specialty
+        displayText: specialty.displayText
     }))
     return specialtyOptions
 })

--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -358,11 +358,17 @@ const specialtyDropdownOptions = computed(() => {
 
     const specialtiesInCategory = specialtiesStore.categoryToSpecialtyMap[selectedCategory.value as SpecialtyCategory]
     const specialtiesInCategorySet = new Set(specialtiesInCategory)
+
     console.log(specialtiesInCategorySet)
-    const specialtyOptions = specialtiesInCategory.map(specialty => ({
-        value: specialty,
-        displayText: specialty.displayText
-    }))
+
+    const specialtyOptions = specialtiesStore.specialtyDisplayOptions
+        .filter(specialty => specialtiesInCategorySet.has(specialty.code))
+        .map(selection => ({
+            value: selection.code,
+            displayText: selection.displayText
+        }))
+    console.log(specialtyOptions)
+
     return specialtyOptions
 })
 

--- a/components/SlidingRightPanel.vue
+++ b/components/SlidingRightPanel.vue
@@ -3,32 +3,34 @@
         <div
             v-if="shouldShowPanel"
             class="absolute left-96 inset-y-24 ml-1 bg-primary-bg
-            border-l border-secondary-bg/40 shadow-lg z-10 rounded-lg"
+            border-l border-secondary-bg/40 shadow-lg z-10 rounded-lg flex flex-col"
             :class="[
                 panelWidth,
             ]"
         >
             <!-- Close button -->
-            <button
-                class="absolute top-4 right-4 p-2 hover:bg-secondary-bg/20 rounded-full transition-colors z-10"
-                @click="closePanelHandler"
-            >
-                <svg
-                    class="w-6 h-6 stroke-primary"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width="2"
+            <div class="sticky top-0 z-10 bg-primary-bg flex justify-end p-6 rounded-t-lg">
+                <button
+                    class="absolute top-1 right-4 p-2 hover:bg-secondary-bg/20 rounded-full transition-colors z-10"
+                    @click="closePanelHandler"
                 >
-                    <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d="M6 18L18 6M6 6l12 12"
-                    />
-                </svg>
-            </button>
+                    <svg
+                        class="w-6 h-6 stroke-primary"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke-width="2"
+                    >
+                        <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            d="M6 18L18 6M6 6l12 12"
+                        />
+                    </svg>
+                </button>
+            </div>
 
             <!-- Panel Content -->
-            <div class="h-full overflow-y-auto overflow-x-hidden pt-16 pb-2">
+            <div class="h-full overflow-y-auto overflow-x-hidden pb-2">
                 <!-- Search Result Details -->
                 <div v-if="bottomSheetStore.bottomSheetType === BottomSheetType.SearchResultDetails">
                     <SearchResultDetails />

--- a/components/SlidingRightPanel.vue
+++ b/components/SlidingRightPanel.vue
@@ -11,7 +11,7 @@
             <!-- Close button -->
             <div class="sticky top-0 z-10 bg-primary-bg flex justify-end p-6 rounded-t-lg">
                 <button
-                    class="absolute top-1 right-4 p-2 hover:bg-secondary-bg/20 rounded-full transition-colors z-10"
+                    class="absolute top-1 right-2 p-2 hover:bg-secondary-bg/20 rounded-full transition-colors z-10"
                     @click="closePanelHandler"
                 >
                     <svg


### PR DESCRIPTION
✅ Resolves #1630 

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed

Reworked specialties section to first filter by category, then specialty.
Styled the same as the other parts of the filter panel - continuous dropdowns.
Added sticky banner to top with close button - contents of panel scroll underneath it when panning up.
Refactored existing code - mainly toggle function of dropdown arrows.
Specialties belonging to category are loaded as a Set - higher lookup time/quicker loading.

## 🧪 Testing instructions

Run locally. Search functionality should still be working just fine.

## 📸 Screenshots

- ### Before
<img width="432" height="634" alt="Screenshot 2026-03-25 at 12 17 08" src="https://github.com/user-attachments/assets/f8151674-6765-4b57-9872-a02439ac4a54" />

- ### After
<img width="432" height="634" alt="Screenshot 2026-03-25 at 12 17 28" src="https://github.com/user-attachments/assets/264dabe3-93e2-43d0-b225-121a864c213f" />
