### PR TITLE
style: Moderation Panel: Update, Update & Exit, Reject, and Approve should indicate that they are clickable

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,0 +1,1 @@
+setups.@nuxt/test-utils="3.23.0"

--- a/components/moderation-panel/ModEditHealthcareProfessionalSection.vue
+++ b/components/moderation-panel/ModEditHealthcareProfessionalSection.vue
@@ -142,7 +142,7 @@
                 <h2
                     :id="ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalMedicalInfo"
                     class="mod-healthcare-professional-section
-                     my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
+                    my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
                 >
                     {{ t('modHealthcareProfessionalSection.healthcareProfessionalMedicalInfoHeading') }}
                 </h2>
@@ -253,7 +253,7 @@
                 <h2
                     :id="ModHealthcareProfessionalsLeftNavbarSections.HealthcareProfessionalFacilities"
                     class="mod-healthcare-professional-section
-                 my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
+                    my-3.5 text-start text-primary-text text-2xl font-bold font-sans leading-normal"
                 >
                     {{ t("modHealthcareProfessionalSection.facilities") }}
                 </h2>

--- a/components/moderation-panel/ModEditSubmissionTopbar.vue
+++ b/components/moderation-panel/ModEditSubmissionTopbar.vue
@@ -4,7 +4,7 @@
             <button
                 type="button"
                 data-testid="mod-edit-submission-copy-submission-id"
-                class="flex flex-row w-90 bg-neutral p-2 m-2 border-2 border-slate-400 rounded hover"
+                class="flex flex-row bg-neutral p-2 m-2 border-2 border-slate-400 rounded hover"
                 @click="copySubmissionId"
             >
                 ID: {{ selectedSubmissionId }}
@@ -62,6 +62,11 @@
                 {{
                     t('modEditSubmissionTopNav.approve') }}
             </button>
+            <Button
+                :button-style="'primary'"
+            >
+                Approve
+            </Button>
         </div>
     </div>
 </template>
@@ -71,6 +76,7 @@ import { ref, type Ref } from 'vue'
 import SVGCopyContent from '~/assets/icons/content-copy.svg'
 import SVGSuccessCheckMark from '~/assets/icons/checkmark-square.svg'
 import { useModerationSubmissionsStore } from '~/stores/moderationSubmissionsStore'
+import Button from '~/components/ui-components/ButtonTypes.vue'
 
 const { t } = useI18n()
 

--- a/components/moderation-panel/ModEditSubmissionTopbar.vue
+++ b/components/moderation-panel/ModEditSubmissionTopbar.vue
@@ -22,8 +22,8 @@
                 />
             </button>
         </div>
-        <div class="flex flex-row justify p-2 font-bold ">
-            <button
+        <div class="flex flex-row gap-2 justify p-2 font-bold ">
+            <!-- <button
                 type="button"
                 class="flex justify-center items-center rounded-full bg-secondary-bg border-primary-text-muted
                 border-2 w-28 text-sm mr-2"
@@ -61,11 +61,34 @@
             >
                 {{
                     t('modEditSubmissionTopNav.approve') }}
-            </button>
+            </button> -->
+            <Button
+                :button-style="'primaryOutline'"
+                data-testid="submission-topNav-update"
+                @click="updateWithoutExiting"
+            >
+                {{ t('modEditSubmissionTopNav.update') }}
+            </Button>
+            <Button
+                :button-style="'primaryOutline'"
+                data-testid="submission-topNav-updateAndExit"
+                @click="updateAndExit"
+            >
+                {{ t('modEditSubmissionTopNav.updateAndExit') }}
+            </Button>
+            <Button
+                :button-style="'destructive'"
+                data-testid="mod-edit-submission-reject-button"
+                @click="showRejectionConfirmation"
+            >
+                {{ t('modEditSubmissionTopNav.reject') }}
+            </Button>
             <Button
                 :button-style="'primary'"
+                data-testid="submission-topNav-updateAndExit"
+                @click="acceptSubmission"
             >
-                Approve
+                {{ t('modEditSubmissionTopNav.approve') }}
             </Button>
         </div>
     </div>

