### PR TITLE
refactor: more ui cleanliness

### DIFF
--- a/components/HamburgerMenu.vue
+++ b/components/HamburgerMenu.vue
@@ -89,7 +89,10 @@
                             class="flex flex-col gap-6 px-4 mt-6 mb-1"
                         >
                             <!-- Home Link -->
-                            <NuxtLink to="/">
+                            <NuxtLink
+                                to="/"
+                                @click="handleHomeClick"
+                            >
                                 <div
                                     class="text-primary"
                                     @click="closeMenu()"
@@ -321,8 +324,14 @@ import SVGUserIcon from '~/assets/icons/user-icon.svg'
 import SVGSignOutIcon from '~/assets/icons/sign-out-icon.svg'
 import { useAuthStore } from '~/stores/authStore'
 import { buildLoginRoute, resolveAuthReturnPath } from '~/utils/auth0Config'
+import { useModerationScreenStore } from '~/stores/moderationScreenStore'
+import { useModerationSubmissionUnsavedStore } from '~/stores/moderationSubmissionUnsavedStore'
+import { isMyPageFormRoute, leaveToAppHome } from '~/utils/moderationUtils'
 
 const authStore = useAuthStore()
+const moderationScreenStore = useModerationScreenStore()
+const moderationSubmissionUnsavedStore = useModerationSubmissionUnsavedStore()
+const modalStore = useModalStore()
 const toast = useToast()
 const router = useRouter()
 const route = useRoute()
