### PR TITLE
refactor: fix auth flow

### DIFF
--- a/components/HamburgerMenu.vue
+++ b/components/HamburgerMenu.vue
@@ -176,7 +176,7 @@
                                 class="text-primary"
                             >
                                 <NuxtLink
-                                    to="/login"
+                                    :to="loginRoute"
                                     @click="closeMenu()"
                                 >
                                     {{ t('hamburgerMenu.login') }}
@@ -306,7 +306,7 @@
 
 <script lang="ts" setup>
 import { useToast } from 'vue-toastification'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { ref } from 'vue'
 import { vCloseOnOutsideClick } from '~/composables/closeOnOutsideClick'
 import SVGHamburgerMenuIcon from '~/assets/icons/hamburger-menu.svg'
@@ -314,13 +314,18 @@ import SVGGithubIcon from '~/assets/icons/social-github.svg'
 import SVGUserIcon from '~/assets/icons/user-icon.svg'
 import SVGSignOutIcon from '~/assets/icons/sign-out-icon.svg'
 import { useAuthStore } from '~/stores/authStore'
+import { buildLoginRoute, resolveAuthReturnPath } from '~/utils/auth0Config'
 
 const authStore = useAuthStore()
 const toast = useToast()
 const router = useRouter()
+const route = useRoute()
 const { t } = useI18n()
 
 const isMenuOpen = ref(false)
