### PR TITLE
fix: form validation and error placement

### DIFF
--- a/components/SubmissionForm.vue
+++ b/components/SubmissionForm.vue
@@ -31,7 +31,7 @@
                 :placeholder="t('submitPage.location')"
                 @blur="initialValidationCheck(location, 'googleMaps')"
             >
-            <div class="google-maps-validation-container flex text-error text-xs font-sans h-3 mt-1 mb-3">
+            <div class="google-maps-validation-container flex text-error text-xs font-sans h-3 mt-1 mb-4">
                 <span
                     v-show="!isValidInput.googleMapsUrl.value"
                     class="text-error text-xs font-sans"
@@ -66,7 +66,7 @@
                     @blur="initialValidationCheck(firstName, 'firstName')"
                 >
             </div>
-            <div class="name-validation-container flex text-error text-xs font-sans h-3 mt-1 mb-3">
+            <div class="name-validation-container flex text-error text-xs font-sans h-3 mt-1 mb-4">
                 <div class="last-name-validation-container w-44 mr-5">
                     <span
                         v-show="!isValidInput.lastName.value"
@@ -85,17 +85,11 @@
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
             >{{ t('submitPage.spokenLanguage1') }}</span>
-            <p
-                v-show="!isValidInput.primarySpokeLangauge.value"
-                role="alert"
-                class="text-error text-xs font-sans"
-            >
-                {{ t('submitPage.spokenLanguageValidation') }}
-            </p>
+
             <select
                 v-model="selectLanguage1"
                 data-testid="submit-select-language1"
-                class="mb-5 px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
+                class=" px-3 py-3.5 w-96 h-12 bg-secondary-bg rounded-lg border border-primary-text-muted
                         text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                 :placeholder="t('submitPage.selectLanguage1')"
                 @change="initialValidationCheck(selectLanguage1, 'primaryLanguage')"
@@ -108,19 +102,23 @@
                     {{ locale.displayText }}
                 </option>
             </select>
+            <div class="primary-language-validation-container flex text-error text-xs font-sans h-3 mt-1 mb-4">
+                <span
+                    v-show="!isValidInput.primarySpokeLangauge.value"
+                    role="alert"
+                    class="text-error text-xs font-sans"
+                >
+                    {{ t('submitPage.spokenLanguageValidation') }}
+                </span>
+            </div>
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
             >{{ t('submitPage.spokenLanguage2') + " (" + t('submitPage.optional') + ")" }}</span>
-            <p
-                v-show="!isValidInput.secondarySpokenLanguage.value"
-                class="text-error text-xs font-sans"
-            >
-                {{ t('submitPage.invalidOption') }}
-            </p>
+
             <select
                 v-model="selectLanguage2"
                 data-testid="submit-select-language2"
-                class="mb-5 px-3 py-3.5 w-96 h-12 bg-primary-text-inverted rounded-lg border border-primary-text-muted
+                class=" px-3 py-3.5 w-96 h-12 bg-primary-text-inverted rounded-lg border border-primary-text-muted
                         text-primary-text text-sm font-normal font-sans placeholder-primary-text-muted"
                 :placeholder="t('submitPage.selectLanguage2')"
                 @change="selectLanguage2 ? initialValidationCheck(selectLanguage2, 'secondaryLanguage') : null"
@@ -133,6 +131,14 @@
                     {{ locale.displayText }}
                 </option>
             </select>
+            <div class="secondary-language-validation-container flex text-error text-xs font-sans h-3 mt-1 mb-4">
+                <span
+                    v-show="!isValidInput.secondarySpokenLanguage.value"
+                    class="text-error text-xs font-sans"
+                >
+                    {{ t('submitPage.invalidOption') }}
+                </span>
+            </div>
             <span
                 class="mb-2 text-primary-text text-sm font-normal font-sans"
             >{{ t('submitPage.otherNotes') + " (" + t('submitPage.optional') + ")" }}</span>
@@ -194,7 +200,7 @@ const isValidInput = {
     googleMapsUrl: ref(true),
     lastName: ref(true),
     firstName: ref(true),
-    primarySpokeLangauge: ref(false),
+    primarySpokeLangauge: ref(true),
     secondarySpokenLanguage: ref(true)
 }
 

--- a/tests/e2e/submit.spec.ts
+++ b/tests/e2e/submit.spec.ts
@@ -47,6 +47,8 @@ test.describe('Submit page', () => {
         })
 
         test('requires Spoken Language 1 to be selected', async ({ page }) => {
+            await expect(page.getByText(enUS.submitPage.spokenLanguageValidation)).toBeHidden()
+            await page.getByRole('button', { name: enUS.submitPage.submitButton }).click()
             await expect(page.getByText(enUS.submitPage.spokenLanguageValidation)).toBeVisible()
             await page.getByRole('combobox').first().selectOption('ja_JP')
             await expect(page.getByText(enUS.submitPage.spokenLanguageValidation)).toBeHidden()


### PR DESCRIPTION
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed
I noticed that the validation message was being displayed by default on page load and was above the drop-down while others were below. Amended on both primary and secondary languages and made some small spacing changes so the errors aren't too close to next headers.

## 🧪 Testing instructions
-Run yarn dev:localserver
-Click on "Add a doctor"
-Observe error is displayed below drop-down only if user try's to submit empty.

Expected result: Error should not be displayed on load and should be below drop-down if triggered.

## 📸 Screenshots

- ### Before
 #### First load of screen
 
<img width="2263" height="1352" alt="image" src="https://github.com/user-attachments/assets/8699ab36-6b50-43aa-8f02-d062ef984497" />

 #### After clicking submit 
<img width="2263" height="1346" alt="image" src="https://github.com/user-attachments/assets/884fc5b7-03f4-4749-884e-3d4c3a139cb1" />

- ### After
 #### First load of screen
<img width="2278" height="1335" alt="image" src="https://github.com/user-attachments/assets/014a65e6-d76a-4f39-b255-82d57ca50347" />

 #### After clicking submit 
<img width="2283" height="1334" alt="image" src="https://github.com/user-attachments/assets/a4a8a68b-51aa-45d7-b932-b4c1de90810d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted vertical spacing of validation containers and restructured how language validation messages are positioned and displayed in the submission form.

* **Bug Fixes**
  * Corrected initial validation state so the primary language error is not shown before user interaction.

* **Tests**
  * Updated end-to-end test to assert the spoken-language validation message is initially hidden and appears after submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->