### PR TITLE
fix: ModInputField now checks all numbers for full width characters and converts them to half width

### DIFF
--- a/components/moderation-panel/ModCreateFacilitySection.vue
+++ b/components/moderation-panel/ModCreateFacilitySection.vue
@@ -33,6 +33,7 @@
                     type="text"
                     :placeholder="t('modFacilitySection.placeholderTextFacilityPhoneNumber')"
                     :required="true"
+                    :number-converter="true"
                     :input-validation-check="validatePhoneNumber"
                     :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityPhoneNumber')"
                 />
@@ -70,6 +71,7 @@
                         type="text"
                         :placeholder="t('modFacilitySection.placeholderTextFacilityPostalCode')"
                         :required="true"
+                        :number-converter="true"
                         :input-validation-check="validatePostalCode"
                         :invalid-input-error-message="t('modFacilitySection.inputErrorMessageFacilityPostalCode')"
                     />

--- a/components/moderation-panel/ModInputField.vue
+++ b/components/moderation-panel/ModInputField.vue
@@ -30,6 +30,7 @@
 <script setup lang="ts">
 import { ref, type Ref, watch, nextTick } from 'vue'
 import { useI18n } from '#imports'
+import { convertNumbers } from '~/utils/facilitiesUtils'
 
 const { t } = useI18n()
 
@@ -37,23 +38,6 @@ const isTheInputValueValid: Ref<boolean> = ref(true)
 const validationCheckedPreviously: Ref<boolean> = ref(false)
 
 const model = defineModel<string>()
-
-function convertNumbers() {
-    const fullToHalfwidthMap = {
-        '０': '0',
-        '１': '1',
-        '２': '2',
-        '３': '3',
-        '４': '4',
-        '５': '5',
-        '６': '6',
-        '７': '7',
-        '８': '8',
-        '９': '9'
-    }
-
-    model.value = model.value.replace(/[０-９]/g, number => fullToHalfwidthMap[number])
-}
 
 const props = defineProps({
     label: {
@@ -64,8 +48,11 @@ const props = defineProps({
     placeholder: String,
     required: Boolean,
     invalidInputErrorMessage: String,
-    inputValidationCheck: Function
+    inputValidationCheck: Function,
+    numberConverter: Boolean
 })
+
+// console.log(convertNumbers('２５'))
 
 const labelsToOnlyValidateOnBlur = [
     t('modSubmissionForm.labelHealthcareProfessionalLastName'),
@@ -88,7 +75,9 @@ watch(
         if (validationCheckedPreviously.value && props.inputValidationCheck) {
             isTheInputValueValid.value = props.inputValidationCheck(model.value)
         }
-        convertNumbers()
+        if (props.numberConverter) {
+            model.value = convertNumbers(model.value)
+        }
     }
 )
 </script>

--- a/components/moderation-panel/ModInputField.vue
+++ b/components/moderation-panel/ModInputField.vue
@@ -38,6 +38,23 @@ const validationCheckedPreviously: Ref<boolean> = ref(false)
 
 const model = defineModel<string>()
 
+function convertNumbers() {
+    const fullToHalfwidthMap = {
+        '０': '0',
+        '１': '1',
+        '２': '2',
+        '３': '3',
+        '４': '4',
+        '５': '5',
+        '６': '6',
+        '７': '7',
+        '８': '8',
+        '９': '9'
+    }
+
+    model.value = model.value.replace(/[０-９]/g, number => fullToHalfwidthMap[number])
+}
+
 const props = defineProps({
     label: {
         type: String,
@@ -71,6 +88,7 @@ watch(
         if (validationCheckedPreviously.value && props.inputValidationCheck) {
             isTheInputValueValid.value = props.inputValidationCheck(model.value)
         }
+        convertNumbers()
     }
 )
 </script>

--- a/tests/vitest/unit/formValidations.spec.ts
+++ b/tests/vitest/unit/formValidations.spec.ts
@@ -1,0 +1,20 @@
+import {expect} from 'chai'
+import { convertNumbers } from '~/utils/facilitiesUtils'
+
+describe('convertNumbers', () => {
+    it('accepts a half-width code', () => {
+        expect(convertNumbers('123456')).to.be.true
+    })
+
+    it('accepts a full-width code', () => {
+        expect(convertNumbers('１２３４５６')).to.be.true
+    })
+
+    it('converts all types of dashes', () => {
+        expect(convertNumbers('−–—')).to.be.true
+    })
+
+    it('does not convert alphabetical or Japanese characters to half width', () => {
+        expect(convertNumbers('ａあア亜')).to.be.true
+    })
+})

--- a/utils/facilitiesUtils.ts
+++ b/utils/facilitiesUtils.ts
@@ -114,7 +114,12 @@ export const convertNumbers = (form) => {
         '９': '9'
     }
 
+    // form = form.replace(/ー/g, '-')
+
     form = form.replace(/ー/g, '-')
+        .replace(/−/g, '-')
+        .replace(/–/g, '-')
+        .replace(/—/g, '-')
 
     return form.replace(/[０-９]/g, number => fullToHalfwidthMap[number])
 }

--- a/utils/facilitiesUtils.ts
+++ b/utils/facilitiesUtils.ts
@@ -99,3 +99,22 @@ export function validateUpdateFacility(
     }
     return { valid: errors.length === 0, errors }
 }
+
+export const convertNumbers = (form) => {
+    const fullToHalfwidthMap = {
+        '０': '0',
+        '１': '1',
+        '２': '2',
+        '３': '3',
+        '４': '4',
+        '５': '5',
+        '６': '6',
+        '７': '7',
+        '８': '8',
+        '９': '9'
+    }
+
+    form = form.replace(/ー/g, '-')
+
+    return form.replace(/[０-９]/g, number => fullToHalfwidthMap[number])
+}

--- a/utils/formValidations.ts
+++ b/utils/formValidations.ts
@@ -262,3 +262,5 @@ export function validateNameLocaleMatchesLanguage(
             return true
     }
 }
+
+


### PR DESCRIPTION
✅ Resolves #[1762]

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [ ] PR assignee has been selected
- [ ] PR label has been selected

## 🔧 What changed
ModInputField.vue now searches for full width numbers and changes them to half width numbers. This creates both better consistency across the site, but also ensures numbers will pass validation.

## 🧪 Testing instructions

## 📸 Screenshots

- ### Before
- ### After


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric input now automatically converts full-width digits to standard ASCII digits.
  * Validation and stored values remain consistent regardless of the digit format entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->