### PR TITLE
fix(i18n): add missing searchBar.resultsFound translations

### DIFF
--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -112,7 +112,8 @@
     "allLocations": "所有地点",
     "allSpecialties": "所有专科",
     "search": "搜索",
-    "searchAndFilterDoctors": "搜索和筛选医生"
+    "searchAndFilterDoctors": "搜索和筛选医生",
+    "resultsFound": "无结果 | 1 条结果 | {n} 条结果"
   },
   "searchResultsList": {
     "loadMore": "加载更多",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -112,7 +112,8 @@
     "search": "Suchen",
     "allLocations": "All Locations",
     "allSpecialties": "All Specialties",
-    "searchAndFilterDoctors": "Ärzte suchen und filtern"
+    "searchAndFilterDoctors": "Ärzte suchen und filtern",
+    "resultsFound": "Keine Ergebnisse | 1 Ergebnis gefunden | {n} Ergebnisse gefunden"
   },
   "searchResultsList": {
     "loadMore": "Mehr laden",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -115,7 +115,8 @@
     "allLocations": "All Locations",
     "allSpecialties": "All Specialties",
     "search": "Search",
-    "searchAndFilterDoctors": "Search and filter doctors"
+    "searchAndFilterDoctors": "Search and filter doctors",
+    "resultsFound": "No results | 1 result found | {n} results found"
   },
   "searchResultsList": {
     "loadMore": "Load More",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -112,7 +112,8 @@
     "allLocations": "Tous les lieux",
     "allSpecialties": "Toutes les spécialités",
     "search": "Rechercher",
-    "searchAndFilterDoctors": "Rechercher et filtrer les médecins"
+    "searchAndFilterDoctors": "Rechercher et filtrer les médecins",
+    "resultsFound": "Aucun résultat | 1 résultat trouvé | {n} résultats trouvés"
   },
   "searchResultsList": {
     "loadMore": "Charger plus",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -116,7 +116,8 @@
     "allLocations": "Tutte le località",
     "allSpecialties": "Tutte le specialità",
     "search": "Cerca",
-    "searchAndFilterDoctors": "Cerca e filtra i medici"
+    "searchAndFilterDoctors": "Cerca e filtra i medici",
+    "resultsFound": "Nessun risultato | 1 risultato trovato | {n} risultati trovati"
   },
   "searchResultsList": {
     "loadMore": "Carica altro",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -112,7 +112,8 @@
     "allLocations": "すべての場所",
     "allSpecialties": "すべての専門分野",
     "search": "検索",
-    "searchAndFilterDoctors": "医師を検索・フィルター"
+    "searchAndFilterDoctors": "医師を検索・フィルター",
+    "resultsFound": "結果なし | 1件の結果 | {n}件の結果"
   },
   "searchResultsList": {
     "loadMore": "さらに読み込む",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -112,7 +112,8 @@
     "allLocations": "Todos os locais",
     "allSpecialties": "Todas as especialidades",
     "search": "Procurar",
-    "searchAndFilterDoctors": "Pesquisar e filtrar médicos"
+    "searchAndFilterDoctors": "Pesquisar e filtrar médicos",
+    "resultsFound": "Nenhum resultado | 1 resultado encontrado | {n} resultados encontrados"
   },
   "searchResultsList": {
     "loadMore": "Carregar mais",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -112,7 +112,8 @@
     "allLocations": "Все места",
     "allSpecialties": "Все специальности",
     "search": "Поиск",
-    "searchAndFilterDoctors": "Поиск и фильтрация врачей"
+    "searchAndFilterDoctors": "Поиск и фильтрация врачей",
+    "resultsFound": "Ничего не найдено | Найден 1 результат | Найдено {n} результатов"
   },
   "searchResultsList": {
     "loadMore": "Загрузить еще",

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -112,7 +112,8 @@
     "allLocations": "Lahat ng Lokasyon",
     "allSpecialties": "Lahat ng Espesyalidad",
     "search": "Maghanap",
-    "searchAndFilterDoctors": "Maghanap at mag-filter ng mga doktor"
+    "searchAndFilterDoctors": "Maghanap at mag-filter ng mga doktor",
+    "resultsFound": "Walang resulta | 1 resulta | {n} resulta"
   },
   "searchResultsList": {
     "loadMore": "โหลดเพิ่มเติม",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -112,7 +112,8 @@
     "allLocations": "Tất cả địa điểm",
     "allSpecialties": "Tất cả chuyên khoa",
     "search": "Tìm kiếm",
-    "searchAndFilterDoctors": "Tìm kiếm và lọc bác sĩ"
+    "searchAndFilterDoctors": "Tìm kiếm và lọc bác sĩ",
+    "resultsFound": "Không có kết quả | 1 kết quả | {n} kết quả"
   },
   "searchResultsList": {
     "loadMore": "Tải thêm",


### PR DESCRIPTION
The search results count in SearchBar referenced a locale key that was never defined in any language file.

✅ Resolves #[Issue number]

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed

## 🧪 Testing instructions

## 📸 Screenshots

- ### Before
- ### After


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Added search results counter translations across all supported languages (English, French, German, Italian, Chinese, Japanese, Portuguese, Russian, Tagalog, and Vietnamese) with proper pluralization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->