### PR TITLE
fix: valid google URL not being accepted

### DIFF
--- a/tests/e2e/submit.spec.ts
+++ b/tests/e2e/submit.spec.ts
@@ -46,6 +46,13 @@ test.describe('Submit page', () => {
             await expect(page.getByText(enUS.submitPage.googleMapsValidation)).toBeVisible()
         })
 
+        test('rejects a Google Maps URL with no location path', async ({ page }) => {
+            const urlInput = page.getByPlaceholder(enUS.submitPage.location)
+            await urlInput.fill('https://maps.google.com')
+            await urlInput.blur()
+            await expect(page.getByText(enUS.submitPage.googleMapsValidation)).toBeVisible()
+        })
+
         test('requires Spoken Language 1 to be selected', async ({ page }) => {
             await expect(page.getByText(enUS.submitPage.spokenLanguageValidation)).toBeVisible()
             await page.getByRole('combobox').first().selectOption('ja_JP')

--- a/utils/formValidations.ts
+++ b/utils/formValidations.ts
@@ -218,11 +218,8 @@ export function validateUserSubmittedFirstName(name: string): boolean {
 
 export function validateGoogleMapsUrlInput(url: string): boolean {
     url = url.trim()
-    if (url.startsWith('https://www.google.com/maps') || url.startsWith('https://www.google.co.jp/maps')
-      || url.startsWith('https://maps.google.com/')) {
-        return true
-    }
-    return false
+    const googleMapsRegex = /^https:\/\/(www\.)?(google\.com\/maps|google\.co\.jp\/maps|maps\.google\.com|maps\.app\.goo\.gl)\//
+    return googleMapsRegex.test(url)
 }
 
 export function validateFirstSpokenLanguage(localeCode: string): boolean {


### PR DESCRIPTION
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed
Updated the form validation for google URL to accept google maps short format.

## 🧪 Testing instructions
-Run yarn dev:localserver
-Click on "Add a doctor"
-Enter short form google maps link

Expected results: Short link will not trigger validation

## 📸 Screenshots

- ### Before
<img width="1201" height="1130" alt="image" src="https://github.com/user-attachments/assets/02f5362e-e18b-43b0-ae4c-8d67d476e428" />

- ### After
<img width="1130" height="1112" alt="image" src="https://github.com/user-attachments/assets/8adfc7c1-431b-430a-bfa2-347a09385730" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation logic for Google Maps URLs to properly recognize and validate additional URL formats and patterns, providing more reliable input handling across different submission scenarios.

* **Tests**
  * Expanded test coverage for Google Maps URL validation to include edge cases and various URL format variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->