### PR TITLE
fix: accept full-width digits in postal code and phone number validation

### DIFF
--- a/tests/vitest/unit/formValidations.spec.ts
+++ b/tests/vitest/unit/formValidations.spec.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai'
+import { validatePostalCode, validatePhoneNumber } from '@/utils/formValidations'
+
+describe('validatePostalCode', () => {
+    it('accepts a half-width postal code', () => {
+        expect(validatePostalCode('123-4567')).to.be.true
+    })
+
+    it('accepts a full-width postal code typed with a Japanese IME', () => {
+        // Full-width digits and full-width hyphen, as produced by a kana IME.
+        expect(validatePostalCode('１２３－４５６７')).to.be.true
+    })
+
+    it('accepts full-width digits combined with an ASCII hyphen', () => {
+        expect(validatePostalCode('１２３-４５６７')).to.be.true
+    })
+
+    it('rejects a postal code with no hyphen', () => {
+        expect(validatePostalCode('1234567')).to.be.false
+        expect(validatePostalCode('１２３４５６７')).to.be.false
+    })
+
+    it('rejects a postal code with the wrong digit count', () => {
+        expect(validatePostalCode('12-3456')).to.be.false
+    })
+})
+
+describe('validatePhoneNumber', () => {
+    it('accepts a half-width phone number', () => {
+        expect(validatePhoneNumber('090-1234-5678')).to.be.true
+    })
+
+    it('accepts a full-width phone number typed with a Japanese IME', () => {
+        expect(validatePhoneNumber('０９０-１２３４-５６７８')).to.be.true
+    })
+
+    it('rejects an empty phone number', () => {
+        expect(validatePhoneNumber('')).to.be.false
+    })
+
+    it('rejects a non-numeric phone number', () => {
+        expect(validatePhoneNumber('abc')).to.be.false
+    })
+})

--- a/utils/formValidations.ts
+++ b/utils/formValidations.ts
@@ -40,11 +40,16 @@ export function validateNameJa(nameJa: string): boolean {
 }
 
 export function validatePhoneNumber(phoneNumber: string): boolean {
-    if (phoneNumber.length < 1) {
+    // NFKC folds full-width digits/symbols to ASCII, so a phone number typed with
+    // a Japanese IME (e.g. "０９０－１２３４－５６７８") validates the same as its half-width
+    // form. Same approach as validateNameJa above.
+    const normalizedPhoneNumber = phoneNumber.normalize('NFKC')
+
+    if (normalizedPhoneNumber.length < 1) {
         return false
     }
 
-    const isPhoneNumberValid: boolean = isValidPhoneNumber(phoneNumber)
+    const isPhoneNumberValid: boolean = isValidPhoneNumber(normalizedPhoneNumber)
 
     if (!isPhoneNumberValid) {
         return false
@@ -137,11 +142,16 @@ export function validateCityJa(cityJa: string): boolean {
 }
 
 export function validatePostalCode(postalCode: string): boolean {
-    if (postalCode.length > 18) {
+    // NFKC folds full-width digits/hyphen to ASCII, so a postal code typed with a
+    // Japanese IME (e.g. "１２３－４５６７") validates the same as its half-width form.
+    // Same approach as validateNameJa above.
+    const normalizedPostalCode = postalCode.normalize('NFKC')
+
+    if (normalizedPostalCode.length > 18) {
         return false
     }
 
-    const isPostalCodeValid = isValidPostalCode(postalCode)
+    const isPostalCodeValid = isValidPostalCode(normalizedPostalCode)
 
     if (!isPostalCodeValid) {
         return false


### PR DESCRIPTION
✅ Resolves #1762

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

(Leaving assignee/label unchecked — I don't have triage rights on this repo, happy for a maintainer to set them.)

## 🔧 What changed

`validatePostalCode` and `validatePhoneNumber` now `NFKC`-normalize the input before the regex check, so a postal code or phone number typed with a Japanese IME (full-width digits, e.g. `１２３－４５６７` / `０９０－１２３４－５６７８`) validates the same as its half-width form. Invalid input is still rejected.

This mirrors `validateNameJa` in the same file, which already folds full-width input with `NFKC`, so it just brings the numeric fields in line with how the Japanese name field is already handled. Validation-only — the stored value is untouched, same as `validateNameJa`.

## 🧪 Testing instructions

Added `tests/vitest/unit/formValidations.spec.ts` covering the half-width, full-width, and invalid cases for both validators.

- `yarn test:unit` is green (39 tests).
- Reverting the two validator changes makes the three full-width cases fail (`expected false to be true`), so the tests pin the fix both ways.
- `eslint` is clean on the changed files.

Manual: with a Japanese IME on, type `１２３－４５６７` into the facility postal code field. Before this it shows the "invalid" error and blocks submit; after, it's accepted.

## 📸 Screenshots

N/A — non-visual validation fix; the behaviour is covered by the unit test above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation so phone numbers and postal codes accept both half-width and full-width character input.
  * Postal codes now handle mixed full-width digits with standard hyphens.
  * Rejection checks remain in place for empty, malformed, or incorrectly formatted values.

* **Tests**
  * Added unit coverage for accepted and rejected phone number and postal code inputs.
  * Verified behavior with ASCII and Japanese IME-style entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->