+const loginRoute = computed(() => buildLoginRoute(
+    route.path === '/login' ? resolveAuthReturnPath(route.fullPath) : route.fullPath
+))
 
 function openMenu() {
     isMenuOpen.value = true

--- a/components/LoginForm.vue
+++ b/components/LoginForm.vue
@@ -11,7 +11,7 @@
             class="h-8"
         />
         <span>
-            {{ t('login.redirectingtoauth0') }}...
+            {{ statusMessage }}...
         </span>
     </h1>
 </template>
@@ -19,11 +19,21 @@
 <script lang="ts" setup>
 import SVGLoadingIcon from '~/assets/icons/loading.svg'
 import { useAuthStore } from '~/stores/authStore'
+import { resolveAuthReturnPath } from '~/utils/auth0Config'
 
 const authStore = useAuthStore()
-
+const route = useRoute()
+const router = useRouter()
 const { t } = useI18n()
+const statusMessage = ref(t('login.checkingauth'))
 
-// since the login is a redirection, let's go there right away
-await authStore.login()
+await authStore.waitForAuth0ToLoad()
+
+if (authStore.isLoggedIn) {
+    statusMessage.value = t('login.checkingauth')
+    await router.replace(resolveAuthReturnPath(route.fullPath))
+} else {
+    statusMessage.value = t('login.redirectingtoauth0')
+    await authStore.login()
+}
 </script>

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -196,7 +196,7 @@
                         data-testid="topnav-login"
                         class="flex text-primary"
                     >
-                        <NuxtLink to="/login">
+                        <NuxtLink :to="loginRoute">
                             {{ t('topNav.login') }}
                         </NuxtLink>
                     </div>
@@ -219,12 +219,16 @@ import SVGSignOutIcon from '~/assets/icons/sign-out-icon.svg'
 import { useAuthStore } from '~/stores/authStore'
 import { useScreenOrientation } from '~/composables/useScreenOrientation'
 import { vCloseOnOutsideClick } from '~/composables/closeOnOutsideClick'
+import { buildLoginRoute, resolveAuthReturnPath } from '~/utils/auth0Config'
 
 const { t } = useI18n()
 const toast = useToast()
 const router = useRouter()
 const route = useRoute()
 
+const loginRoute = computed(() => buildLoginRoute(
+    route.path === '/login' ? resolveAuthReturnPath(route.fullPath) : route.fullPath
+))
 const profileMenuIsOpen = ref(false)
 const authStore = useAuthStore()
 const { isLandscape } = useScreenOrientation()

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -87,6 +87,10 @@ const runModerationAuthRedirect = () => {
     void authStore.redirectIfUnauthenticatedUser('/moderation', doesTheUserHaveAccess)
 }
 
+watch(
+    () => [authStore.isLoggedIn, authStore.isLoadingAuth] as const,
+    runModerationAuthRedirect
+)
 watch(() => route.path, runModerationAuthRedirect)
 onMounted(runModerationAuthRedirect)
 </script>

--- a/pages/my-page.vue
+++ b/pages/my-page.vue
@@ -99,6 +99,10 @@ const runModerationAuthRedirect = () => {
     void authStore.redirectIfUnauthenticatedUser('/my-page', doesTheUserHaveAccess)
 }
 
+watch(
+    () => [authStore.isLoggedIn, authStore.isLoadingAuth] as const,
+    runModerationAuthRedirect
+)
 watch(() => route.path, runModerationAuthRedirect)
 onMounted(runModerationAuthRedirect)
 </script>

--- a/plugins/vue-auth0-plugin.client.ts
+++ b/plugins/vue-auth0-plugin.client.ts
@@ -2,11 +2,6 @@ import { defineNuxtPlugin } from '#app'
 import { initializeAuth0 } from '~/utils/auth0'
 
 export default defineNuxtPlugin(async nuxtApp => {
-    const auth0 = await initializeAuth0()
-    nuxtApp.vueApp.use(auth0)
-
-    //load the user's session. don't await so it doesn't block the rendering
-    //This must be ran auth0 is initialized in the vue app
-    auth0.checkSession()
+    const auth0Client = await initializeAuth0()
+    nuxtApp.vueApp.use(auth0Client)
 })
-

--- a/stores/authStore.ts
+++ b/stores/authStore.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { auth0 } from '../utils/auth0.js'
+import { getAuth0AuthorizationParams, resolveAuthReturnPath } from '~/utils/auth0Config'
 import { useLoadingStore } from './loadingStore.js'
 import { useCookie, useRuntimeConfig } from '#app'
 import { useTranslation } from '~/composables/useTranslation.js'
@@ -39,10 +40,16 @@ export const useAuthStore = defineStore('authStore', () => {
 
         try {
             loadingStore.setIsLoading(true)
+            await waitForAuth0ToLoad()
 
-            if (!isLoggedIn.value) {
-                await auth0.loginWithRedirect()
+            if (isLoggedIn.value) {
+                return
             }
+
+            await auth0.loginWithRedirect({
+                appState: { target: resolveAuthReturnPath(route.fullPath) },
+                authorizationParams: getAuth0AuthorizationParams()
+            })
 
             //set the loading visual state back to normal
             loadingStore.setIsLoading(false)
@@ -69,22 +76,15 @@ export const useAuthStore = defineStore('authStore', () => {
                 return useCookie('auth_token').value ?? undefined
             }
 
-            if (!auth0) {
-                await waitForAuth0ToLoad()
-            }
+            await waitForAuth0ToLoad()
 
-            if (!auth0.isAuthenticated.value) {
+            if (!auth0?.isAuthenticated.value) {
                 return undefined
             }
 
-            const token = await auth0.getAccessTokenSilently({
-                authorizationParams: {
-                    audience: 'findadoc',
-                    tokenSigningAlg: 'RS256'
-                }
+            return await auth0.getAccessTokenSilently({
+                authorizationParams: getAuth0AuthorizationParams()
             })
-
-            return token
         } catch (error) {
             console.error(useTranslation('authErrors.authBearerToken'), `${JSON.stringify(error)}`)
         }
@@ -117,23 +117,25 @@ export const useAuthStore = defineStore('authStore', () => {
         routePath: string,
         doesTheUserHaveAccess: Ref<boolean>
     ) => {
-        // This promise is here to make the Suspense component work.
-        // It doesn't do anything, but <Suspense> requires an awaited setup method
-        await new Promise(resolve => {
-            //ignore if route change is unrelated to moderation
-            const needsRedirectDueToAccess = route.path.startsWith(routePath)
-              && !isLoggedIn.value && !isLoadingAuth.value
-            if (needsRedirectDueToAccess) {
-                // give the user a bit of time to read the message before redirecting
-                doesTheUserHaveAccess.value = false
-                setTimeout(() => {
-                    // Redirect to login page if user is not logged in
-                    router.push('/')
-                }, 10000)
-            }
+        if (!route.path.startsWith(routePath)) {
+            return
+        }
 
-            resolve(true)
-        })
+        if (isLoadingAuth.value) {
+            return
+        }
+
+        if (isLoggedIn.value) {
+            doesTheUserHaveAccess.value = true
+            return
+        }
+
+        doesTheUserHaveAccess.value = false
+        setTimeout(() => {
+            if (!isLoggedIn.value && route.path.startsWith(routePath)) {
+                router.push('/')
+            }
+        }, 10000)
     }
 
     return { userId,
@@ -143,5 +145,6 @@ export const useAuthStore = defineStore('authStore', () => {
         login,
         logout,
         getAuthBearerToken,
+        waitForAuth0ToLoad,
         redirectIfUnauthenticatedUser }
 })

--- a/tests/vitest/unit/auth0Config.spec.ts
+++ b/tests/vitest/unit/auth0Config.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it } from 'vitest'
+import { expect } from 'chai'
+import {
+    buildLoginRoute,
+    isAuth0ConsentRequiredError,
+    resolveAuthReturnPath,
+    sanitizeAuthReturnPath
+} from '@/utils/auth0Config'
+
+describe('sanitizeAuthReturnPath', () => {
+    it('rejects external and login paths', () => {
+        expect(sanitizeAuthReturnPath('//evil.com')).to.equal(null)
+        expect(sanitizeAuthReturnPath('/login')).to.equal(null)
+        expect(sanitizeAuthReturnPath('/login?returnTo=/')).to.equal(null)
+    })
+
+    it('allows internal app paths', () => {
+        expect(sanitizeAuthReturnPath('/')).to.equal('/')
+        expect(sanitizeAuthReturnPath('/my-page?view=settings')).to.equal('/my-page?view=settings')
+    })
+})
+
+describe('resolveAuthReturnPath', () => {
+    it('uses returnTo on the login page', () => {
+        expect(resolveAuthReturnPath('/login?returnTo=%2Fmy-page')).to.equal('/my-page')
+        expect(resolveAuthReturnPath('/login?returnTo=%2Fmy-page%3Fview%3Dsettings'))
+            .to.equal('/my-page?view=settings')
+    })
+
+    it('falls back to home when login has no return target', () => {
+        expect(resolveAuthReturnPath('/login')).to.equal('/')
+        expect(resolveAuthReturnPath('/login?foo=bar')).to.equal('/')
+    })
+
+    it('preserves the current route outside login', () => {
+        expect(resolveAuthReturnPath('/my-page')).to.equal('/my-page')
+        expect(resolveAuthReturnPath('/my-page?view=settings')).to.equal('/my-page?view=settings')
+    })
+})
+
+describe('buildLoginRoute', () => {
+    it('encodes the current page as returnTo', () => {
+        expect(buildLoginRoute('/my-page?view=settings')).to.deep.equal({
+            path: '/login',
+            query: { returnTo: '/my-page?view=settings' }
+        })
+    })
+})
+
+describe('isAuth0ConsentRequiredError', () => {
+    it('detects consent_required from Auth0 error payload', () => {
+        expect(isAuth0ConsentRequiredError({
+            error: 'consent_required',
+            error_description: 'Consent required' // eslint-disable-line camelcase
+        })).to.be.true
+    })
+
+    it('returns false for unrelated errors', () => {
+        expect(isAuth0ConsentRequiredError({ error: 'login_required' })).to.be.false
+        expect(isAuth0ConsentRequiredError(null)).to.be.false
+    })
+})

--- a/utils/auth0.ts
+++ b/utils/auth0.ts
@@ -1,7 +1,6 @@
-
 import type { Auth0Plugin } from '@auth0/auth0-vue'
 import { createAuth0 } from '@auth0/auth0-vue'
-import { useRoute } from 'vue-router'
+import { getAuth0AuthorizationParams } from '~/utils/auth0Config'
 
 //eslint-disable-next-line
 export let auth0: Auth0Plugin
@@ -16,13 +15,7 @@ export const initializeAuth0 = async () => {
         const auth0Plugin = createAuth0({
             domain: 'findadoc.jp.auth0.com',
             clientId: 'HB5Jow9yA5yiA4LTPQCKBYrfDyRkO9JX',
-            authorizationParams: {
-                appState: {
-                    target: useRoute().path
-                },
-                //eslint-disable-next-line
-                redirect_uri: window.location.origin
-            }
+            authorizationParams: getAuth0AuthorizationParams()
         })
 
         //set the global auth0 instance

--- a/utils/auth0Config.ts
+++ b/utils/auth0Config.ts
@@ -1,0 +1,70 @@
+/** Auth0 API identifier — must match the findadoc API in Auth0 and the server JWT audience. */
+export const AUTH0_API_AUDIENCE = 'findadoc'
+
+const LOGIN_PATH = '/login'
+export const AUTH_RETURN_TO_QUERY = 'returnTo'
+
+export function getAuth0AuthorizationParams(redirectUri = window.location.origin) {
+    return {
+        audience: AUTH0_API_AUDIENCE,
+        redirect_uri: redirectUri // eslint-disable-line camelcase
+    }
+}
+
+/** Reject unsafe or recursive post-login targets. */
+export function sanitizeAuthReturnPath(path: string | null | undefined): string | null {
+    if (!path || !path.startsWith('/') || path.startsWith('//')) {
+        return null
+    }
+
+    const [pathname] = path.split('?')
+    if (pathname === LOGIN_PATH || (pathname && pathname.startsWith(`${LOGIN_PATH}/`))) {
+        return null
+    }
+
+    return path
+}
+
+/**
+ * Resolve where to send the user after Auth0 login.
+ * On `/login`, honors `?returnTo=`; otherwise uses the current route.
+ */
+export function resolveAuthReturnPath(currentFullPath: string): string {
+    const [pathname, search = ''] = currentFullPath.split('?')
+
+    if (pathname === LOGIN_PATH || (pathname && pathname.startsWith(`${LOGIN_PATH}/`))) {
+        if (search) {
+            const returnTo = sanitizeAuthReturnPath(
+                new URLSearchParams(search).get(AUTH_RETURN_TO_QUERY)
+            )
+            if (returnTo) {
+                return returnTo
+            }
+        }
+
+        return '/'
+    }
+
+    return sanitizeAuthReturnPath(currentFullPath) ?? '/'
+}
+
+export function buildLoginRoute(returnTo: string) {
+    return {
+        path: LOGIN_PATH,
+        query: {
+            [AUTH_RETURN_TO_QUERY]: sanitizeAuthReturnPath(returnTo) ?? '/'
+        }
+    }
+}
+
+export function isAuth0ConsentRequiredError(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+        return false
+    }
+
+    const auth0Error = error as { error?: string, error_description?: string, message?: string }
+    return auth0Error.error === 'consent_required'
+      || auth0Error.error_description === 'Consent required'
+      || auth0Error.message?.includes('consent_required') === true
+      || auth0Error.message?.includes('Consent required') === true
+}


### PR DESCRIPTION
## Summary

Fixes the Auth0 login and post-login redirect flow so users return to the page they were trying to access (e.g. `/my-page`, `/moderation`) instead of always landing on home. Centralizes Auth0 configuration and return-path logic in a new `auth0Config` utility, and tightens how protected routes react when auth state finishes loading.

## Problem

- Login links went to `/login` with no context about where the user came from.
- After Auth0 redirected back, users were not reliably sent to their intended destination.
- Auth0 `authorizationParams` (audience, redirect URI) were duplicated and inconsistent across `auth0.ts` and `authStore.ts`.
- `LoginForm` immediately called `login()` without waiting for Auth0 to finish initializing, which could race with session restoration.
- Protected pages (`/my-page`, `/moderation`) only re-checked access on route change / mount, not when `isLoggedIn` or `isLoadingAuth` changed after Auth0 loaded.

## Solution

### New `utils/auth0Config.ts`

Single source of truth for Auth0 client settings and post-login routing:

| Export | Purpose |
|--------|---------|
| `AUTH0_API_AUDIENCE` | API identifier (`findadoc`) — must match Auth0 and server JWT audience |
| `getAuth0AuthorizationParams()` | Shared `audience` + `redirect_uri` for login and token requests |
| `sanitizeAuthReturnPath()` | Blocks open redirects (`//evil.com`) and recursive `/login` targets |
| `resolveAuthReturnPath()` | Determines post-login destination from current route or `?returnTo=` on `/login` |
| `buildLoginRoute()` | Builds `/login?returnTo=...` for nav login links |
| `isAuth0ConsentRequiredError()` | Helper for detecting Auth0 consent errors (tested, ready for error handling) |

### Auth store (`stores/authStore.ts`)

- `login()` now waits for Auth0 to load, skips redirect if already logged in, and passes `appState.target` + shared `authorizationParams` to `loginWithRedirect`.
- `getAuthBearerToken()` uses the same `getAuth0AuthorizationParams()` instead of inline audience config.
- `redirectIfUnauthenticatedUser()` simplified: early-returns while auth is loading, grants access when logged in, otherwise shows the “checking auth” UI and redirects home after 10s.
- Exposes `waitForAuth0ToLoad()` for components that need to await Auth0 initialization.

### UI entry points

- **TopNav** and **HamburgerMenu**: login links use `:to="loginRoute"` so the current page is encoded as `?returnTo=`.
- **LoginForm**: waits for Auth0, short-circuits to `resolveAuthReturnPath()` if already authenticated, otherwise redirects to Auth0 with a status message.

### Protected pages

- **`/my-page`** and **`/moderation`**: added a watcher on `[isLoggedIn, isLoadingAuth]` so access is re-evaluated when Auth0 finishes loading (not only on navigation).

### Auth0 plugin

- Removed redundant `checkSession()` call from the Nuxt plugin; Auth0 Vue SDK handles session restoration on init.

## Flow (after this PR)

```mermaid
sequenceDiagram
    participant User
    participant App
    participant Login as /login
    participant Auth0

    User->>App: clicks Login on /my-page
    App->>Login: navigate to /login?returnTo=/my-page
    Login->>App: waitForAuth0ToLoad()
    alt already logged in
        Login->>App: router.replace(/my-page)
    else not logged in
        Login->>Auth0: loginWithRedirect(appState.target=/my-page)
        Auth0->>App: callback with session
        App->>User: redirect to /my-page
    end
```

## Files changed

| File | Change |
|------|--------|
| `utils/auth0Config.ts` | **New** — shared Auth0 config and return-path helpers |
| `tests/vitest/unit/auth0Config.spec.ts` | **New** — unit tests for sanitization, routing, consent detection |
| `stores/authStore.ts` | Login/token/redirect logic uses shared config |
| `utils/auth0.ts` | Uses `getAuth0AuthorizationParams()`; removes per-init `appState` |
| `plugins/vue-auth0-plugin.client.ts` | Simplified init (no manual `checkSession`) |
| `components/LoginForm.vue` | Wait for auth, handle already-logged-in users |
| `components/TopNav.vue` | Login link preserves return path |
| `components/HamburgerMenu.vue` | Login link preserves return path |
| `pages/my-page.vue` | Watch auth state for access checks |
| `pages/moderation.vue` | Watch auth state for access checks |

## Test plan

- [ ] From `/my-page` while logged out, click **Login** → Auth0 → confirm you land back on `/my-page`
- [ ] From `/moderation` while logged out, same flow → confirm return to `/moderation`
- [ ] Visit `/login?returnTo=/my-page` directly while logged out → confirm post-login redirect to `/my-page`
- [ ] Visit `/login` while already logged in → confirm immediate redirect to `/` (no Auth0 round-trip)
- [ ] Confirm API calls still send a valid bearer token (moderation/my-page actions work after login)
- [ ] Confirm `/login?returnTo=//evil.com` does not redirect off-site (falls back to `/`)
- [ ] Run unit tests: `yarn vitest tests/vitest/unit/auth0Config.spec.ts`

## Notes for reviewers

- This PR is **auth-flow only** — it does not include unrelated UI/moderation navigation changes from other branches.
- `isAuth0ConsentRequiredError` is added and tested but not yet wired into UI error handling; it is available for a follow-up if consent prompts need custom handling.
- The 10-second delay before redirecting unauthenticated users off protected pages is existing behavior, preserved intentionally so users can read the “checking authentication” message.