@@ -339,6 +348,18 @@ function openMenu() {
 
 function closeMenu() {
     isMenuOpen.value = false
+}
+
+function handleHomeClick(event: MouseEvent) {
+    closeMenu()
+
+    if (!isMyPageFormRoute(route.path)) {
+        return
+    }
+
+    event.preventDefault()
+    moderationSubmissionUnsavedStore.runLeaveOr(() =>
+        leaveToAppHome(router, moderationScreenStore, modalStore))
 }
 
 async function logout() {

--- a/components/MyPageAccessPanel.vue
+++ b/components/MyPageAccessPanel.vue
@@ -264,7 +264,7 @@ function sidebarNavLinkClass(page: NavPage): string {
 
     const currentView = typeof route.query.view === 'string' ? route.query.view : 'settings'
     const isActive = route.path === targetPath
-        && (page.listView ? currentView === targetView : currentView === 'settings' || currentView === '')
+      && (page.listView ? currentView === targetView : currentView === 'settings' || currentView === '')
 
     return isActive
         ? `${base} border-primary text-primary-text bg-accent-bg/20`
@@ -273,6 +273,9 @@ function sidebarNavLinkClass(page: NavPage): string {
 
 async function loadIfLoggedIn(): Promise<void> {
     if (!authStore.isLoggedIn || authStore.isLoadingAuth) {
+        return
+    }
+    if (accessStore.isLoaded) {
         return
     }
     await accessStore.fetchAccess()

--- a/components/MyPageAccessPanel.vue
+++ b/components/MyPageAccessPanel.vue
@@ -67,8 +67,7 @@
                         >
                             <NuxtLink
                                 :to="pageRoute(page)"
-                                class="text-primary-text hover:text-primary block py-1.5 px-2 rounded-md
-                                hover:bg-accent-bg/30 text-base font-semibold underline underline-offset-2"
+                                :class="sidebarNavLinkClass(page)"
                                 :data-testid="`access-page-link-${page.id}`"
                                 @click="onPageClick(page.listView)"
                             >
@@ -86,8 +85,7 @@
                         >
                             <NuxtLink
                                 :to="pageRoute(page)"
-                                class="text-primary-text hover:text-primary block py-1.5 px-2 rounded-md
-                                hover:bg-accent-bg/30 text-base font-semibold underline underline-offset-2"
+                                :class="sidebarNavLinkClass(page)"
                                 :data-testid="`access-page-link-${page.id}-mobile`"
                                 @click="onPageClick(page.listView)"
                             >
@@ -123,8 +121,7 @@
                         >
                             <NuxtLink
                                 :to="pageRoute(page)"
-                                class="text-primary-text hover:text-primary block py-1.5 px-2 rounded-md
-                                hover:bg-accent-bg/30 text-base font-semibold underline underline-offset-2"
+                                :class="sidebarNavLinkClass(page)"
                                 :data-testid="`access-page-link-${page.id}`"
                                 @click="onPageClick(page.listView)"
                             >
@@ -142,8 +139,7 @@
                         >
                             <NuxtLink
                                 :to="pageRoute(page)"
-                                class="text-primary-text hover:text-primary block py-1.5 px-2 rounded-md
-                                hover:bg-accent-bg/30 text-base font-semibold underline underline-offset-2"
+                                :class="sidebarNavLinkClass(page)"
                                 :data-testid="`access-page-link-${page.id}-mobile`"
                                 @click="onPageClick(page.listView)"
                             >
@@ -166,6 +162,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { useAuthStore } from '~/stores/authStore'
 import { useCurrentUserAccessStore } from '~/stores/currentUserAccessStore'
 import {
@@ -184,6 +181,7 @@ interface NavPage {
 }
 
 const { t } = useI18n()
+const route = useRoute()
 const authStore = useAuthStore()
 const accessStore = useCurrentUserAccessStore()
 const moderationSubmissionsStore = useModerationSubmissionsStore()
@@ -254,6 +252,23 @@ function pageRoute(page: NavPage): string | { path: string, query: { view: strin
         path: page.route,
         query: { view }
     }
+}
+
+function sidebarNavLinkClass(page: NavPage): string {
+    const base = 'block py-2 px-3 text-sm font-medium transition-colors border-l-2 rounded-r-md'
+    const resolved = pageRoute(page)
+    const targetPath = typeof resolved === 'string' ? resolved : resolved.path
+    const targetView = typeof resolved === 'string'
+        ? 'settings'
+        : resolved.query.view
+
+    const currentView = typeof route.query.view === 'string' ? route.query.view : 'settings'
+    const isActive = route.path === targetPath
+        && (page.listView ? currentView === targetView : currentView === 'settings' || currentView === '')
+
+    return isActive
+        ? `${base} border-primary text-primary-text bg-accent-bg/20`
+        : `${base} border-transparent text-primary-text-muted hover:text-primary-text hover:bg-accent-bg/10`
 }
 
 async function loadIfLoggedIn(): Promise<void> {

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -16,13 +16,12 @@
                 <NuxtLink
                     to="/"
                     :aria-label="t('common.siteName')"
-                    @click="handleMobileLogoClick"
+                    @click="handleHomeClick"
                 >
                     <SVGSiteLogo
                         role="img"
                         :aria-label="t('common.siteName')"
                         class="mt-1 mr-1 w-10 h-10 shrink-0 align-middle fill-primary group-hover:fill-primary-hover"
-                        @click="toggleLogoText()"
                     />
                 </NuxtLink>
                 <Transition
@@ -63,6 +62,7 @@
                         class="flex"
                         to="/"
                         :aria-label="t('common.siteName')"
+                        @click="handleHomeClick"
                     >
                         <SVGSiteLogo
                             role="img"
@@ -102,6 +102,7 @@
                     <NuxtLink
                         to="/"
                         :class="navLinkClass('/')"
+                        @click="handleHomeClick"
                     >{{ t('topNav.home') }}
                     </NuxtLink>
                     <NuxtLink
@@ -212,9 +213,12 @@ import SVGAccordionArrow from '~/assets/icons/accordion-arrow.svg'
 import SVGUserIcon from '~/assets/icons/user-icon.svg'
 import SVGSignOutIcon from '~/assets/icons/sign-out-icon.svg'
 import { useAuthStore } from '~/stores/authStore'
+import { useModerationScreenStore } from '~/stores/moderationScreenStore'
+import { useModerationSubmissionUnsavedStore } from '~/stores/moderationSubmissionUnsavedStore'
 import { useScreenOrientation } from '~/composables/useScreenOrientation'
 import { vCloseOnOutsideClick } from '~/composables/closeOnOutsideClick'
 import { buildLoginRoute, resolveAuthReturnPath } from '~/utils/auth0Config'
+import { isMyPageFormRoute, leaveToAppHome } from '~/utils/moderationUtils'
 
 const { t } = useI18n()
 const toast = useToast()
@@ -226,6 +230,9 @@ const loginRoute = computed(() => buildLoginRoute(
 ))
 const profileMenuIsOpen = ref(false)
 const authStore = useAuthStore()
+const moderationScreenStore = useModerationScreenStore()
+const moderationSubmissionUnsavedStore = useModerationSubmissionUnsavedStore()
+const modalStore = useModalStore()
 const { isLandscape } = useScreenOrientation()
 const showGlobalSearch = computed(() =>
     isLandscape.value
@@ -250,11 +257,20 @@ function closeProfileMenu() {
     profileMenuIsOpen.value = false
 }
 
-function handleMobileLogoClick(e: Event) {
-    if (router.currentRoute.value.path === '/') {
-        e.preventDefault()
+function handleHomeClick(event: MouseEvent) {
+    if (route.path === '/') {
+        event.preventDefault()
         toggleLogoText()
+        return
     }
+
+    if (!isMyPageFormRoute(route.path)) {
+        return
+    }
+
+    event.preventDefault()
+    moderationSubmissionUnsavedStore.runLeaveOr(() =>
+        leaveToAppHome(router, moderationScreenStore, modalStore))
 }
 
 function navLinkClass(path: string): string {

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -97,24 +97,21 @@
             >
                 <nav
                     id="desktop-menu-items"
-                    class="portrait:hidden flex gap-3 mx-6 self-center items-center whitespace-nowrap"
+                    class="portrait:hidden flex mx-6 self-center items-end whitespace-nowrap border-b border-accent-bg"
                 >
-                    <!-- About Link -->
-                    <NuxtLink
-                        to="/about"
-                        class="hover:text-primary-hover transition-colors"
-                    >{{ t('topNav.about') }}
-                    </NuxtLink>
-                    <!-- Home Link -->
                     <NuxtLink
                         to="/"
-                        class="hover:text-primary-hover transition-colors"
+                        :class="navLinkClass('/')"
                     >{{ t('topNav.home') }}
                     </NuxtLink>
-                    <!-- Submit a new Doctor Link -->
+                    <NuxtLink
+                        to="/about"
+                        :class="navLinkClass('/about')"
+                    >{{ t('topNav.about') }}
+                    </NuxtLink>
                     <NuxtLink
                         to="/submit"
-                        class="hover:text-primary-hover transition-colors"
+                        :class="navLinkClass('/submit')"
                     >{{ t('topNav.submit') }}
                     </NuxtLink>
                     <!-- My Page menu trigger (if logged in) -->
@@ -260,6 +257,17 @@ function handleMobileLogoClick(e: Event) {
         e.preventDefault()
         toggleLogoText()
     }
+}
+
+function navLinkClass(path: string): string {
+    const isActive = path === '/'
+        ? route.path === '/'
+        : route.path === path || route.path.startsWith(`${path}/`)
+    const base = 'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px'
+
+    return isActive
+        ? `${base} border-primary text-primary-text`
+        : `${base} border-transparent text-primary-text-muted hover:text-primary-text`
 }
 async function logout() {
     try {

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -93,11 +93,11 @@
             <!-- Desktop Right Section -->
             <div
                 id="right-section"
-                class="flex"
+                class="flex items-center"
             >
                 <nav
                     id="desktop-menu-items"
-                    class="portrait:hidden flex mx-6 self-center items-end whitespace-nowrap border-b border-accent-bg"
+                    class="portrait:hidden flex mx-6 items-end whitespace-nowrap border-b border-accent-bg"
                 >
                     <NuxtLink
                         to="/"
@@ -125,8 +125,8 @@
                     >
                         <button
                             data-testid="topnav-profile-section"
-                            class="flex items-center gap-2 rounded-xl px-3 py-2 text-primary-text
-                            hover:bg-primary-hover/10 transition-colors"
+                            class="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-primary-text
+                            border-b-2 -mb-px border-transparent hover:text-primary-text transition-colors"
                             @click="toggleProfileMenu"
                         >
                             <span class="max-w-44 truncate font-medium">
@@ -187,16 +187,14 @@
                             </button>
                         </div>
                     </div>
-                    <!-- Login Button (if logged out)  -->
-                    <div
+                    <NuxtLink
                         v-if="!authStore.isLoggedIn"
+                        :to="loginRoute"
                         data-testid="topnav-login"
-                        class="flex text-primary"
+                        :class="navLinkClass('/login')"
                     >
-                        <NuxtLink :to="loginRoute">
-                            {{ t('topNav.login') }}
-                        </NuxtLink>
-                    </div>
+                        {{ t('topNav.login') }}
+                    </NuxtLink>
                 </nav>
                 <LocaleSelector class="portrait:hidden" />
                 <HamburgerMenu class="landscape:hidden justify-end z-20 p-2 bg-primary-bg/20 rounded-2xl" />

--- a/components/moderation-panel/ModCreateFacilityOrProfessionalTopbar.vue
+++ b/components/moderation-panel/ModCreateFacilityOrProfessionalTopbar.vue
@@ -3,7 +3,7 @@
         <div class="facility-hp-topbar-actions flex justify p-2 font-bold ">
             <button
                 type="button"
-                :class="[buttonBaseClass, buttonPrimaryClass, 'w-28 text-lg mr-2']"
+                :class="[buttonBaseClass, buttonPrimaryClass, buttonPaddingClass, 'text-lg mr-2']"
                 data-testid="mod-create-facility-hp-topbar-create"
                 @click="createFacilityOrHealthcareProfessional"
             >
@@ -13,7 +13,7 @@
             </button>
             <button
                 type="button"
-                :class="[buttonBaseClass, buttonOutlineClass, 'w-28 text-lg mr-2']"
+                :class="[buttonBaseClass, buttonOutlineClass, buttonPaddingClass, 'text-lg mr-2']"
                 data-testid="mod-create-facility-hp-topbar-exit"
                 @click="openExitConfirmation"
             >
@@ -80,6 +80,7 @@ const toast = useToast()
 
 const { t } = useI18n()
 const buttonBaseClass = 'inline-flex justify-center items-center rounded-full border-2 font-bold'
+const buttonPaddingClass = 'px-5 py-2 whitespace-nowrap'
 const buttonOutlineClass = 'bg-secondary-bg border-primary-text-muted text-primary-text hover:bg-accent-bg/20'
 const buttonPrimaryClass = 'bg-primary border-primary text-primary-text-inverted hover:bg-primary-hover'
 const buttonDangerFilledClass = 'bg-error border-error text-primary-text-inverted hover:opacity-90'

--- a/components/moderation-panel/ModDashboardTopbar.vue
+++ b/components/moderation-panel/ModDashboardTopbar.vue
@@ -50,28 +50,28 @@
         </div>
         <div
             v-if="moderationSubmissionsStore.selectedModerationListViewChosen === SelectedModerationListView.Submissions"
-            class="flex flex-wrap items-center gap-2"
+            class="flex items-end border-b border-accent-bg -mb-px"
         >
             <button
                 type="button"
                 :class="statusFilterClass(SelectedSubmissionListViewTab.ForReview)"
                 @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.ForReview)"
             >
-                {{ t("modDashboardLeftNav.forReview") }} ({{ statusCounts.forReviewCount }})
+                {{ t("modDashboardLeftNav.forReview") }} ({{ moderationSubmissionsStore.statusTotalCounts.forReviewCount }})
             </button>
             <button
                 type="button"
                 :class="statusFilterClass(SelectedSubmissionListViewTab.Approved)"
                 @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.Approved)"
             >
-                {{ t("modDashboardLeftNav.approved") }} ({{ statusCounts.approvedCount }})
+                {{ t("modDashboardLeftNav.approved") }} ({{ moderationSubmissionsStore.statusTotalCounts.approvedCount }})
             </button>
             <button
                 type="button"
                 :class="statusFilterClass(SelectedSubmissionListViewTab.Rejected)"
                 @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.Rejected)"
             >
-                {{ t("modDashboardLeftNav.rejected") }} ({{ statusCounts.rejectedCount }})
+                {{ t("modDashboardLeftNav.rejected") }} ({{ moderationSubmissionsStore.statusTotalCounts.rejectedCount }})
             </button>
         </div>
     </div>
@@ -82,7 +82,6 @@ import { computed } from 'vue'
 import {
     SelectedModerationListView,
     SelectedSubmissionListViewTab,
-    SubmissionStatus,
     useModerationSubmissionsStore
 } from '~/stores/moderationSubmissionsStore'
 import { useCurrentUserAccessStore } from '~/stores/currentUserAccessStore'
@@ -116,40 +115,17 @@ const submissionSearchQuery = computed({
     set: (newValue: string) => moderationSubmissionsStore.setSubmissionSearchQuery(newValue)
 })
 
-const statusCounts = computed(() => {
-    const submissions = moderationSubmissionsStore.submissionsData
-    const forReviewCount = submissions.filter(submission => {
-        const isNewSubmission = !submission.isRejected && !submission.isApproved && !submission.isUnderReview
-        return submission.isUnderReview || isNewSubmission
-    }).length
-    const approvedCount = submissions.filter(submission => submission.isApproved).length
-    const rejectedCount = submissions.filter(submission => submission.isRejected).length
-
-    return {
-        forReviewCount,
-        approvedCount,
-        rejectedCount
-    }
-})
-
-function updateSubmissionListViewState(newValue: SelectedSubmissionListViewTab) {
-    moderationSubmissionsStore.setSelectedModerationListViewTabChosen(newValue)
-
-    const status = newValue === SelectedSubmissionListViewTab.Approved
-        ? SubmissionStatus.Approved
-        : newValue === SelectedSubmissionListViewTab.Rejected
-            ? SubmissionStatus.Rejected
-            : SubmissionStatus.InReview
-    moderationSubmissionsStore.filterSubmissionByStatus(status)
+async function updateSubmissionListViewState(newValue: SelectedSubmissionListViewTab) {
+    await moderationSubmissionsStore.setSelectedModerationListViewTabChosen(newValue)
 }
 
 function statusFilterClass(tab: SelectedSubmissionListViewTab): string {
     const isActive = moderationSubmissionsStore.selectedModerationListViewTabChosen === tab
-    const baseClass = 'inline-flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm transition-colors'
+    const baseClass = 'px-4 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px'
 
     return isActive
-        ? `${baseClass} border-primary bg-primary text-primary-text-inverted`
-        : `${baseClass} border-accent-bg bg-secondary-bg text-primary-text hover:bg-accent-bg/20`
+        ? `${baseClass} border-primary text-primary-text`
+        : `${baseClass} border-transparent text-primary-text-muted hover:text-primary-text`
 }
 
 const updateTextForModerationDashboard = (selectedView: SelectedModerationListView) => {

--- a/components/moderation-panel/ModDashboardTopbar.vue
+++ b/components/moderation-panel/ModDashboardTopbar.vue
@@ -54,6 +54,13 @@
         >
             <button
                 type="button"
+                :class="statusFilterClass(SelectedSubmissionListViewTab.New)"
+                @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.New)"
+            >
+                {{ t("modDashboardLeftNav.new") }} ({{ moderationSubmissionsStore.statusTotalCounts.newCount }})
+            </button>
+            <button
+                type="button"
                 :class="statusFilterClass(SelectedSubmissionListViewTab.ForReview)"
                 @click="updateSubmissionListViewState(SelectedSubmissionListViewTab.ForReview)"
             >

--- a/components/moderation-panel/ModEditFacilityOrProfessionalTopbar.vue
+++ b/components/moderation-panel/ModEditFacilityOrProfessionalTopbar.vue
@@ -25,7 +25,7 @@
         <div class="facility-hp-topbar-actions flex justify p-2 font-bold ">
             <button
                 type="button"
-                :class="[buttonBaseClass, buttonOutlineClass, 'w-28 mr-2']"
+                :class="[buttonBaseClass, buttonOutlineClass, buttonPaddingClass, 'mr-2']"
                 data-testid="mod-edit-facility-hp-topbar-back"
                 @click="navigateBackToDashboard"
             >
@@ -35,7 +35,7 @@
             <button
                 type="button"
                 :disabled="!hasPendingChanges"
-                :class="[buttonBaseClass, buttonOutlineClass, 'w-28 mr-2']"
+                :class="[buttonBaseClass, buttonOutlineClass, buttonPaddingClass, 'mr-2']"
                 data-testid="mod-edit-facility-hp-topbar-update"
                 @click="saveChanges"
             >
@@ -46,7 +46,7 @@
             <button
                 type="button"
                 :disabled="!hasPendingChanges"
-                :class="[buttonBaseClass, buttonOutlineClass, 'w-28 mr-2']"
+                :class="[buttonBaseClass, buttonOutlineClass, buttonPaddingClass, 'mr-2']"
                 data-testid="mod-edit-facility-hp-topbar-update-and-exit"
                 @click="saveChangesAndExit"
             >
@@ -56,7 +56,7 @@
             </button>
             <button
                 type="button"
-                :class="[buttonBaseClass, buttonDangerClass, 'w-28 mr-2']"
+                :class="[buttonBaseClass, buttonDangerClass, buttonPaddingClass, 'mr-2']"
                 data-testid="mod-edit-facility-hp-topbar-delete"
                 @click="openDeleteConfirmation"
             >
@@ -136,7 +136,8 @@ import { handleModerationResponseErrors } from '~/composables/useModerationRespo
 import type { Facility, HealthcareProfessional } from '~/typedefs/gqlTypes'
 import { arraysAreEqual } from '~/utils/arrayUtils'
 import { hasEnglishLocalizedName } from '~/utils/nameUtils'
-import { hasServerErrors, navigateToModerationDashboard } from '~/utils/moderationUtils'
+import { hasServerErrors, leaveToModerationDashboard, getModerationDashboardViewForScreen } from '~/utils/moderationUtils'
+import { useModerationSubmissionUnsavedStore } from '~/stores/moderationSubmissionUnsavedStore'
 
 const router = useRouter()
 
@@ -145,6 +146,7 @@ const facilitiesStore = useFacilitiesStore()
 const { facilitySectionFields } = storeToRefs(facilitiesStore)
 const healthcareProfessionalsStore = useHealthcareProfessionalsStore()
 const moderationScreenStore = useModerationScreenStore()
+const moderationSubmissionUnsavedStore = useModerationSubmissionUnsavedStore()
 const modalStore = useModalStore()
 
 // Initialize the value of the selected Id based off of Moderation Screen
@@ -207,6 +209,7 @@ const { t } = useI18n()
 
 const showCopySuccessIcon: Ref<boolean> = ref(false)
 const buttonBaseClass = 'inline-flex justify-center items-center rounded-full border-2 text-base font-bold'
+const buttonPaddingClass = 'px-5 py-2 whitespace-nowrap'
 const buttonOutlineClass = 'bg-secondary-bg border-primary-text-muted text-primary-text hover:bg-accent-bg/20'
 const buttonDangerClass = 'bg-secondary-bg border-error text-error hover:bg-error/10'
 const buttonDangerFilledClass = 'bg-error border-error text-primary-text-inverted hover:opacity-90'
@@ -378,25 +381,26 @@ const saveChanges = async () => {
 }
 
 const saveChangesAndExit = async () => {
+    const dashboardView = getModerationDashboardViewForScreen(moderationScreenStore.activeScreen)
+
     if (moderationScreenStore.editFacilityScreenIsActive()) {
-        const response = await saveChanges()
-
-        if (response === undefined || hasServerErrors(response)) {
-            return
+        if (hasPendingFormChanges()) {
+            const response = await saveChanges()
+            if (response === undefined || hasServerErrors(response)) {
+                return
+            }
         }
-
-        await router.push('/my-page?view=facilities')
-        moderationScreenStore.setActiveScreen(ModerationScreen.Dashboard)
+        await leaveToModerationDashboard(router, moderationScreenStore, modalStore, dashboardView)
+        return
     }
     if (moderationScreenStore.editHealthcareProfessionalScreenIsActive()) {
-        const response = await saveChanges()
-
-        if (response === undefined || hasServerErrors(response)) {
-            return
+        if (hasPendingFormChanges()) {
+            const response = await saveChanges()
+            if (response === undefined || hasServerErrors(response)) {
+                return
+            }
         }
-
-        await router.push('/my-page?view=healthcare-professionals')
-        moderationScreenStore.setActiveScreen(ModerationScreen.Dashboard)
+        await leaveToModerationDashboard(router, moderationScreenStore, modalStore, dashboardView)
     }
 }
 
@@ -422,7 +426,7 @@ const deleteFacilityOrHealthcareProfessional = async () => {
             'modEditFacilityOrHPTopbar.facilityDeletedSuccessfully'
         )
         // Redirect to the dashboard since the facility no longer exists
-        await navigateToModerationDashboard(router, moderationScreenStore)
+        await leaveToModerationDashboard(router, moderationScreenStore, modalStore)
         modalType.value = null
         modalStore.hideModal()
         return response
@@ -446,14 +450,16 @@ const deleteFacilityOrHealthcareProfessional = async () => {
             'modEditFacilityOrHPTopbar.healthcareProfessionalDeletedSuccessfully'
         )
         // Redirect to the dashboard since the healthcare professional no longer exists
-        await navigateToModerationDashboard(router, moderationScreenStore)
+        await leaveToModerationDashboard(router, moderationScreenStore, modalStore)
         modalType.value = null
         modalStore.hideModal()
         return response
     }
 }
 
-const navigateBackToDashboard = async () => {
-    await navigateToModerationDashboard(router, moderationScreenStore)
+const navigateBackToDashboard = () => {
+    const dashboardView = getModerationDashboardViewForScreen(moderationScreenStore.activeScreen)
+    moderationSubmissionUnsavedStore.runLeaveOr(() =>
+        leaveToModerationDashboard(router, moderationScreenStore, modalStore, dashboardView))
 }
 </script>

--- a/components/moderation-panel/ModEditFacilitySection.vue
+++ b/components/moderation-panel/ModEditFacilitySection.vue
@@ -294,11 +294,11 @@
 </template>
 
 <script lang="ts" setup>
-import { type Ref, ref, computed, onBeforeMount, nextTick, watch } from 'vue'
+import { type Ref, ref, computed, onBeforeMount, onUnmounted, nextTick, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useToast } from 'vue-toastification'
-import { useRoute, useRouter } from 'vue-router'
-import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
+import { useRoute } from 'vue-router'
+import { useModerationScreenStore } from '~/stores/moderationScreenStore'
 import { useFacilitiesStore } from '~/stores/facilitiesStore'
 import { useHealthcareProfessionalsStore } from '~/stores/healthcareProfessionalsStore'
 import { useI18n } from '#imports'
@@ -319,10 +319,10 @@ import { checkPrefectureNameMatch } from '~/utils/facilitiesUtils'
 import { stableStringify } from '~/utils/stableStringify'
 import { matchesHealthcareProfessionalSearch } from '~/utils/moderationSearchUtils'
 import { formatFirstLocalizedFullName } from '~/utils/nameUtils'
+import { useModerationSubmissionUnsavedStore } from '~/stores/moderationSubmissionUnsavedStore'
 
 const toast = useToast()
 const route = useRoute()
-const router = useRouter()
 const { t } = useI18n()
 const loadingStore = useLoadingStore()
 const moderationScreenStore = useModerationScreenStore()
@@ -333,13 +333,10 @@ const isFacilitySectionInitialized: Ref<boolean> = ref(false)
 
 const facilityFormState = computed(() =>
     JSON.parse(stableStringify(facilitySectionFields.value)))
-const { makeNonDirty: makeFacilityFormNonDirty } = useUnsavedChanges({
+const moderationSubmissionUnsavedStore = useModerationSubmissionUnsavedStore()
+const { makeNonDirty: makeFacilityFormNonDirty, tryLeave: tryLeaveFacilityForm } = useUnsavedChanges({
     data: { source: facilityFormState },
-    mode: 'update',
-    onClose: () => {
-        moderationScreenStore.setActiveScreen(ModerationScreen.Dashboard)
-        router.push('/my-page?view=facilities')
-    }
+    mode: 'update'
 })
 
 watch(
@@ -428,8 +425,13 @@ onBeforeMount(async () => {
     await nextTick()
     isFacilitySectionInitialized.value = true
     makeFacilityFormNonDirty()
+    moderationSubmissionUnsavedStore.registerEditFormTryLeave(tryLeaveFacilityForm)
     loadingStore.setIsLoading(false)
     // Ensure UI updates are reflected
     await nextTick()
+})
+
+onUnmounted(() => {
+    moderationSubmissionUnsavedStore.registerEditFormTryLeave(null)
 })
 </script>

--- a/components/moderation-panel/ModEditHealthcareProfessionalSection.vue
+++ b/components/moderation-panel/ModEditHealthcareProfessionalSection.vue
@@ -284,23 +284,23 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, nextTick, onBeforeMount, reactive, ref, watch, type Ref } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { computed, nextTick, onBeforeMount, onUnmounted, reactive, ref, watch, type Ref } from 'vue'
+import { useRoute } from 'vue-router'
 import { useToast } from 'vue-toastification'
 import { useHealthcareProfessionalsStore } from '~/stores/healthcareProfessionalsStore'
 import { useFacilitiesStore } from '~/stores/facilitiesStore'
-import { useModerationScreenStore, ModerationScreen } from '~/stores/moderationScreenStore'
+import { useModerationScreenStore } from '~/stores/moderationScreenStore'
 import { useLocaleStore } from '~/stores/localeStore'
 import { Insurance, Locale, Degree, Specialty, type LocalizedNameInput, type Facility } from '~/typedefs/gqlTypes'
 import { useI18n } from '#imports'
 import { validateNameLocaleMatchesLanguage } from '~/utils/formValidations'
 import { stableStringify } from '~/utils/stableStringify'
 import { filterByCaseInsensitiveIncludes, matchesFacilitySearch } from '~/utils/moderationSearchUtils'
+import { useModerationSubmissionUnsavedStore } from '~/stores/moderationSubmissionUnsavedStore'
 // Keeps track of if the search bar inputs have been autofilled with existing facilities
 
 const toast = useToast()
 const route = useRoute()
-const router = useRouter()
 const { t } = useI18n()
 
 const loadingStore = useLoadingStore()
@@ -331,13 +331,10 @@ const selectedFacilitiesModel = computed({
 
 const hpFormState = computed(() =>
     JSON.parse(stableStringify(hpStore.healthcareProfessionalSectionFields)))
-const { makeNonDirty: makeHpFormNonDirty } = useUnsavedChanges({
+const moderationSubmissionUnsavedStore = useModerationSubmissionUnsavedStore()
+const { makeNonDirty: makeHpFormNonDirty, tryLeave: tryLeaveHpForm } = useUnsavedChanges({
     data: { source: hpFormState },
-    mode: 'update',
-    onClose: () => {
-        moderationScreenStore.setActiveScreen(ModerationScreen.Dashboard)
-        router.push('/my-page?view=healthcare-professionals')
-    }
+    mode: 'update'
 })
 
 watch(
@@ -624,8 +621,13 @@ onBeforeMount(async () => {
 
     isHealthcareProfessionalInitialized.value = true
     makeHpFormNonDirty()
+    moderationSubmissionUnsavedStore.registerEditFormTryLeave(tryLeaveHpForm)
     loadingStore.setIsLoading(false)
 
     await nextTick()
+})
+
+onUnmounted(() => {
+    moderationSubmissionUnsavedStore.registerEditFormTryLeave(null)
 })
 </script>

--- a/components/moderation-panel/ModEditSubmissionForm.vue
+++ b/components/moderation-panel/ModEditSubmissionForm.vue
@@ -148,7 +148,7 @@ import { handleModerationResponseErrors } from '~/composables/useModerationRespo
 import { ModerationSubmissionActionType, useModerationSubmissionActions } from '~/composables/useModerationSubmissionActions'
 import { mapIdsToEntities, matchesFacilitySearch, matchesHealthcareProfessionalSearch } from '~/utils/moderationSearchUtils'
 import { formatFirstLocalizedFullName, hasEnglishLocalizedName } from '~/utils/nameUtils'
-import { navigateToModerationDashboard as goToModerationDashboard } from '~/utils/moderationUtils'
+import { leaveToModerationDashboard } from '~/utils/moderationUtils'
 import {
     hasRequiredHealthcareProfessionalSelections,
     validateModerationFacilityFields
@@ -177,10 +177,9 @@ const formState = computed(() => ({
     notes: currentSubmissionNotes.value
 }))
 const moderationSubmissionUnsavedStore = useModerationSubmissionUnsavedStore()
-const { makeNonDirty, isDirty, tryClose } = useUnsavedChanges({
+const { makeNonDirty, isDirty, tryLeave } = useUnsavedChanges({
     data: { source: formState },
-    mode: 'update',
-    onClose: () => navigateToModerationDashboard()
+    mode: 'update'
 })
 watch(isDirty, dirty => moderationSubmissionUnsavedStore.setEditSubmissionFormDirty(dirty), {
     immediate: true,
@@ -490,13 +489,16 @@ async function saveSubmissionDraft(
     }
 
     const submissionResult = result.data
-    if (submissionResult) initializeSubmissionFormValues(submissionResult.updateSubmission)
+    if (submissionResult) {
+        initializeSubmissionFormValues(submissionResult.updateSubmission)
+    }
+    makeNonDirty()
 
     if (options.showSuccessToast ?? true) {
         returnWithSuccessToast(result, toast, t, 'modSubmissionForm.successMessageUpdated')
     }
     if (options.shouldExitAfterUpdate) {
-        await goToModerationDashboard(router, screenStore)
+        await leaveToModerationDashboard(router, screenStore, modalStore, 'submissions')
         return true
     }
 
@@ -574,7 +576,7 @@ async function confirmAndApproveSubmission(e: Event) {
         }
         await resetModalRefs()
         returnWithSuccessToast(result, toast, t, 'modSubmissionForm.successMessageApproved')
-        await goToModerationDashboard(router, screenStore)
+        await leaveToModerationDashboard(router, screenStore, modalStore, 'submissions')
     } catch {
         toast.error(t('modSubmissionForm.errorMessageCompletedForm'))
         await resetModalRefs()
@@ -592,7 +594,7 @@ const rejectSubmission = async () => {
     await moderationSubmissionStore.rejectSubmission()
     await resetModalRefs()
     toast.success(t('modSubmissionForm.facilitySuccessfullyRejected'))
-    navigateToModerationDashboard()
+    await leaveToModerationDashboard(router, screenStore, modalStore, 'submissions')
 }
 
 watch(
@@ -629,7 +631,7 @@ watch(
 )
 
 onUnmounted(() => {
-    moderationSubmissionUnsavedStore.registerEditSubmissionTryClose(null)
+    moderationSubmissionUnsavedStore.registerEditFormTryLeave(null)
     moderationSubmissionUnsavedStore.setEditSubmissionFormDirty(false)
 })
 
@@ -664,13 +666,7 @@ onMounted(async () => {
     await nextTick()
 
     isEditSubmissionFormInitialized.value = true
-    moderationSubmissionUnsavedStore.registerEditSubmissionTryClose(tryClose)
+    moderationSubmissionUnsavedStore.registerEditFormTryLeave(tryLeave)
     loadingStore.setIsLoading(false)
 })
-
-const navigateToModerationDashboard = () => {
-    goToModerationDashboard(router, screenStore, modalStore)
-}
-
-// Unsaved changes on browser back / router leave are handled by useUnsavedChanges + unsaved-changes-plugin (router.beforeEach).
 </script>

--- a/components/moderation-panel/ModEditSubmissionTopbar.vue
+++ b/components/moderation-panel/ModEditSubmissionTopbar.vue
@@ -4,7 +4,7 @@
             <button
                 type="button"
                 data-testid="mod-edit-submission-back-to-dashboard"
-                :class="[buttonBaseClass, buttonOutlineClass, 'w-28 mr-2 p-2 m-2']"
+                :class="[buttonBaseClass, buttonOutlineClass, buttonPaddingClass, 'mr-2 m-2']"
                 @click="goToDashboard"
             >
                 {{ t('modEditFacilityOrHPTopbar.back') }}
@@ -33,7 +33,7 @@
         <div class="flex flex-row justify p-2 font-bold ">
             <button
                 type="button"
-                :class="[buttonBaseClass, buttonOutlineClass, 'w-28 mr-2']"
+                :class="[buttonBaseClass, buttonOutlineClass, buttonPaddingClass, 'mr-2']"
                 data-testid="submission-topNav-update"
                 @click="requestUpdate"
             >
@@ -43,7 +43,7 @@
             </button>
             <button
                 type="button"
-                :class="[buttonBaseClass, buttonOutlineClass, 'w-28 mr-2']"
+                :class="[buttonBaseClass, buttonOutlineClass, buttonPaddingClass, 'mr-2']"
                 data-testid="submission-topNav-updateAndExit"
                 @click="requestUpdateAndExit"
             >
@@ -54,7 +54,7 @@
             <button
                 data-testid="mod-edit-submission-reject-button"
                 type="button"
-                :class="[buttonBaseClass, buttonDangerClass, 'w-28 mr-2']"
+                :class="[buttonBaseClass, buttonDangerClass, buttonPaddingClass, 'mr-2']"
                 @click="requestRejectConfirmation"
             >
                 {{
@@ -62,7 +62,7 @@
             </button>
             <button
                 type="button"
-                :class="[buttonBaseClass, buttonPrimaryClass, 'w-28 mr-2']"
+                :class="[buttonBaseClass, buttonPrimaryClass, buttonPaddingClass, 'mr-2']"
                 @click="requestApproveConfirmation"
             >
                 {{
@@ -79,7 +79,7 @@ import { useRouter } from 'vue-router'
 import SVGCopyContent from '~/assets/icons/content-copy.svg'
 import SVGSuccessCheckMark from '~/assets/icons/checkmark-square.svg'
 import { ModerationSubmissionActionType, useModerationSubmissionActions } from '~/composables/useModerationSubmissionActions'
-import { navigateToModerationDashboard } from '~/utils/moderationUtils'
+import { leaveToModerationDashboard } from '~/utils/moderationUtils'
 
 const { t } = useI18n()
 const router = useRouter()
@@ -92,12 +92,13 @@ const { emitModerationSubmissionAction } = useModerationSubmissionActions()
 const { selectedSubmissionId } = storeToRefs(moderationSubmissionStore)
 
 const goToDashboard = () => {
-    moderationSubmissionUnsavedStore.runEditSubmissionBackOr(() =>
-        navigateToModerationDashboard(router, moderationScreenStore, modalStore))
+    moderationSubmissionUnsavedStore.runLeaveOr(() =>
+        leaveToModerationDashboard(router, moderationScreenStore, modalStore, 'submissions'))
 }
 
 const showCopySuccessIcon: Ref<boolean> = ref(false)
 const buttonBaseClass = 'inline-flex justify-center items-center rounded-full border-2 text-base font-bold'
+const buttonPaddingClass = 'px-5 py-2 whitespace-nowrap'
 const buttonOutlineClass = 'bg-secondary-bg border-primary-text-muted text-primary-text hover:bg-accent-bg/20'
 const buttonPrimaryClass = 'bg-primary border-primary text-primary-text-inverted hover:bg-primary-hover'
 const buttonDangerClass = 'bg-secondary-bg border-error text-error hover:bg-error/10'

--- a/components/moderation-panel/ModLeftNavbar.vue
+++ b/components/moderation-panel/ModLeftNavbar.vue
@@ -1,6 +1,7 @@
 <template>
     <aside
-        class="w-full md:w-80 shrink-0 px-4 py-4 md:py-6 md:m-4 md:mr-0
+        class="w-full md:w-80 shrink-0 md:self-stretch md:max-h-full md:overflow-y-auto
+        px-4 py-4 md:py-6
         border border-accent-bg bg-secondary-bg rounded-xl shadow-sm"
     >
         <h2 class="text-3xl md:text-4xl font-semibold mb-4 md:mb-6 text-primary-text">

--- a/components/moderation-panel/ModLeftNavbar.vue
+++ b/components/moderation-panel/ModLeftNavbar.vue
@@ -1,7 +1,7 @@
 <template>
     <aside
-        class="w-full md:w-80 px-4 py-4 md:py-6 border-b md:border-b-0
-        md:border-r border-accent-bg bg-secondary-bg"
+        class="w-full md:w-80 shrink-0 px-4 py-4 md:py-6 md:m-4 md:mr-0
+        border border-accent-bg bg-secondary-bg rounded-xl shadow-sm"
     >
         <h2 class="text-3xl md:text-4xl font-semibold mb-4 md:mb-6 text-primary-text">
             My Page

--- a/components/moderation-panel/ModListContainer.vue
+++ b/components/moderation-panel/ModListContainer.vue
@@ -1,18 +1,14 @@
 <template>
-    <div class="relative flex flex-col min-h-screen w-full border-t border-border">
-        <!-- Centered 7xl container with left/right borders -->
-        <div class="mx-auto w-full max-w-7xl border-l border-r border-border relative overflow-hidden">
-            <!-- Background SVG (contained) -->
+    <div class="relative flex flex-col h-full w-full min-h-0">
+        <div class="flex flex-col h-full min-h-0 overflow-hidden">
             <div class="absolute inset-0 z-0 opacity-10 pointer-events-none flex items-center justify-center">
                 <SVGCharactersTogetherWelcomeScreen class="w-3/5 h-3/5 object-contain" />
             </div>
 
-            <!-- Scrollable Foreground Content -->
-            <div class="flex-1 h-screen overflow-y-auto gap-4 pt-0 border-t border-border">
-                <!-- Submissions -->
+            <div class="relative z-10 flex-1 min-h-0 overflow-y-auto">
                 <div
                     v-if="hasSubmissions && submissionsModerationListViewChosen"
-                    class="grid grid-cols-1 landscape:grid-cols-2 gap-4 items-start justify-start mx-2 mt-2 mb-44"
+                    class="grid grid-cols-1 landscape:grid-cols-2 gap-4 items-start justify-start p-3 md:p-4"
                 >
                     <div
                         v-for="(submission, index) in modSubmissionsStore.filteredSubmissionDataForListComponent"
@@ -27,10 +23,9 @@
                     </div>
                 </div>
 
-                <!-- Facilities -->
                 <div
                     v-else-if="hasFacilities && facilitiesModerationListViewChosen"
-                    class="grid grid-cols-1 landscape:grid-cols-2 gap-4 items-start justify-start mx-2 mt-2 mb-44"
+                    class="grid grid-cols-1 landscape:grid-cols-2 gap-4 items-start justify-start p-3 md:p-4"
                 >
                     <div
                         v-for="(facility, index) in facilitiesStore.facilityData"
@@ -45,10 +40,9 @@
                     </div>
                 </div>
 
-                <!-- Healthcare Professionals -->
                 <div
                     v-else-if="hasHealthcareProfessionals && healthcareProfessionalsModerationListViewChosen"
-                    class="grid grid-cols-1 landscape:grid-cols-2 gap-4 items-start justify-start mx-2 mt-2 mb-44"
+                    class="grid grid-cols-1 landscape:grid-cols-2 gap-4 items-start justify-start p-3 md:p-4"
                 >
                     <div
                         v-for="(healthcareProfessional, index) in healthcareProfessionalsStore.healthcareProfessionalsData"
@@ -63,64 +57,62 @@
                     </div>
                 </div>
 
-                <!-- No data fallback -->
                 <div
                     v-else
-                    class="text-center py-8 mx-2"
+                    class="text-center py-8 px-4"
                 >
                     {{ t("modPanelSubmissionList.noSubmissions") }}
                 </div>
+            </div>
 
-                <!-- Sticky Pagination at Bottom -->
-                <div class="fixed bottom-0 left-0 w-full bg-primary-bg border-t border-accent-bg z-20">
-                    <div class="max-w-7xl mx-auto flex flex-col md:flex-row md:items-center px-3 py-2 gap-2">
-                        <div class="w-full md:flex-1 flex justify-center">
-                            <Pagination
-                                v-if="submissionsModerationListViewChosen"
-                                :current-offset="modSubmissionsStore.currentOffset"
-                                :total-items="modSubmissionsStore.totalSubmissionsCount"
-                                :items-per-page="modSubmissionsStore.itemsPerPage"
-                                @update:offset="modSubmissionsStore.setOffset"
-                            />
-                            <Pagination
-                                v-if="facilitiesModerationListViewChosen"
-                                :current-offset="facilitiesStore.currentOffset"
-                                :total-items="facilitiesStore.totalFacilitiesCount"
-                                :items-per-page="facilitiesStore.itemsPerPage"
-                                @update:offset="facilitiesStore.setOffset"
-                            />
-                            <Pagination
-                                v-if="healthcareProfessionalsModerationListViewChosen"
-                                :current-offset="healthcareProfessionalsStore.currentOffset"
-                                :total-items="healthcareProfessionalsStore.totalHealthcareProfessionalsCount"
-                                :items-per-page="healthcareProfessionalsStore.itemsPerPage"
-                                @update:offset="healthcareProfessionalsStore.setOffset"
-                            />
-                        </div>
-                        <div class="w-full md:w-auto flex items-center justify-center md:justify-end gap-2">
-                            <label
-                                for="items-per-page-select"
-                                class="text-xs sm:text-sm text-primary-text-muted"
-                            >{{ $t('modListContainer.resultsPerPage') }}
-                            </label>
-                            <select
-                                id="items-per-page-select"
-                                :value="getCurrentItemsPerPage()"
-                                class="border border-accent-bg rounded px-2 py-1 text-sm bg-secondary-bg
-                                text-primary-text focus:ring-primary focus:border-primary"
-                                @change="handleItemsPerPageChange"
-                            >
-                                <option value="10">
-                                    10
-                                </option>
-                                <option value="25">
-                                    25
-                                </option>
-                                <option value="50">
-                                    50
-                                </option>
-                            </select>
-                        </div>
+            <div class="relative z-10 shrink-0 border-t border-accent-bg bg-secondary-bg px-3 py-2">
+                <div class="flex flex-col md:flex-row md:items-center gap-2">
+                    <div class="w-full md:flex-1 flex justify-center">
+                        <Pagination
+                            v-if="submissionsModerationListViewChosen"
+                            :current-offset="modSubmissionsStore.currentOffset"
+                            :total-items="modSubmissionsStore.totalSubmissionsCount"
+                            :items-per-page="modSubmissionsStore.itemsPerPage"
+                            @update:offset="modSubmissionsStore.setOffset"
+                        />
+                        <Pagination
+                            v-if="facilitiesModerationListViewChosen"
+                            :current-offset="facilitiesStore.currentOffset"
+                            :total-items="facilitiesStore.totalFacilitiesCount"
+                            :items-per-page="facilitiesStore.itemsPerPage"
+                            @update:offset="facilitiesStore.setOffset"
+                        />
+                        <Pagination
+                            v-if="healthcareProfessionalsModerationListViewChosen"
+                            :current-offset="healthcareProfessionalsStore.currentOffset"
+                            :total-items="healthcareProfessionalsStore.totalHealthcareProfessionalsCount"
+                            :items-per-page="healthcareProfessionalsStore.itemsPerPage"
+                            @update:offset="healthcareProfessionalsStore.setOffset"
+                        />
+                    </div>
+                    <div class="w-full md:w-auto flex items-center justify-center md:justify-end gap-2">
+                        <label
+                            for="items-per-page-select"
+                            class="text-xs sm:text-sm text-primary-text-muted"
+                        >{{ $t('modListContainer.resultsPerPage') }}
+                        </label>
+                        <select
+                            id="items-per-page-select"
+                            :value="getCurrentItemsPerPage()"
+                            class="border border-accent-bg rounded px-2 py-1 text-sm bg-secondary-bg
+                            text-primary-text focus:ring-primary focus:border-primary"
+                            @change="handleItemsPerPageChange"
+                        >
+                            <option value="10">
+                                10
+                            </option>
+                            <option value="25">
+                                25
+                            </option>
+                            <option value="50">
+                                50
+                            </option>
+                        </select>
                     </div>
                 </div>
             </div>
@@ -152,6 +144,7 @@ const submissionsModerationListViewChosen = computed(() => modSubmissionsStore.s
 
 onMounted(async () => {
     await modSubmissionsStore.getSubmissions()
+    await modSubmissionsStore.fetchStatusCounts()
     await facilitiesStore.getFacilities()
     await healthcareProfessionalsStore.getHealthcareProfessionals()
 })
@@ -178,24 +171,19 @@ function getCurrentItemsPerPage(): number {
 }
 
 async function handleItemsPerPageChange(event: Event) {
-    // Extract the new selected value from the event target and convert it to a number.
     const newItemsPerPage = Number((event.target as HTMLSelectElement).value)
-    // Use a switch statement to perform the correct action based on the currently active moderation view.
     switch (modSubmissionsStore.selectedModerationListViewChosen) {
         case SelectedModerationListView.Submissions:
-            // Update the itemsPerPage and reset the offset to 0 for submissions.
             modSubmissionsStore.setItemsPerPage(newItemsPerPage)
             modSubmissionsStore.setOffset(0)
             await modSubmissionsStore.getSubmissions()
             break
         case SelectedModerationListView.Facilities:
-            // Update the itemsPerPage and reset the offset to 0 for facilities.
             facilitiesStore.setItemsPerPage(newItemsPerPage)
             facilitiesStore.setOffset(0)
             await facilitiesStore.getFacilities()
             break
         case SelectedModerationListView.HealthcareProfessionals:
-            // Update the itemsPerPage and reset the offset to 0 for healtchare professionals.
             healthcareProfessionalsStore.setItemsPerPage(newItemsPerPage)
             healthcareProfessionalsStore.setOffset(0)
             await healthcareProfessionalsStore.getHealthcareProfessionals()
@@ -203,4 +191,3 @@ async function handleItemsPerPageChange(event: Event) {
     }
 }
 </script>
-

--- a/components/moderation-panel/ModListContainerItem.vue
+++ b/components/moderation-panel/ModListContainerItem.vue
@@ -229,7 +229,5 @@ const displayedHealthcareProfessionalName = computed(() => {
     )
 })
 
-const isNewSubmission = computed(() => {
-    return props.submission ? isNewSubmissionStatus(props.submission) : false
-})
+const isNewSubmission = computed(() => props.submission ? isNewSubmissionStatus(props.submission) : false)
 </script>

--- a/components/moderation-panel/ModListContainerItem.vue
+++ b/components/moderation-panel/ModListContainerItem.vue
@@ -184,6 +184,7 @@
 import type { Facility, HealthcareProfessional, Submission } from '~/typedefs/gqlTypes'
 import { useModerationSubmissionsStore, SelectedModerationListView } from '~/stores/moderationSubmissionsStore'
 import { formatToReadableDate } from '~/utils/dateUtils'
+import { isNewSubmission as isNewSubmissionStatus } from '~/utils/moderationUtils'
 import SVGHPPersonIcon from '~/assets/icons/hp-person-icon.svg'
 import SVGHospitalFacilityIcon from '~/assets/icons/hospital-facility-icon.svg'
 
@@ -229,12 +230,6 @@ const displayedHealthcareProfessionalName = computed(() => {
 })
 
 const isNewSubmission = computed(() => {
-    if (!props.submission) {
-        return false
-    }
-    if (props.submission.isApproved || props.submission.isRejected || props.submission.isUnderReview) {
-        return false
-    }
-    return true
+    return props.submission ? isNewSubmissionStatus(props.submission) : false
 })
 </script>

--- a/components/moderation-panel/ModListContainerItem.vue
+++ b/components/moderation-panel/ModListContainerItem.vue
@@ -40,6 +40,12 @@
                         >
                             {{ t('modListContainerItem.approvedSubmission') }}
                         </span>
+                        <span
+                            v-if="props.submission.isRejected"
+                            class="text-xs px-2 py-1 rounded-full bg-error/80 text-primary-inverted ml-2"
+                        >
+                            {{ t('modListContainerItem.rejectedSubmission') }}
+                        </span>
                     </div>
                 </div>
 
@@ -148,14 +154,11 @@
                     </div>
                     <div class="flex-1">
                         <span class="block text-lg font-bold">
-                            <!-- TO DO: use function to default name to selected locale or English -->
-                            {{ props.healthcareProfessional.names[0].lastName
-                                + ' '
-                                + props.healthcareProfessional.names[0].firstName
-                            }}
-                            {{ props.healthcareProfessional.names[0].middleName
-                                ? props.healthcareProfessional.names[0].middleName
-                                : '' }}
+                            {{ displayedHealthcareProfessionalName?.lastName }}
+                            {{ displayedHealthcareProfessionalName?.firstName }}
+                            <template v-if="displayedHealthcareProfessionalName?.middleName">
+                                {{ displayedHealthcareProfessionalName.middleName }}
+                            </template>
                         </span>
                     </div>
                 </div>
@@ -215,6 +218,15 @@ const handleClickToFacilityForm = (id: string) => {
 const handleClickToHPForm = (id: string) => {
     healthcareProfessionalsStore.selectedHealthcareProfessionalId = id
 }
+
+const displayedHealthcareProfessionalName = computed(() => {
+    if (!props.healthcareProfessional) {
+        return undefined
+    }
+    return healthcareProfessionalsStore.displayChosenLocaleForHealthcareProfessional(
+        props.healthcareProfessional
+    )
+})
 
 const isNewSubmission = computed(() => {
     if (!props.submission) {

--- a/components/moderation-panel/ModMainContent.vue
+++ b/components/moderation-panel/ModMainContent.vue
@@ -1,6 +1,9 @@
 <template>
-    <div class="h-full overflow-hidden">
-        <div v-if="moderationScreenStore.dashboardScreenIsActive()">
+    <div class="h-full min-h-0 overflow-hidden flex flex-col">
+        <div
+            v-if="moderationScreenStore.dashboardScreenIsActive()"
+            class="h-full min-h-0 flex flex-col"
+        >
             <MyPageSettingsContent v-if="isSettingsView" />
             <ModListContainer v-else />
         </div>

--- a/composables/useUnsavedChanges.ts
+++ b/composables/useUnsavedChanges.ts
@@ -62,23 +62,30 @@ export const useUnsavedChanges = <T>(config: Config<T>) => {
         $unsavedChangesRegistry.unregister(instanceId)
     })
 
-    const tryClose = () => {
+    const tryLeave = (onLeave: () => void | Promise<void>) => {
         if (isDirty.value) {
             useNuxtApp().$withConfirmation(() => {
-                $unsavedChangesRegistry.unregister(instanceId)
-                config.onClose?.()
+                makeNonDirty()
+                void onLeave()
             }, {
                 mode: config.mode,
                 onCancel: config.onCancel,
                 message: t('modEditFacilityOrHPTopbar.hasUnsavedChanges')
             })
         } else {
-            config.onClose?.()
+            void onLeave()
+        }
+    }
+
+    const tryClose = () => {
+        if (config.onClose) {
+            tryLeave(config.onClose)
         }
     }
 
     return {
         tryClose,
+        tryLeave,
         isDirty,
         makeDirty,
         makeNonDirty

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -241,6 +241,8 @@
     "facilitySuccessfullyRejected": "Facility rejected successfully",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
     "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully",
     "searchExistingFacilities": "Search for existing Facility",
     "searchExistingHealthcareProfessionals": "Search for existing Healthcare Professionals",
     "labelModNoteInput": "Moderator Notes",
@@ -414,6 +416,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "已驳回",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -163,6 +163,7 @@
     "facilities": "机构",
     "healthcareProfessionals": "医师",
     "forReview": "待审核",
+    "new": "New",
     "approved": "已批准",
     "rejected": "已驳回",
     "submissions": "Submissions"

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -211,6 +211,7 @@
     "facilities": "Einrichtungen",
     "healthcareProfessionals": "Gesundheitsfachkräfte",
     "forReview": "Zur Überprüfung",
+    "new": "New",
     "approved": "Genehmigt",
     "rejected": "Abgelehnt",
     "submissions": "Submissions"

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -289,6 +289,8 @@
     "facilitySuccessfullyRejected": "Facility rejected successfully",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
     "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully",
     "searchExistingFacilities": "Search for existing Facility",
     "searchExistingHealthcareProfessionals": "Search for existing Healthcare Professionals",
     "labelModNoteInput": "Moderator Notes",
@@ -414,6 +416,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "Abgelehnt",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -389,7 +389,9 @@
     "submissionConfirmationAcceptanceButton": "Yes, submit",
     "submissionConfirmationMessage": "Are you sure you want to submit this form?",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
-    "rejectSubmissionConfirmationButton": "Yes, reject the submission"
+    "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully"
   },
   "modDashboardHealthcareProfessionalCard": {
     "spokenLanguages": "Spoken languages",
@@ -408,6 +410,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "Rejected",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -221,6 +221,7 @@
     "facilities": "Facilities",
     "healthcareProfessionals": "Healthcare Professionals",
     "forReview": "For Review",
+    "new": "New",
     "approved": "Approved",
     "rejected": "Rejected",
     "submissions": "Submissions"

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -194,6 +194,8 @@
     "facilitySuccessfullyRejected": "Facility rejected successfully",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
     "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully",
     "searchExistingFacilities": "Search for existing Facility",
     "searchExistingHealthcareProfessionals": "Search for existing Healthcare Professionals",
     "labelModNoteInput": "Moderator Notes",
@@ -414,6 +416,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "Rejeté",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -156,6 +156,7 @@
     "facilities": "Établissements",
     "healthcareProfessionals": "Professionnels de la santé",
     "forReview": "À examiner",
+    "new": "New",
     "approved": "Approuvé",
     "rejected": "Rejeté",
     "submissions": "Submissions"

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -167,6 +167,7 @@
     "facilities": "Strutture",
     "healthcareProfessionals": "Professionisti sanitari",
     "forReview": "In revisione",
+    "new": "New",
     "approved": "Approvato",
     "rejected": "Rifiutato",
     "submissions": "Inoltrato"

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -332,6 +332,8 @@
     "submissionConfirmationMessage": "Sei sicuro di inviare questo form?",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
     "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully",
     "searchExistingFacilities": "Search for existing facility",
     "searchExistingHealthcareProfessionals": "Search for existing healthcare professionals",
     "labelModNoteInput": "Moderator Notes",
@@ -421,6 +423,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "Rifiutato",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -163,6 +163,7 @@
     "facilities": "Facilities",
     "healthcareProfessionals": "Healthcare Professionals",
     "forReview": "For Review",
+    "new": "New",
     "approved": "Approved",
     "rejected": "Rejected",
     "submissions": "Submissions"

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -241,6 +241,8 @@
     "facilitySuccessfullyRejected": "Facility rejected successfully",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
     "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully",
     "searchExistingFacilities": "Search for existing Facility",
     "searchExistingHealthcareProfessionals": "Search for existing Healthcare Professionals",
     "labelModNoteInput": "Moderator Notes",
@@ -414,6 +416,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "Rejected",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -234,6 +234,8 @@
     "facilitySuccessfullyRejected": "Facility rejected successfully",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
     "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully",
     "searchExistingFacilities": "Search for existing Facility",
     "searchExistingHealthcareProfessionals": "Search for existing Healthcare Professionals",
     "labelModNoteInput": "Moderator Notes",
@@ -414,6 +416,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "Rejeitado",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -156,6 +156,7 @@
     "facilities": "Instalações",
     "healthcareProfessionals": "Profissionais de saúde",
     "forReview": "Para Revisão",
+    "new": "New",
     "approved": "Aprovado",
     "rejected": "Rejeitado",
     "submissions": "Submissions"

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -234,6 +234,8 @@
     "facilitySuccessfullyRejected": "Facility rejected successfully",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
     "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully",
     "searchExistingFacilities": "Search for existing Facility",
     "searchExistingHealthcareProfessionals": "Search for existing Healthcare Professionals",
     "labelModNoteInput": "Moderator Notes",
@@ -414,6 +416,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "Отклонено",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -156,6 +156,7 @@
     "facilities": "Услуги",
     "healthcareProfessionals": " Медицинские специалисты ",
     "forReview": " Для рассмотрения ",
+    "new": "New",
     "approved": "Одобрено",
     "rejected": "Отклонено",
     "submissions": "Submissions"

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -288,6 +288,8 @@
     "facilitySuccessfullyRejected": "Matagumpay na hindi na-apprubahan ang pasilidad",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
     "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully",
     "searchExistingFacilities": "Search for existing Facility",
     "searchExistingHealthcareProfessionals": "Search for existing Healthcare Professionals",
     "labelModNoteInput": "Moderator Notes",
@@ -414,6 +416,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "Hindi na-aprubahan",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -163,6 +163,7 @@
     "facilities": "Pasilidad",
     "healthcareProfessionals": "Mga Propesyonal sa Pangangalagang Pangkalusugan",
     "forReview": "Para sa Pagsusuri",
+    "new": "New",
     "approved": "Aprubado",
     "rejected": "Hindi na-aprubahan",
     "submissions": "Mga Isinumite"

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -163,6 +163,7 @@
     "facilities": "Cơ sở vật chất",
     "healthcareProfessionals": "Chuyên gia y tế",
     "forReview": "Đang xem xét",
+    "new": "New",
     "approved": "Đã được phê duyệt",
     "rejected": "Bị từ chối",
     "submissions": "Các bài gửi"

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -328,6 +328,8 @@
     "facilitySuccessfullyRejected": "Facility rejected successfully",
     "rejectSubmissionConfirmationMessage": "Are you sure you want to reject this submission?",
     "rejectSubmissionConfirmationButton": "Yes, reject the submission",
+    "successMessageUpdated": "Submission updated successfully",
+    "successMessageApproved": "Submission approved successfully",
     "searchExistingFacilities": "Search for existing Facility",
     "searchExistingHealthcareProfessionals": "Search for existing Healthcare Professionals",
     "labelModNoteInput": "Moderator Notes",
@@ -414,6 +416,7 @@
     "newSubmission": "New",
     "underReviewSubmission": "Under Review",
     "approvedSubmission": "Approved",
+    "rejectedSubmission": "Bị từ chối",
     "createdDate": "Created on",
     "updatedDate": "Updated last"
   },

--- a/layouts/moderationlayout.vue
+++ b/layouts/moderationlayout.vue
@@ -4,7 +4,7 @@
         class="h-dvh w-full font-sans text-primary-text bg-primary-bg flex flex-col"
     >
         <TopNav class="shrink-0" />
-        <main class="flex-1 overflow-y-auto">
+        <main class="flex-1 min-h-0 overflow-hidden flex flex-col">
             <NuxtPage />
         </main>
     </div>

--- a/layouts/my-page.vue
+++ b/layouts/my-page.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        data-testid="moderation-app"
+        data-testid="my-page-app"
         class="h-dvh w-full font-sans text-primary-text bg-primary-bg flex flex-col"
     >
         <TopNav class="shrink-0" />

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -3,7 +3,7 @@
         <Suspense>
             <div
                 data-testid="moderation-content"
-                class="h-full w-full flex flex-col flex-1 font-sans text-primary-text bg-primary-bg"
+                class="h-full w-full flex flex-col flex-1 min-h-0 font-sans text-primary-text bg-primary-bg"
             >
                 <div
                     v-if="authStore.isLoadingAuth"
@@ -34,10 +34,10 @@
                 <div
                     v-if="authStore.isLoggedIn"
                     data-testid="moderation-page"
-                    class="flex flex-col md:flex-row min-h-full"
+                    class="flex flex-col md:flex-row flex-1 min-h-0"
                 >
                     <ModLeftNavbar />
-                    <div class="w-full flex flex-col items-stretch p-3 md:p-4 gap-3 md:gap-4 min-h-0">
+                    <div class="w-full flex flex-col items-stretch p-3 md:p-4 gap-3 md:gap-4 min-h-0 flex-1">
                         <div
                             class="bg-secondary-bg border border-accent-bg rounded-xl
                             shadow-sm px-3 md:px-5 py-3 md:py-4"

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -74,7 +74,7 @@ import { definePageMeta, useI18n } from '#imports'
 
 // tell nuxt to our moderation layout
 definePageMeta({
-    layout: 'moderationlayout'
+    layout: 'my-page'
 })
 
 const { t } = useI18n()

--- a/pages/my-page.vue
+++ b/pages/my-page.vue
@@ -1,9 +1,9 @@
 <template>
-    <div>
+    <div class="h-full min-h-0 flex flex-col">
         <Suspense>
             <div
                 data-testid="moderation-content"
-                class="h-full w-full flex flex-col flex-1 min-h-0 font-sans text-primary-text bg-primary-bg"
+                class="h-full w-full flex flex-col flex-1 min-h-0 overflow-hidden font-sans text-primary-text bg-primary-bg"
             >
                 <div
                     v-if="authStore.isLoadingAuth"
@@ -34,13 +34,13 @@
                 <div
                     v-if="authStore.isLoggedIn"
                     data-testid="moderation-page"
-                    class="flex flex-col md:flex-row flex-1 min-h-0"
+                    class="flex flex-col md:flex-row flex-1 min-h-0 h-full overflow-hidden p-3 md:p-4 gap-3 md:gap-4"
                 >
                     <ModLeftNavbar />
-                    <div class="w-full flex flex-col items-stretch p-3 md:p-4 gap-3 md:gap-4 min-h-0 flex-1">
+                    <div class="w-full flex flex-col items-stretch gap-3 md:gap-4 min-h-0 flex-1 overflow-hidden">
                         <div
                             v-if="!isSettingsView"
-                            class="bg-secondary-bg border border-accent-bg rounded-xl
+                            class="shrink-0 bg-secondary-bg border border-accent-bg rounded-xl
                             shadow-sm px-3 md:px-5 py-3 md:py-4"
                         >
                             <ModTopbar />
@@ -79,8 +79,8 @@ import { useAuthStore } from '~/stores/authStore'
 import { definePageMeta, useI18n } from '#imports'
 
 definePageMeta({
-    layout: 'moderationlayout',
-    key: route => route.fullPath
+    layout: 'my-page',
+    key: 'my-page'
 })
 
 const { t } = useI18n()

--- a/pages/my-page.vue
+++ b/pages/my-page.vue
@@ -3,7 +3,7 @@
         <Suspense>
             <div
                 data-testid="moderation-content"
-                class="h-full w-full flex flex-col flex-1 font-sans text-primary-text bg-primary-bg"
+                class="h-full w-full flex flex-col flex-1 min-h-0 font-sans text-primary-text bg-primary-bg"
             >
                 <div
                     v-if="authStore.isLoadingAuth"
@@ -34,10 +34,10 @@
                 <div
                     v-if="authStore.isLoggedIn"
                     data-testid="moderation-page"
-                    class="flex flex-col md:flex-row min-h-full"
+                    class="flex flex-col md:flex-row flex-1 min-h-0"
                 >
                     <ModLeftNavbar />
-                    <div class="w-full flex flex-col items-stretch p-3 md:p-4 gap-3 md:gap-4 min-h-0">
+                    <div class="w-full flex flex-col items-stretch p-3 md:p-4 gap-3 md:gap-4 min-h-0 flex-1">
                         <div
                             v-if="!isSettingsView"
                             class="bg-secondary-bg border border-accent-bg rounded-xl

--- a/plugins/unsaved-changes-plugin.client.ts
+++ b/plugins/unsaved-changes-plugin.client.ts
@@ -27,7 +27,7 @@ export default defineNuxtPlugin({
             const submissionUnsavedStore = useModerationSubmissionUnsavedStore(nuxtApp.$pinia)
 
             nuxtApp.$router.beforeEach(() => {
-                if (!isGloballyDirty.value && !submissionUnsavedStore.isEditSubmissionFormDirty) return true
+                if (!isGloballyDirty.value) return true
 
                 return new Promise<boolean>(resolve => {
                     const message = nuxtApp.$i18n?.t('modEditFacilityOrHPTopbar.hasUnsavedChanges')
@@ -37,7 +37,11 @@ export default defineNuxtPlugin({
                         resolve(true)
                         return
                     }
-                    confirm(() => resolve(true), {
+                    confirm(() => {
+                        activeDirtyIds.clear()
+                        submissionUnsavedStore.setEditSubmissionFormDirty(false)
+                        resolve(true)
+                    }, {
                         mode: confirmationMode.value,
                         onCancel: () => resolve(false),
                         message
@@ -53,7 +57,8 @@ export default defineNuxtPlugin({
             provide: {
                 unsavedChangesRegistry: {
                     register: (id: symbol, mode: 'create' | 'update') => activeDirtyIds.set(id, mode),
-                    unregister: (id: symbol) => activeDirtyIds.delete(id)
+                    unregister: (id: symbol) => activeDirtyIds.delete(id),
+                    clearAll: () => activeDirtyIds.clear()
                 }
             }
         }

--- a/stores/moderationSubmissionUnsavedStore.ts
+++ b/stores/moderationSubmissionUnsavedStore.ts
@@ -1,38 +1,55 @@
 import { defineStore } from 'pinia'
 import { ref, type Ref } from 'vue'
 
+type TryLeaveFn = (onLeave: () => void | Promise<void>) => void
+
 /**
  * Router unsaved-changes guard reads this in addition to useUnsavedChanges' registry
  * so submission-edit dirty state is always visible during navigation.
  *
- * Submission back uses tryClose (not router.push alone): the moderation UI stays on `/moderation`
- * and duplicate navigations never run beforeEach, so the topbar calls the registered tryClose.
+ * Form back/home actions call runLeaveOr (not router.push alone): the active edit form
+ * registers tryLeave so confirmations run before leaving.
  */
 export const useModerationSubmissionUnsavedStore = defineStore('moderationSubmissionUnsaved', () => {
     const isEditSubmissionFormDirty: Ref<boolean> = ref(false)
-    const editSubmissionTryClose: Ref<(() => void) | null> = ref(null)
+    const editFormTryLeave: Ref<TryLeaveFn | null> = ref(null)
 
     function setEditSubmissionFormDirty(value: boolean) {
         isEditSubmissionFormDirty.value = value
     }
 
+    function registerEditFormTryLeave(fn: TryLeaveFn | null) {
+        editFormTryLeave.value = fn
+    }
+
+    /** @deprecated Use registerEditFormTryLeave */
     function registerEditSubmissionTryClose(fn: (() => void) | null) {
-        editSubmissionTryClose.value = fn
+        if (!fn) {
+            registerEditFormTryLeave(null)
+            return
+        }
+        registerEditFormTryLeave(onLeave => onLeave(fn))
+    }
+
+    function runLeaveOr(onLeave: () => void | Promise<void>) {
+        const fn = editFormTryLeave.value
+        if (fn) {
+            fn(onLeave)
+            return
+        }
+        void onLeave()
     }
 
     function runEditSubmissionBackOr(fallback: () => void | Promise<void>) {
-        const fn = editSubmissionTryClose.value
-        if (fn) {
-            fn()
-            return
-        }
-        void fallback()
+        runLeaveOr(fallback)
     }
 
     return {
         isEditSubmissionFormDirty,
         setEditSubmissionFormDirty,
+        registerEditFormTryLeave,
         registerEditSubmissionTryClose,
+        runLeaveOr,
         runEditSubmissionBackOr
     }
 })

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -13,34 +13,30 @@ export enum SelectedSubmissionListViewTab {
     Rejected = 'REJECTED'
 }
 
-export enum SubmissionStatus {
-    InReview = 'IN_REVIEW',
-    Approved = 'APPROVED',
-    Rejected = 'REJECTED'
-}
-
 export enum SelectedModerationListView {
     Facilities = 'FACILITIES',
     HealthcareProfessionals = 'HEALTHCARE_PROFESSIONALS',
     Submissions = 'SUBMISSIONS'
 }
 
+type SubmissionStatusFilter = Pick<SubmissionSearchFilters, 'isUnderReview' | 'isApproved' | 'isRejected'>
+
+const SUBMISSION_TAB_FILTERS: Record<SelectedSubmissionListViewTab, SubmissionStatusFilter> = {
+    [SelectedSubmissionListViewTab.ForReview]: { isUnderReview: true },
+    [SelectedSubmissionListViewTab.Approved]: { isApproved: true },
+    [SelectedSubmissionListViewTab.Rejected]: { isRejected: true }
+}
+
+const SUBMISSION_STATUS_COUNT_QUERIES = [
+    { countKey: 'forReviewCount', filter: { isUnderReview: true } },
+    { countKey: 'approvedCount', filter: { isApproved: true } },
+    { countKey: 'rejectedCount', filter: { isRejected: true } }
+] as const
+
 interface SubmissionStatusCounts {
     forReviewCount: number
     approvedCount: number
     rejectedCount: number
-}
-
-function getStatusFiltersForTab(tab: SelectedSubmissionListViewTab): Partial<SubmissionSearchFilters> {
-    switch (tab) {
-        case SelectedSubmissionListViewTab.Approved:
-            return { isApproved: true }
-        case SelectedSubmissionListViewTab.Rejected:
-            return { isRejected: true }
-        case SelectedSubmissionListViewTab.ForReview:
-        default:
-            return { isUnderReview: true }
-    }
 }
 
 export const useModerationSubmissionsStore = defineStore(
@@ -89,11 +85,10 @@ export const useModerationSubmissionsStore = defineStore(
         }
 
         async function getSubmissions() {
-            const statusFilters = getStatusFiltersForTab(selectedModerationListViewTabChosen.value)
             const filters: SubmissionSearchFilters = {
                 offset: currentOffset.value,
                 limit: itemsPerPage.value,
-                ...statusFilters
+                ...SUBMISSION_TAB_FILTERS[selectedModerationListViewTabChosen.value]
             }
             try {
                 const { filteredSearchResults, totalCount } = await fetchSubmissionsWithCount(filters)
@@ -112,17 +107,22 @@ export const useModerationSubmissionsStore = defineStore(
 
         async function fetchStatusCounts() {
             try {
-                const [forReviewResult, approvedResult, rejectedResult] = await Promise.all([
-                    fetchSubmissionsWithCount({ isUnderReview: true, limit: 1, offset: 0 }),
-                    fetchSubmissionsWithCount({ isApproved: true, limit: 1, offset: 0 }),
-                    fetchSubmissionsWithCount({ isRejected: true, limit: 1, offset: 0 })
-                ])
+                const countResults = await Promise.all(
+                    SUBMISSION_STATUS_COUNT_QUERIES.map(({ filter }) =>
+                        fetchSubmissionsWithCount({ ...filter, limit: 1, offset: 0 }))
+                )
 
-                statusTotalCounts.value = {
-                    forReviewCount: forReviewResult.totalCount,
-                    approvedCount: approvedResult.totalCount,
-                    rejectedCount: rejectedResult.totalCount
-                }
+                statusTotalCounts.value = SUBMISSION_STATUS_COUNT_QUERIES.reduce(
+                    (counts, { countKey }, index) => {
+                        counts[countKey] = countResults[index]?.totalCount ?? 0
+                        return counts
+                    },
+                    {
+                        forReviewCount: 0,
+                        approvedCount: 0,
+                        rejectedCount: 0
+                    }
+                )
             } catch (error) {
                 console.error(`Error fetching submission status counts: ${JSON.stringify(error)}`)
             }

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -25,6 +25,24 @@ export enum SelectedModerationListView {
     Submissions = 'SUBMISSIONS'
 }
 
+interface SubmissionStatusCounts {
+    forReviewCount: number
+    approvedCount: number
+    rejectedCount: number
+}
+
+function getStatusFiltersForTab(tab: SelectedSubmissionListViewTab): Partial<SubmissionSearchFilters> {
+    switch (tab) {
+        case SelectedSubmissionListViewTab.Approved:
+            return { isApproved: true }
+        case SelectedSubmissionListViewTab.Rejected:
+            return { isRejected: true }
+        case SelectedSubmissionListViewTab.ForReview:
+        default:
+            return { isForReview: true }
+    }
+}
+
 export const useModerationSubmissionsStore = defineStore(
     'modSubmissionsStore',
     () => {
@@ -37,11 +55,13 @@ export const useModerationSubmissionsStore = defineStore(
         const didMutationFail: Ref<boolean> = ref(false)
         const selectedModerationListViewTabChosen: Ref<SelectedSubmissionListViewTab>
             = ref(SelectedSubmissionListViewTab.ForReview)
-        const submissionStatusFilterEnabled: Ref<boolean> = ref(false)
+        const statusTotalCounts: Ref<SubmissionStatusCounts> = ref({
+            forReviewCount: 0,
+            approvedCount: 0,
+            rejectedCount: 0
+        })
 
-        // Used for store the total number of submissions found by the current search query.
         const totalSubmissionsCount: Ref<number> = ref(0)
-        // Used for store the starting index (offset) for the current page of results.
         const currentOffset: Ref<number> = ref(0)
         const itemsPerPage: Ref<number> = ref(25)
         const hasNextPage = computed(() => currentOffset.value + itemsPerPage.value < totalSubmissionsCount.value)
@@ -51,24 +71,60 @@ export const useModerationSubmissionsStore = defineStore(
             didMutationFail.value = newValue
         }
 
+        function applySearchFilter(submissions: Submission[]) {
+            const query = submissionSearchQuery.value.trim().toLowerCase()
+            if (!query) {
+                return submissions
+            }
+            return submissions.filter((submission: Submission) => {
+                const submissionId = submission.id.toLowerCase()
+                const healthcareProfessionalName = submission.healthcareProfessionalName.toLowerCase()
+                const facilityNameEn = submission.facility?.nameEn?.toLowerCase() || ''
+                const facilityNameJa = submission.facility?.nameJa?.toLowerCase() || ''
+                return submissionId.includes(query)
+                  || healthcareProfessionalName.includes(query)
+                  || facilityNameEn.includes(query)
+                  || facilityNameJa.includes(query)
+            })
+        }
+
         async function getSubmissions() {
+            const statusFilters = getStatusFiltersForTab(selectedModerationListViewTabChosen.value)
             const filters: SubmissionSearchFilters = {
                 offset: currentOffset.value,
-                limit: itemsPerPage.value
+                limit: itemsPerPage.value,
+                ...statusFilters
             }
             try {
-                // Call the utility function to fetch the paginated data and the total count.
                 const { filteredSearchResults, totalCount } = await fetchSubmissionsWithCount(filters)
                 submissionsData.value = filteredSearchResults
                 totalSubmissionsCount.value = totalCount
-                // Apply a secondary filter on the fetched data based on the currently selected tab.
-                filterSubmissionByStatus(selectedModerationListViewTabChosen.value as unknown as SubmissionStatus)
+                filteredSubmissionDataForListComponent.value = applySearchFilter(filteredSearchResults)
             } catch (error) {
                 console.error(`Error fetching submissions: ${JSON.stringify(error)}`)
                 //eslint-disable-next-line
                 alert('Error loading submissions. Please try again later.')
                 submissionsData.value = []
+                filteredSubmissionDataForListComponent.value = []
                 totalSubmissionsCount.value = 0
+            }
+        }
+
+        async function fetchStatusCounts() {
+            try {
+                const [forReviewResult, approvedResult, rejectedResult] = await Promise.all([
+                    fetchSubmissionsWithCount({ isForReview: true, limit: 1, offset: 0 }),
+                    fetchSubmissionsWithCount({ isApproved: true, limit: 1, offset: 0 }),
+                    fetchSubmissionsWithCount({ isRejected: true, limit: 1, offset: 0 })
+                ])
+
+                statusTotalCounts.value = {
+                    forReviewCount: forReviewResult.totalCount,
+                    approvedCount: approvedResult.totalCount,
+                    rejectedCount: rejectedResult.totalCount
+                }
+            } catch (error) {
+                console.error(`Error fetching submission status counts: ${JSON.stringify(error)}`)
             }
         }
 
@@ -81,61 +137,19 @@ export const useModerationSubmissionsStore = defineStore(
             selectedModerationListViewChosen.value = selectedOption
         }
 
-        function setSelectedModerationListViewTabChosen(selectedOption: SelectedSubmissionListViewTab) {
+        async function setSelectedModerationListViewTabChosen(selectedOption: SelectedSubmissionListViewTab) {
             selectedModerationListViewTabChosen.value = selectedOption
-            submissionStatusFilterEnabled.value = true
+            currentOffset.value = 0
+            await getSubmissions()
         }
 
         function filterSelectedSubmission(submissionId: string | undefined) {
             selectedSubmissionData.value = submissionsData.value.find(submission => submission.id === submissionId)
         }
 
-        function filterSubmissionByStatus(submissionStatus: SubmissionStatus) {
-            const applySearch = (submissions: Submission[]) => {
-                const query = submissionSearchQuery.value.trim().toLowerCase()
-                if (!query) {
-                    return submissions
-                }
-                return submissions.filter((submission: Submission) => {
-                    const submissionId = submission.id.toLowerCase()
-                    const healthcareProfessionalName = submission.healthcareProfessionalName.toLowerCase()
-                    const facilityNameEn = submission.facility?.nameEn?.toLowerCase() || ''
-                    const facilityNameJa = submission.facility?.nameJa?.toLowerCase() || ''
-                    return submissionId.includes(query)
-                      || healthcareProfessionalName.includes(query)
-                      || facilityNameEn.includes(query)
-                      || facilityNameJa.includes(query)
-                })
-            }
-
-            const shouldApplyStatusFilter = submissionStatusFilterEnabled.value
-            if (!shouldApplyStatusFilter) {
-                filteredSubmissionDataForListComponent.value = applySearch(submissionsData.value)
-                return
-            }
-
-            switch (submissionStatus) {
-                case SubmissionStatus.InReview:
-                    filteredSubmissionDataForListComponent.value = applySearch(submissionsData.value
-                        .filter((submission: Submission) => {
-                            const isNewSubmission = !submission.isRejected && !submission.isApproved && !submission.isUnderReview
-                            return submission.isUnderReview || isNewSubmission
-                        }))
-                    break
-                case SubmissionStatus.Approved:
-                    filteredSubmissionDataForListComponent.value = applySearch(submissionsData.value
-                        .filter((submission: Submission) => submission.isApproved))
-                    break
-                case SubmissionStatus.Rejected:
-                    filteredSubmissionDataForListComponent.value = applySearch(submissionsData.value
-                        .filter((submission: Submission) => submission.isRejected))
-                    break
-            }
-        }
-
         function setSubmissionSearchQuery(newQuery: string) {
             submissionSearchQuery.value = newQuery
-            filterSubmissionByStatus(selectedModerationListViewTabChosen.value as unknown as SubmissionStatus)
+            filteredSubmissionDataForListComponent.value = applySearchFilter(submissionsData.value)
         }
 
         async function updateSubmission(
@@ -158,7 +172,6 @@ export const useModerationSubmissionsStore = defineStore(
                 return serverResponse
             }
 
-            // Update the submission in the submissionsData array
             const indexOfOutdatedSubmissionData = submissionsData.value
                 .findIndex(submission => submission.id === updatedSubmission.id)
 
@@ -169,6 +182,8 @@ export const useModerationSubmissionsStore = defineStore(
             }
 
             selectedSubmissionData.value = updatedSubmission
+            filteredSubmissionDataForListComponent.value = applySearchFilter(submissionsData.value)
+            await fetchStatusCounts()
 
             return serverResponse
         }
@@ -211,8 +226,8 @@ export const useModerationSubmissionsStore = defineStore(
 
         return {
             getSubmissions,
+            fetchStatusCounts,
             submissionsData,
-            filterSubmissionByStatus,
             filteredSubmissionDataForListComponent,
             submissionSearchQuery,
             setSubmissionSearchQuery,
@@ -225,6 +240,7 @@ export const useModerationSubmissionsStore = defineStore(
             setSelectedModerationListViewChosen,
             selectedModerationListViewTabChosen,
             setSelectedModerationListViewTabChosen,
+            statusTotalCounts,
             updateSubmission,
             approveSubmission,
             rejectSubmission,

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -6,8 +6,10 @@ import type { Submission, MutationUpdateSubmissionArgs, Mutation, SubmissionSear
 import { gqlClient, graphQLClientRequestWithRetry } from '~/utils/graphql.js'
 import type { ServerResponse } from '~/typedefs/serverResponse'
 import { useTranslation } from '~/composables/useTranslation'
+import { isNewSubmission } from '~/utils/moderationUtils'
 
 export enum SelectedSubmissionListViewTab {
+    New = 'NEW',
     ForReview = 'FOR_REVIEW',
     Approved = 'APPROVED',
     Rejected = 'REJECTED'
@@ -21,7 +23,7 @@ export enum SelectedModerationListView {
 
 type SubmissionStatusFilter = Pick<SubmissionSearchFilters, 'isUnderReview' | 'isApproved' | 'isRejected'>
 
-const SUBMISSION_TAB_FILTERS: Record<SelectedSubmissionListViewTab, SubmissionStatusFilter> = {
+const SUBMISSION_TAB_FILTERS: Partial<Record<SelectedSubmissionListViewTab, SubmissionStatusFilter>> = {
     [SelectedSubmissionListViewTab.ForReview]: { isUnderReview: true },
     [SelectedSubmissionListViewTab.Approved]: { isApproved: true },
     [SelectedSubmissionListViewTab.Rejected]: { isRejected: true }
@@ -33,7 +35,10 @@ const SUBMISSION_STATUS_COUNT_QUERIES = [
     { countKey: 'rejectedCount', filter: { isRejected: true } }
 ] as const
 
+const NEW_SUBMISSIONS_FETCH_LIMIT = 1000
+
 interface SubmissionStatusCounts {
+    newCount: number
     forReviewCount: number
     approvedCount: number
     rejectedCount: number
@@ -50,8 +55,9 @@ export const useModerationSubmissionsStore = defineStore(
         const submissionSearchQuery: Ref<string> = ref('')
         const didMutationFail: Ref<boolean> = ref(false)
         const selectedModerationListViewTabChosen: Ref<SelectedSubmissionListViewTab>
-            = ref(SelectedSubmissionListViewTab.ForReview)
+            = ref(SelectedSubmissionListViewTab.New)
         const statusTotalCounts: Ref<SubmissionStatusCounts> = ref({
+            newCount: 0,
             forReviewCount: 0,
             approvedCount: 0,
             rejectedCount: 0
@@ -60,6 +66,7 @@ export const useModerationSubmissionsStore = defineStore(
         const totalSubmissionsCount: Ref<number> = ref(0)
         const currentOffset: Ref<number> = ref(0)
         const itemsPerPage: Ref<number> = ref(25)
+        const cachedNewSubmissions: Ref<Submission[]> = ref([])
         const hasNextPage = computed(() => currentOffset.value + itemsPerPage.value < totalSubmissionsCount.value)
         const hasPrevPage = computed(() => currentOffset.value > 0)
 
@@ -84,13 +91,39 @@ export const useModerationSubmissionsStore = defineStore(
             })
         }
 
+        async function fetchNewSubmissions() {
+            const { filteredSearchResults } = await fetchSubmissionsWithCount({
+                limit: NEW_SUBMISSIONS_FETCH_LIMIT,
+                offset: 0
+            })
+            return filteredSearchResults.filter(isNewSubmission)
+        }
+
+        function applyNewTabListView(newSubmissions: Submission[]) {
+            cachedNewSubmissions.value = newSubmissions
+            const searchFiltered = applySearchFilter(newSubmissions)
+            totalSubmissionsCount.value = searchFiltered.length
+            submissionsData.value = searchFiltered.slice(
+                currentOffset.value,
+                currentOffset.value + itemsPerPage.value
+            )
+            filteredSubmissionDataForListComponent.value = submissionsData.value
+        }
+
         async function getSubmissions() {
-            const filters: SubmissionSearchFilters = {
-                offset: currentOffset.value,
-                limit: itemsPerPage.value,
-                ...SUBMISSION_TAB_FILTERS[selectedModerationListViewTabChosen.value]
-            }
             try {
+                if (selectedModerationListViewTabChosen.value === SelectedSubmissionListViewTab.New) {
+                    applyNewTabListView(await fetchNewSubmissions())
+                    return
+                }
+
+                cachedNewSubmissions.value = []
+
+                const filters: SubmissionSearchFilters = {
+                    offset: currentOffset.value,
+                    limit: itemsPerPage.value,
+                    ...SUBMISSION_TAB_FILTERS[selectedModerationListViewTabChosen.value]
+                }
                 const { filteredSearchResults, totalCount } = await fetchSubmissionsWithCount(filters)
                 submissionsData.value = filteredSearchResults
                 totalSubmissionsCount.value = totalCount
@@ -107,10 +140,11 @@ export const useModerationSubmissionsStore = defineStore(
 
         async function fetchStatusCounts() {
             try {
-                const countResults = await Promise.all(
-                    SUBMISSION_STATUS_COUNT_QUERIES.map(({ filter }) =>
+                const [newSubmissions, ...countResults] = await Promise.all([
+                    fetchNewSubmissions(),
+                    ...SUBMISSION_STATUS_COUNT_QUERIES.map(({ filter }) =>
                         fetchSubmissionsWithCount({ ...filter, limit: 1, offset: 0 }))
-                )
+                ])
 
                 statusTotalCounts.value = SUBMISSION_STATUS_COUNT_QUERIES.reduce(
                     (counts, { countKey }, index) => {
@@ -118,6 +152,7 @@ export const useModerationSubmissionsStore = defineStore(
                         return counts
                     },
                     {
+                        newCount: newSubmissions.length,
                         forReviewCount: 0,
                         approvedCount: 0,
                         rejectedCount: 0
@@ -149,6 +184,10 @@ export const useModerationSubmissionsStore = defineStore(
 
         function setSubmissionSearchQuery(newQuery: string) {
             submissionSearchQuery.value = newQuery
+            if (selectedModerationListViewTabChosen.value === SelectedSubmissionListViewTab.New) {
+                applyNewTabListView(cachedNewSubmissions.value)
+                return
+            }
             filteredSubmissionDataForListComponent.value = applySearchFilter(submissionsData.value)
         }
 
@@ -182,8 +221,8 @@ export const useModerationSubmissionsStore = defineStore(
             }
 
             selectedSubmissionData.value = updatedSubmission
-            filteredSubmissionDataForListComponent.value = applySearchFilter(submissionsData.value)
             await fetchStatusCounts()
+            await getSubmissions()
 
             return serverResponse
         }

--- a/stores/moderationSubmissionsStore.ts
+++ b/stores/moderationSubmissionsStore.ts
@@ -39,7 +39,7 @@ function getStatusFiltersForTab(tab: SelectedSubmissionListViewTab): Partial<Sub
             return { isRejected: true }
         case SelectedSubmissionListViewTab.ForReview:
         default:
-            return { isForReview: true }
+            return { isUnderReview: true }
     }
 }
 
@@ -113,7 +113,7 @@ export const useModerationSubmissionsStore = defineStore(
         async function fetchStatusCounts() {
             try {
                 const [forReviewResult, approvedResult, rejectedResult] = await Promise.all([
-                    fetchSubmissionsWithCount({ isForReview: true, limit: 1, offset: 0 }),
+                    fetchSubmissionsWithCount({ isUnderReview: true, limit: 1, offset: 0 }),
                     fetchSubmissionsWithCount({ isApproved: true, limit: 1, offset: 0 }),
                     fetchSubmissionsWithCount({ isRejected: true, limit: 1, offset: 0 })
                 ])

--- a/tests/e2e/moderationDashboard.spec.ts
+++ b/tests/e2e/moderationDashboard.spec.ts
@@ -8,6 +8,7 @@ test.describe('Moderation dashboard', () => {
         await page.waitForLoadState('domcontentloaded')
         await expect(page.getByTestId('mod-access-panel')).toBeVisible({ timeout: 30_000 })
         await expect(page.getByTestId('access-page-link-moderation-submissions')).toBeVisible({ timeout: 30_000 })
+        await expect(page.getByRole('button', { name: new RegExp(enUS.modDashboardLeftNav.new, 'i') })).toBeVisible()
         await expect(page.getByRole('button', { name: new RegExp(enUS.modDashboardLeftNav.forReview, 'i') })).toBeVisible()
     })
 
@@ -30,8 +31,9 @@ test.describe('Moderation dashboard', () => {
         await expect(page.getByTestId('access-page-link-moderation-submissions')).toBeVisible({ timeout: 30_000 })
     })
 
-    test('shows left nav for submissions with For Review, Approved, Rejected',
+    test('shows left nav for submissions with New, For Review, Approved, Rejected',
          async ({ page }) => {
+             await expect(page.getByRole('button', { name: new RegExp(enUS.modDashboardLeftNav.new, 'i') })).toBeVisible()
              await expect(page.getByRole('button', { name: new RegExp(enUS.modDashboardLeftNav.forReview, 'i') })).toBeVisible()
              await expect(page.getByRole('button', { name: new RegExp(enUS.modDashboardLeftNav.approved, 'i') })).toBeVisible()
              await expect(page.getByRole('button', { name: new RegExp(enUS.modDashboardLeftNav.rejected, 'i') })).toBeVisible()

--- a/tests/e2e/moderationEditSubmissionModal.spec.ts
+++ b/tests/e2e/moderationEditSubmissionModal.spec.ts
@@ -3,6 +3,8 @@ import { test, expect, type Page } from '@playwright/test'
 
 async function navigateToFirstSubmissionEditPage(page: Page) {
     await page.getByTestId('access-page-link-moderation-submissions').click()
+    // Default tab is "New"; CI seed data has submissions under "For Review".
+    await page.getByRole('button', { name: new RegExp(enUS.modDashboardLeftNav.forReview, 'i') }).click()
     const firstSubmission = page.locator('[data-testid^="mod-submission-list-item-"]').first()
     await expect(firstSubmission).toBeVisible()
     await firstSubmission.click()

--- a/typedefs/gqlTypes.ts
+++ b/typedefs/gqlTypes.ts
@@ -993,6 +993,8 @@ export type SubmissionSearchFilters = {
   healthcareProfessionalName?: InputMaybe<Scalars['String']['input']>;
   /** Filter to approved submissions. */
   isApproved?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Filter to submissions needing review (pending or under review). */
+  isForReview?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter to rejected submissions. */
   isRejected?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter to submissions under review. */

--- a/typedefs/gqlTypes.ts
+++ b/typedefs/gqlTypes.ts
@@ -993,8 +993,6 @@ export type SubmissionSearchFilters = {
   healthcareProfessionalName?: InputMaybe<Scalars['String']['input']>;
   /** Filter to approved submissions. */
   isApproved?: InputMaybe<Scalars['Boolean']['input']>;
-  /** Filter to submissions needing review (pending or under review). */
-  isForReview?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter to rejected submissions. */
   isRejected?: InputMaybe<Scalars['Boolean']['input']>;
   /** Filter to submissions under review. */

--- a/utils/moderationFormValidationUtils.ts
+++ b/utils/moderationFormValidationUtils.ts
@@ -1,3 +1,4 @@
+import type { CreateHealthcareProfessionalInput } from '~/typedefs/gqlTypes'
 import {
     validateAddressLineEn,
     validateAddressLineJa,
@@ -54,11 +55,10 @@ type FacilityValidationFields = {
     postalCode?: string
 }
 
-type HealthcareProfessionalValidationFields = {
-    acceptedInsurance: string[]
-    degrees: string[]
-    spokenLanguages: string[]
-}
+type HealthcareProfessionalValidationFields = Pick<
+    CreateHealthcareProfessionalInput,
+    'acceptedInsurance' | 'degrees' | 'spokenLanguages'
+>
 
 type NormalizedFacilityValidationFields = {
     nameEn: string
@@ -165,7 +165,7 @@ export function validateModerationFacilityFields(fields: FacilityValidationField
 export function hasRequiredHealthcareProfessionalSelections(
     fields: HealthcareProfessionalValidationFields
 ): boolean {
-    return fields.acceptedInsurance.length > 0
-      && fields.degrees.length > 0
-      && fields.spokenLanguages.length > 0
+    return (fields.acceptedInsurance?.length ?? 0) > 0
+      && (fields.degrees?.length ?? 0) > 0
+      && (fields.spokenLanguages?.length ?? 0) > 0
 }

--- a/utils/moderationUtils.ts
+++ b/utils/moderationUtils.ts
@@ -7,6 +7,14 @@ import {
 import { useModerationSubmissionUnsavedStore } from '~/stores/moderationSubmissionUnsavedStore'
 import type { ServerError } from '~/typedefs/serverResponse'
 
+import type { Submission } from '~/typedefs/gqlTypes'
+
+export function isNewSubmission(
+    submission: Pick<Submission, 'isApproved' | 'isRejected' | 'isUnderReview'>
+): boolean {
+    return !submission.isRejected && !submission.isApproved && !submission.isUnderReview
+}
+
 export type ModerationDashboardView = 'submissions' | 'facilities' | 'healthcare-professionals'
 
 const MY_PAGE_FORM_ROUTE = /^\/(?:my-page|moderation)\/(?:edit-|create-)/

--- a/utils/moderationUtils.ts
+++ b/utils/moderationUtils.ts
@@ -1,6 +1,19 @@
 import { isNavigationFailure, NavigationFailureType, type Router } from 'vue-router'
 import { ModerationScreen } from '~/stores/moderationScreenStore'
+import {
+    SelectedModerationListView,
+    useModerationSubmissionsStore
+} from '~/stores/moderationSubmissionsStore'
+import { useModerationSubmissionUnsavedStore } from '~/stores/moderationSubmissionUnsavedStore'
 import type { ServerError } from '~/typedefs/serverResponse'
+
+export type ModerationDashboardView = 'submissions' | 'facilities' | 'healthcare-professionals'
+
+const MY_PAGE_FORM_ROUTE = /^\/(?:my-page|moderation)\/(?:edit-|create-)/
+
+export function isMyPageFormRoute(path: string): boolean {
+    return MY_PAGE_FORM_ROUTE.test(path)
+}
 
 export function hasServerErrors(
     response: { errors?: ServerError[] } | undefined
@@ -8,18 +21,90 @@ export function hasServerErrors(
     return !!response?.errors?.length
 }
 
-export async function navigateToModerationDashboard(
+export function getModerationDashboardViewForScreen(activeScreen: ModerationScreen): ModerationDashboardView {
+    switch (activeScreen) {
+        case ModerationScreen.EditFacility:
+        case ModerationScreen.CreateFacility:
+            return 'facilities'
+        case ModerationScreen.EditHealthcareProfessional:
+        case ModerationScreen.CreateHealthcareProfessional:
+            return 'healthcare-professionals'
+        default:
+            return 'submissions'
+    }
+}
+
+function syncModerationListView(view: ModerationDashboardView) {
+    const moderationSubmissionsStore = useModerationSubmissionsStore()
+    switch (view) {
+        case 'facilities':
+            moderationSubmissionsStore.setSelectedModerationListViewChosen(SelectedModerationListView.Facilities)
+            break
+        case 'healthcare-professionals':
+            moderationSubmissionsStore.setSelectedModerationListViewChosen(
+                SelectedModerationListView.HealthcareProfessionals
+            )
+            break
+        default:
+            moderationSubmissionsStore.setSelectedModerationListViewChosen(SelectedModerationListView.Submissions)
+    }
+}
+
+/** Clears router-guard blockers so programmatic navigation can complete. */
+export function clearModerationNavigationBlockers() {
+    const { $unsavedChangesRegistry } = useNuxtApp()
+    $unsavedChangesRegistry?.clearAll?.()
+    useModerationSubmissionUnsavedStore().setEditSubmissionFormDirty(false)
+}
+
+/**
+ * Leave an edit/create form and return to the my-page dashboard.
+ * Sets screen + list tab first, clears unsaved blockers, then updates the URL.
+ */
+export async function leaveToModerationDashboard(
+    router: Router,
+    moderationScreenStore: {
+        setActiveScreen: (screen: ModerationScreen) => void
+        activeScreen: ModerationScreen
+    },
+    modalStore?: { hideModal: () => void },
+    view?: ModerationDashboardView
+) {
+    const targetView = view ?? getModerationDashboardViewForScreen(moderationScreenStore.activeScreen)
+
+    syncModerationListView(targetView)
+    clearModerationNavigationBlockers()
+    moderationScreenStore.setActiveScreen(ModerationScreen.Dashboard)
+    modalStore?.hideModal()
+
+    const navigationResult = await router.push(`/my-page?view=${targetView}`)
+    if (isNavigationFailure(navigationResult)
+      && !isNavigationFailure(navigationResult, NavigationFailureType.duplicated)) {
+        return
+    }
+}
+
+export async function leaveToAppHome(
     router: Router,
     moderationScreenStore: { setActiveScreen: (screen: ModerationScreen) => void },
     modalStore?: { hideModal: () => void }
 ) {
-    const navigationResult = await router.push('/my-page?view=submissions')
-    if (isNavigationFailure(navigationResult)) {
-        // Already on `/my-page` (dashboard + edit share one route); still switch Pinia screen.
-        if (!isNavigationFailure(navigationResult, NavigationFailureType.duplicated)) {
-            return
-        }
-    }
-    modalStore?.hideModal()
+    clearModerationNavigationBlockers()
     moderationScreenStore.setActiveScreen(ModerationScreen.Dashboard)
+    modalStore?.hideModal()
+
+    const navigationResult = await router.push('/')
+    if (isNavigationFailure(navigationResult)
+      && !isNavigationFailure(navigationResult, NavigationFailureType.duplicated)) {
+        return
+    }
 }
+
+/** @deprecated Use leaveToModerationDashboard */
+export const exitToModerationDashboard = leaveToModerationDashboard
+
+/** @deprecated Use leaveToModerationDashboard */
+export const navigateToModerationDashboard = leaveToModerationDashboard
+
+/** @deprecated Use leaveToAppHome */
+export const navigateToAppHome = leaveToAppHome


### PR DESCRIPTION
## Summary

This PR cleans up the My Page moderation experience: layout, navigation, and form flows are more consistent, and several bugs that blocked back/home/update-and-exit are fixed.

- Rename `moderationlayout` to `my-page` and make the page full-viewport with a scrollable center panel so the sidebar stays a fixed height
- Fix back, home, and update-and-exit navigation from edit/create forms, including correct return to the submissions (or facilities/HP) tab
- Fix unsaved-changes handling so programmatic navigation is not blocked after save or confirm-leave
- Add missing UI polish: rejected submission badge, form button padding, success toast i18n keys, and permissions loading no longer re-fetches on every in-page navigation

## Changes

### Layout & structure
- Renamed `layouts/moderationlayout.vue` → `layouts/my-page.vue`; pages now use `layout: 'my-page'`
- My Page uses a stable route key (`my-page`) so switching between list and edit views does not remount the whole page
- Full-height layout with overflow constrained to the center content area; sidebar no longer stretches with long facility lists

### Navigation & unsaved changes
- Introduced `leaveToModerationDashboard` and `leaveToAppHome` in `moderationUtils.ts` to centralize leaving forms
- Navigation now: syncs the correct list tab → clears unsaved blockers → sets dashboard screen → updates the URL
- `useUnsavedChanges` gains `tryLeave` so back/home can navigate to different destinations (not only the dashboard)
- Edit forms register `tryLeave`; back/home buttons use `runLeaveOr` for consistent unsaved-change prompts
- Router guard simplified to rely on the dirty registry; `clearAll` added to the unsaved-changes plugin
- Submission **Update & Exit** calls `makeNonDirty()` after save so navigation is not blocked
- Facility/HP **Update & Exit** exits even when there are no pending changes

### UI & i18n
- Added **Rejected** status badge on submission list items
- Increased horizontal padding on form topbar action buttons (`Update`, `Update & Exit`, etc.)
- Added missing `modSubmissionForm.successMessageUpdated` and `successMessageApproved` strings across all locales
- Top nav / hamburger home logo correctly leaves My Page edit routes (with unsaved-changes prompt when needed)
- Access panel skips re-fetching permissions when already loaded

### Other refactors
- Submission status filtering/counts cleanup in `moderationSubmissionsStore`
- Dashboard topbar and list container layout simplification
- Top nav alignment updates for My Page routes

## Test plan

- [ ] Open a submission from **Submissions** → edit → **Back** returns to submissions list (not facilities/settings)
- [ ] Edit a submission with unsaved changes → **Back** shows confirmation → confirm returns to submissions list
- [ ] Edit a submission → make changes → **Update & Exit** saves, shows success toast, and returns to submissions list
- [ ] Edit a facility → **Update & Exit** returns to facilities list; repeat for healthcare professionals
- [ ] From an edit form, click site logo / **Home** → lands on main search page (`/`)
- [ ] From an edit form with unsaved changes, click **Home** → prompt appears → confirm navigates home
- [ ] Rejected submissions show the red **Rejected** badge in the list
- [ ] Long facility lists scroll inside the center panel; sidebar height stays stable
- [ ] Navigate between list and edit views — permissions sidebar should not flash "loading" on every transition
- [ ] Run existing moderation e2e specs (`moderationDashboard`, `moderationEditFacilityOrProfessional`, `moderationEditSubmissionModal`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **New** status in moderation navigation and submission lists.
  * Moderation lists now show updated counts and clearer status badges, including rejected items.
  * Improved home/navigation behavior to better handle unsaved changes.

* **Bug Fixes**
  * Fixed moderation page layout and scrolling so panels and lists fit more reliably.
  * Improved leave/exit handling across forms to reduce accidental data loss.
  * Refined active link highlighting in the main and sidebar navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->