### PR TITLE
fix(i18n): whitelist dynamic unsavedChanges keys and add unit tests #1703

### DIFF
--- a/i18n/clean-translations.spec.js
+++ b/i18n/clean-translations.spec.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { shouldPruneKey } from './cleanUnusedLocaleKeys.js'
+
+describe('Translation Cleanup Script - Key Pruning Logic', () => {
+    // ... leave the rest of the test cases exactly as they are ...
+    it('should prune a key if it is not used in the codebase', () => {
+        const mockUsedKeys = new Set(['nav.home', 'buttons.save'])
+        const result = shouldPruneKey('abandoned.feature.title', mockUsedKeys)
+        expect(result).toBe(true)
+    })
+
+    it('should NOT prune a standard key if it is explicitly used in the codebase', () => {
+        const mockUsedKeys = new Set(['nav.home', 'buttons.save'])
+        const result = shouldPruneKey('nav.home', mockUsedKeys)
+        expect(result).toBe(false)
+    })
+
+    it('should protect dynamic unsavedChanges keys even if they are missing from the static checklist', () => {
+        const mockUsedKeys = new Set(['nav.home'])
+
+        const testKeys = [
+            'unsavedChanges.create.title',
+            'unsavedChanges.create.message',
+            'unsavedChanges.update.title',
+            'unsavedChanges.update.message'
+        ]
+
+        testKeys.forEach(key => {
+            const result = shouldPruneKey(key, mockUsedKeys)
+            expect(result).toBe(false)
+        })
+    })
+})

--- a/i18n/cleanUnusedLocaleKeys.js
+++ b/i18n/cleanUnusedLocaleKeys.js
@@ -118,18 +118,25 @@ function removeKeysFromJson(obj, keysToRemove) {
     }, obj)
 }
 
+export function shouldPruneKey(key, usedKeysSet) {
+    const isUnsavedChangesKey = /^unsavedChanges\.(create|update)\./.test(key)
+    if (isUnsavedChangesKey) {
+        return false
+    }
+    return !usedKeysSet.has(key)
+}
+
 const run = async () => {
     const usedKeys = await extractUsedTranslationKeys()
 
     const unusedKeysByLocale = translationFilePaths.reduce((acc, filePath) => {
         const content = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
         const allKeys = extractAllKeysFromJson(content)
-        const unusedKeys = allKeys.filter(key => !usedKeys.has(key))
+
+        const unusedKeys = allKeys.filter(key => shouldPruneKey(key, usedKeys))
 
         if (unusedKeys.length > 0) {
-            // Clean JSON
             const cleanedContent = removeKeysFromJson(content, unusedKeys)
-            // Rewrite file
             fs.writeFileSync(filePath, JSON.stringify(cleanedContent, null, 2), 'utf-8')
             acc[path.basename(filePath)] = unusedKeys
         }
@@ -154,4 +161,3 @@ const run = async () => {
 }
 
 run()
-


### PR DESCRIPTION
Resolves #1703

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed

- **Fixed Static Analysis Blindness:** Resolved an issue where the translation cleanup script was accidentally purging valid translation keys (`unsavedChanges.create.title`, `unsavedChanges.update.message`, etc.). This occurred because the keys are constructed dynamically at runtime using template string interpolation (e.g., `` `unsavedChanges.${mode}.title` ``), which a raw text-search could not match.
- **Architectural Refactor for Testability:** Decoupled the key-evaluation loop from the destructive I/O core in `i18n/cleanUnusedLocaleKeys.js`. Extracted the logic into a pure, exported utility function named `shouldPruneKey`.
- **Regex Shield Integration:** Implemented a regex pattern (`/^unsavedChanges\.(create|update)\./`) inside `shouldPruneKey` to explicitly whitelist and protect these dynamic nested properties from deletion.
- **Comprehensive Unit Testing Suite:** Created a new unit test file `i18n/clean-translations.spec.js` leveraging **Vitest** to programmatically assert and lock down key preservation behavior.

## 🧪 Testing instructions

1. Run the local translation cleanup script to verify it completely protects the keys across all locale files:
   ```bash
   node i18n/cleanUnusedLocaleKeys.js


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating translation cleanup logic and key preservation behaviors.

* **Improvements**
  * Enhanced translation key cleanup to intelligently preserve critical dynamic keys while removing unused translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ourjapanlife/findadoc-web/pull/1742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->