### PR TITLE
fix: Prevent submission page from showing success message when submission fails #1428

### DIFF
--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -251,8 +251,8 @@ async function submitNewSubmission(e: Event) {
 
     const response = await submissionStore.createNewSubmission(newSubmission)
     // This is used in the component and not graphQL call as it is user messaging and needs the mounted toast library
-    if (response?.errors?.length) {
-        handleServerErrorMessaging(response.errors, toast, t)
+    if (response?.hasErrors || response?.errors?.length) {
+        handleServerErrorMessaging(response.errors ?? [], toast, t)
         return
     }
 

--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -209,7 +209,7 @@ const validateFields = () => {
     isValidInput.primarySpokeLangauge.value = validations.validateFirstSpokenLanguage(selectLanguage1.value)
     validationCheckedPreviously.secondarySpokenLanguage.value = true
     isValidInput.secondarySpokenLanguage.value = selectLanguage2.value
-        ? validations.validateUserSubmittedLastName(selectLanguage2.value)
+        ? validations.validateSecondSpokenLanguage(selectLanguage2.value)
         : true
 
     if (

--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -219,14 +219,17 @@ const validateFields = () => {
         || !isValidInput.primarySpokeLangauge.value
         || !isValidInput.secondarySpokenLanguage.value
     ) {
-        return
+        return false
     }
+
+    return true
 }
 
 async function submitNewSubmission(e: Event) {
     e.preventDefault()
 
-    validateFields()
+    const isValid = validateFields()
+    if (!isValid) return
 
     const spokenLanguages: Locale[] = []
 

--- a/composables/handleServerErrorMessaging.ts
+++ b/composables/handleServerErrorMessaging.ts
@@ -5,6 +5,10 @@ export function handleServerErrorMessaging(
     serverErrors: ServerError[], toast: ToastInterface,
     t: (translatableString: string) => string | undefined
 ) {
+    if (serverErrors.length === 0) {
+        toast.error(t('serverErrorMessages.genericErrorMessage') ?? 'An error occurred')
+        return
+    }
     serverErrors.forEach(error => {
         if (t(`serverErrorMessages.${error.code}`)) {
             toast.error((t(`serverErrorMessages.${error.code}`)))


### PR DESCRIPTION
fix: Prevent submission page from showing success message when submission fails #1428

✅ Resolves #[1428]

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed

- Added return boolean from validateFields and check result before submitting
- Added hasErrors check to catch network-level failures in submitNewSubmission
- Added fallback generic error toast in handleServerErrorMessaging for empty error arrays

## 🧪 Testing instructions

- Run find a doc server on local.
- Run find a doc web on local. (yarn dev:localserver)
- Navigate to submission screen within UI.
- Stop find a doc server.
- Enter required information and click submit.

Expected result: Error will indicate to try again

Previous Behavior: User is able to submit and receive success with invalid/missing details.

Updated Behavior: User is required to enter valid information for the fields mentioned below to proceed.

1. Google Maps URL
2. Healthcare Professional Name
3. Spoken Language 1

<img width="1501" height="1174" alt="image" src="https://github.com/user-attachments/assets/a66319b9-58ab-48dd-9ca5-db77b0705c7e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Form validation now returns explicit success/failure and prevents submission when invalid.
  * Corrected secondary spoken-language validation to use the proper check.
  * Broadened server error detection so additional error conditions are surfaced.
  * Added fallback generic error message when server errors are empty to ensure user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->