--- a/components/ui-components/ButtonTypes.vue
+++ b/components/ui-components/ButtonTypes.vue
@@ -1,0 +1,24 @@
+<template>
+    <div :class="buttonTypes[buttonStyle]">
+        <slot />
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    buttonStyle: {
+        type: String
+    }
+})
+
+const buttonStyle = props.buttonStyle
+
+// console.log(props.button)
+
+const buttonTypes = {
+    primary: 'bg-primary px-6 py-3 flex justify-center items-center rounded-full cursor-pointer',
+    secondary: 'bg-secondary p-2 flex justify-center items-center rounded-full cursor-pointer'
+}
+
+console.log(buttonTypes[buttonStyle])
+</script>

--- a/components/ui-components/ButtonTypes.vue
+++ b/components/ui-components/ButtonTypes.vue
@@ -13,12 +13,9 @@ const props = defineProps({
 
 const buttonStyle = props.buttonStyle
 
-// console.log(props.button)
-
 const buttonTypes = {
-    primary: 'bg-primary px-6 py-3 flex justify-center items-center rounded-full cursor-pointer',
-    secondary: 'bg-secondary p-2 flex justify-center items-center rounded-full cursor-pointer'
+    primary: 'bg-primary hover:bg-primary-hover active:opacity-50 text-white inline w-fit h-fit px-6 py-3 flex justify-center items-center rounded-full cursor-pointer',
+    primaryOutline: 'border-primary hover:bg-primary-hover hover:text-white active:opacity-50 text-primary border-2 w-fit h-fit px-6 py-3 flex justify-center items-center rounded-full cursor-pointer',
+    destructive: 'bg-error hover:opacity-50 w-fit h-fit px-6 py-3 text-white flex justify-center items-center rounded-full cursor-pointer'
 }
-
-console.log(buttonTypes[buttonStyle])
 </script>

--- a/components/ui-components/ButtonTypes.vue
+++ b/components/ui-components/ButtonTypes.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :class="buttonTypes[buttonStyle]">
+    <div :class="`${buttonTypes[props.buttonStyle]} ${baseStyles}`">
         <slot />
     </div>
 </template>
@@ -7,15 +7,16 @@
 <script setup>
 const props = defineProps({
     buttonStyle: {
-        type: String
+        type: String,
+        required: true
     }
 })
 
-const buttonStyle = props.buttonStyle
+const baseStyles = 'inline w-fit h-fit px-6 py-3 flex justify-center items-center rounded-full cursor-pointer'
 
 const buttonTypes = {
-    primary: 'bg-primary hover:bg-primary-hover active:opacity-50 text-white inline w-fit h-fit px-6 py-3 flex justify-center items-center rounded-full cursor-pointer',
-    primaryOutline: 'border-primary hover:bg-primary-hover hover:text-white active:opacity-50 text-primary border-2 w-fit h-fit px-6 py-3 flex justify-center items-center rounded-full cursor-pointer',
-    destructive: 'bg-error hover:opacity-50 w-fit h-fit px-6 py-3 text-white flex justify-center items-center rounded-full cursor-pointer'
+    primary: 'bg-primary hover:bg-primary-hover active:opacity-50 text-white',
+    primaryOutline: 'border-primary hover:bg-primary-hover hover:text-white active:opacity-50 text-primary border-2',
+    destructive: 'bg-error hover:opacity-50 active:opacity-75 text-white'
 }
 </script>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,23 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import { defineVitestProject } from '@nuxt/test-utils/config'
+
+export default defineConfig({
+  test: {
+    projects: [
+      await defineVitestProject({
+        test: {
+          name: 'nuxt',
+          include: ['test/nuxt/*.{test,spec}.ts'],
+          environment: 'nuxt',
+          environmentOptions: {
+            nuxt: {
+              rootDir: fileURLToPath(new URL('.', import.meta.url)),
+              domEnvironment: 'happy-dom',
+            },
+          },
+        },
+      }),
+    ],
+  },
+})


### PR DESCRIPTION
✅ Resolves #1700

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed
Moderation buttons are now a component with three options: 
- primary
- destructive
- primaryOutline

This simplifies button selection to predetermined styles to maintain consistency across the site. It also adds hover states and active states as well as the cursor-pointer style to indicate a button is clickable.

## 🧪 Testing instructions

## 📸 Screenshots

- ### Before

<img width="992" height="170" alt="Image" src="https://github.com/user-attachments/assets/f6e64751-2721-4d13-80cd-1e43814c9915" />

- ### After

<img width="1028" height="138" alt="image" src="https://github.com/user-attachments/assets/941d030b-e096-4e0f-9e4b-a9235d1acb34" />
