### PR TITLE
fix: accept Google Maps share links in submission form

### DIFF
--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -88,7 +88,7 @@
     "firstName": "名",
     "firstNameValidation": "请输入名字（不含姓）",
     "googleMaps": "谷歌地图 URL",
-    "googleMapsValidation": "请输入以https://开头的URL链接",
+    "googleMapsValidation": "请输入 Google 地图链接（例如 https://maps.app.goo.gl/…）",
     "heading": "添加医师",
     "healthcareProfessionalName": "医师姓名",
     "invalidOption": "无效选项",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -88,7 +88,7 @@
     "firstName": "Vorname",
     "firstNameValidation": "Geben Sie einen Vornamen ein",
     "googleMaps": "Google Maps URL",
-    "googleMapsValidation": "Geben Sie eine URL ein, die mit https:// beginnt",
+    "googleMapsValidation": "Geben Sie einen Google Maps-Link ein (z. B. https://maps.app.goo.gl/…)",
     "heading": "Einen Arzt hinzufügen",
     "healthcareProfessionalName": "Name des Arztes",
     "invalidOption": "Ungültige Option",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -91,7 +91,7 @@
     "firstName": "First name",
     "firstNameValidation": "Enter a first name",
     "googleMaps": "Google Maps URL",
-    "googleMapsValidation": "Enter a URL starting with https://",
+    "googleMapsValidation": "Enter a Google Maps link (e.g. https://maps.app.goo.gl/…)",
     "heading": "Add a Doctor",
     "healthcareProfessionalName": "Healthcare Professional Name",
     "invalidOption": "Invalid option",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -87,7 +87,7 @@
   "submitPage": {
     "firstName": "Prénom",
     "googleMaps": "URL de Google Maps",
-    "googleMapsValidation": "Entrez une URL commençant par https://",
+    "googleMapsValidation": "Entrez un lien Google Maps (par ex. https://maps.app.goo.gl/…)",
     "heading": "Ajouter un médecin",
     "healthcareProfessionalName": "Nom du professionnel de la santé",
     "invalidOption": "Option invalide",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -92,7 +92,7 @@
     "firstName": "Nome",
     "firstNameValidation": "Inserisci un nome",
     "googleMaps": "URL di Google Maps",
-    "googleMapsValidation": "Inserisci un URL che inizi con https://",
+    "googleMapsValidation": "Inserisci un link di Google Maps (es. https://maps.app.goo.gl/…)",
     "heading": "Aggiungi un medico",
     "healthcareProfessionalName": "Nome del professionista sanitario",
     "invalidOption": "Opzione non valida",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -88,7 +88,7 @@
     "firstName": "名",
     "firstNameValidation": "Enter a first name",
     "googleMaps": "Google MapsのURL",
-    "googleMapsValidation": "https://を含む、アドレスを入れてください",
+    "googleMapsValidation": "Googleマップのリンクを入力してください（例：https://maps.app.goo.gl/…）",
     "heading": "医師情報の追加",
     "healthcareProfessionalName": "医師の姓名",
     "invalidOption": "選択外の項目を選んでいます",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -88,7 +88,7 @@
     "firstName": "Nome",
     "firstNameValidation": "Enter a first name",
     "googleMaps": "Endereço no Google Maps",
-    "googleMapsValidation": "Insira uma endereço começando com https://",
+    "googleMapsValidation": "Insira um link do Google Maps (ex.: https://maps.app.goo.gl/…)",
     "heading": "Adicionar um profissional de saúde",
     "healthcareProfessionalName": "Nome do profissional de saúde",
     "invalidOption": "Opção inválida",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -87,7 +87,7 @@
   "submitPage": {
     "firstName": "Имя",
     "googleMaps": "Google Maps URL",
-    "googleMapsValidation": " Введите URL, начинающийся с https:/",
+    "googleMapsValidation": "Введите ссылку Google Карт (например, https://maps.app.goo.gl/…)",
     "heading": "Добавить доктора",
     "healthcareProfessionalName": " Имя специалиста в области здравоохранения ",
     "invalidOption": " Недопустимый параметр ",

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -88,7 +88,7 @@
     "firstName": "Pangalan",
     "firstNameValidation": "Ilagay ang Pangalan",
     "googleMaps": "Google Maps URL",
-    "googleMapsValidation": "Ilagay ang URL na nagsisimula sa https://",
+    "googleMapsValidation": "Maglagay ng link ng Google Maps (hal. https://maps.app.goo.gl/…)",
     "heading": "Magdagdag ng Doktor",
     "healthcareProfessionalName": "Pangalan ng Propesyonal sa Pangangalagang Pangkalusugan",
     "invalidOption": "Hindi wastong opsyon",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -88,7 +88,7 @@
     "firstName": "Tên",
     "firstNameValidation": "Nhập tên của bạn",
     "googleMaps": "Google Maps URL",
-    "googleMapsValidation": "Nhập một URL bắt đầu bằng https://",
+    "googleMapsValidation": "Nhập liên kết Google Maps (ví dụ: https://maps.app.goo.gl/…)",
     "heading": "Thêm bác sĩ",
     "healthcareProfessionalName": "Tên chuyên gia y tế",
     "invalidOption": "Tùy chọn không hợp lệ",

--- a/tests/vitest/unit/validateGoogleMapsUrl.spec.ts
+++ b/tests/vitest/unit/validateGoogleMapsUrl.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai'
+import { validateGoogleMapsUrlInput } from '@/utils/formValidations'
+
+describe('validateGoogleMapsUrlInput', () => {
+    it('accepts full google.com/maps place URLs', () => {
+        expect(validateGoogleMapsUrlInput('https://www.google.com/maps/place/Some+Clinic')).to.be.true
+    })
+
+    it('accepts google.co.jp/maps URLs', () => {
+        expect(validateGoogleMapsUrlInput('https://www.google.co.jp/maps/place/Some+Clinic')).to.be.true
+    })
+
+    it('accepts maps.google.com URLs', () => {
+        expect(validateGoogleMapsUrlInput('https://maps.google.com/?q=Some+Clinic')).to.be.true
+    })
+
+    // The "Share" button in the Google Maps app/website hands users these short
+    // links — the format the doctor could not submit before this fix.
+    it('accepts maps.app.goo.gl share links', () => {
+        expect(validateGoogleMapsUrlInput('https://maps.app.goo.gl/abc123XYZ')).to.be.true
+    })
+
+    it('accepts legacy goo.gl/maps share links', () => {
+        expect(validateGoogleMapsUrlInput('https://goo.gl/maps/abc123XYZ')).to.be.true
+    })
+
+    it('trims surrounding whitespace before validating', () => {
+        expect(validateGoogleMapsUrlInput('  https://maps.app.goo.gl/abc123XYZ  ')).to.be.true
+    })
+
+    it('rejects a non-google https URL', () => {
+        expect(validateGoogleMapsUrlInput('https://example.com')).to.be.false
+    })
+
+    it('rejects a non-https URL', () => {
+        expect(validateGoogleMapsUrlInput('http://example.com')).to.be.false
+    })
+
+    it('rejects an empty string', () => {
+        expect(validateGoogleMapsUrlInput('')).to.be.false
+    })
+})

--- a/utils/formValidations.ts
+++ b/utils/formValidations.ts
@@ -219,7 +219,10 @@ export function validateUserSubmittedFirstName(name: string): boolean {
 export function validateGoogleMapsUrlInput(url: string): boolean {
     url = url.trim()
     if (url.startsWith('https://www.google.com/maps') || url.startsWith('https://www.google.co.jp/maps')
-      || url.startsWith('https://maps.google.com/')) {
+      || url.startsWith('https://maps.google.com/')
+      // Short "Share" links produced by the Google Maps app/website. These are
+      // what most users actually paste, so they must be accepted.
+      || url.startsWith('https://maps.app.goo.gl/') || url.startsWith('https://goo.gl/maps/')) {
         return true
     }
     return false


### PR DESCRIPTION
## Problem

Doctors submitting via `/submit` could get stuck: the **submit button appears to do nothing** and the message *"Enter a URL starting with https://"* stays visible below the Google Maps field.

Root cause: `validateGoogleMapsUrlInput` only accepted full `google.com/maps`, `google.co.jp/maps`, and `maps.google.com` URLs. It **rejected the short share links Google Maps actually produces** from its "Share" button — `https://maps.app.goo.gl/…` and `https://goo.gl/maps/…` — which is what most users (especially on mobile) paste. When the URL fails validation, `submitNewSubmission` returns early, so the form silently refuses to submit.

## Fix

- Accept `https://maps.app.goo.gl/` and `https://goo.gl/maps/` links in `validateGoogleMapsUrlInput` (`utils/formValidations.ts`).
- Reword the `submitPage.googleMapsValidation` message across all locales to reference a Google Maps link instead of the misleading "starting with https://".
- Add unit tests covering the newly-accepted share links and continued rejection of non-Maps / non-https / empty input.

No backend change needed — `createSubmission` stores the URL as a raw string with no format check.

## Testing

- `npx vitest run -c vitest.unit.config.ts tests/vitest/unit/validateGoogleMapsUrl.spec.ts` → 9 passing.
- Manual: paste `https://maps.app.goo.gl/abc123` on `/submit` → validation clears and submission proceeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Maps link validation now accepts more share-link formats, including short links.
* **Bug Fixes**
  * Improved validation for Google Maps fields across languages with clearer examples.
  * Added coverage for accepted, trimmed, and rejected URL cases to help prevent invalid submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->