### PR TITLE
feat(seo): enable hybrid rendering for public routes

### DIFF
--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -37,7 +37,9 @@
                 class="h-svh"
             >
                 <Loader />
-                <BottomSheetContainer />
+                <ClientOnly>
+                    <BottomSheetContainer />
+                </ClientOnly>
                 <ClientOnly>
                     <MapContainer
                         class="h-[calc(100vh)]"

--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -1,66 +1,74 @@
 <template>
     <div class="h-full w-full">
-        <Onboarding
-            v-if="onboardingState === OnboardingState.NotStarted"
-        />
-        <!-- Search Container -->
-        <div
-            v-if="onboardingState === OnboardingState.Completed"
-            id="search-container"
-            class="flex flex-col h-svh overflow-hidden"
-        >
-            <TopNav class="absolute top-0 left-0 right-0 z-10 mx-2" />
-            <!-- Landscape / Desktop Mode -->
+        <!-- Decide onboarding vs app on the client so SSR/prerender cannot
+             bake "not-started" HTML that ignores localStorage. -->
+        <ClientOnly>
+            <Onboarding
+                v-if="onboardingState === OnboardingState.NotStarted"
+            />
+            <!-- Search Container -->
             <div
-                v-if="isLandscape"
-                id="search-landscape"
-                class="flex flex-col flex-1 overflow-hidden "
+                v-if="onboardingState === OnboardingState.Completed"
+                id="search-container"
+                class="flex flex-col h-svh overflow-hidden"
             >
-                <Loader />
-                <div class="flex flex-1 overflow-hidden">
-                    <LeftNavbar
-                        class="bg-primary-bg w-96 z-20
+                <TopNav class="absolute top-0 left-0 right-0 z-10 mx-2" />
+                <!-- Landscape / Desktop Mode -->
+                <div
+                    v-if="isLandscape"
+                    id="search-landscape"
+                    class="flex flex-col flex-1 overflow-hidden "
+                >
+                    <Loader />
+                    <div class="flex flex-1 overflow-hidden">
+                        <LeftNavbar
+                            class="bg-primary-bg w-96 z-20
                     fixed top-24 left-0 h-[calc(95vh-96px)] rounded-r-md"
-                    />
-                    <div class="flex-1 relative">
-                        <ClientOnly>
-                            <MapContainer class="h-full" />
-                        </ClientOnly>
-                        <SlidingRightPanel />
+                        />
+                        <div class="flex-1 relative">
+                            <ClientOnly>
+                                <MapContainer class="h-full" />
+                            </ClientOnly>
+                            <SlidingRightPanel />
+                        </div>
                     </div>
                 </div>
+                <!-- Portrait / Mobile Mode -->
+                <div
+                    v-else
+                    id="search-portrait"
+                    class="h-svh"
+                >
+                    <Loader />
+                    <ClientOnly>
+                        <BottomSheetContainer />
+                    </ClientOnly>
+                    <ClientOnly>
+                        <MapContainer
+                            class="h-[calc(100vh)]"
+                            @map-moved="handleMapMoved"
+                        />
+                    </ClientOnly>
+                </div>
+                <Footer class="z-20 absolute bottom-0 left-0 right-0 mx-2" />
             </div>
-            <!-- Portrait / Mobile Mode -->
-            <div
-                v-else
-                id="search-portrait"
-                class="h-svh"
-            >
-                <Loader />
-                <ClientOnly>
-                    <BottomSheetContainer />
-                </ClientOnly>
-                <ClientOnly>
-                    <MapContainer
-                        class="h-[calc(100vh)]"
-                        @map-moved="handleMapMoved"
-                    />
-                </ClientOnly>
-            </div>
-            <Footer class="z-20 absolute bottom-0 left-0 right-0 mx-2" />
-        </div>
+        </ClientOnly>
     </div>
 </template>
 
 <script lang="ts" setup>
 import { storeToRefs } from 'pinia'
-import { useOnboardingStore } from '@/stores/onboardingStore'
+import { useOnboardingStore, OnboardingState } from '@/stores/onboardingStore'
 import { useBottomSheetStore } from '@/stores/bottomSheetStore'
 import SlidingRightPanel from '~/components/SlidingRightPanel.vue'
 import { useScreenOrientation } from '~/composables/useScreenOrientation'
 
 const onboardingStore = useOnboardingStore()
 const { onboardingState } = storeToRefs(onboardingStore)
+
+onMounted(() => {
+    onboardingStore.hydrateFromStorage()
+})
 
 const bottomSheetStore = useBottomSheetStore()
 const { isLandscape } = useScreenOrientation()

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,7 +22,7 @@ export default defineNuxtConfig({
 
     // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins
     plugins: [],
-    ssr: false,
+    ssr: true,
 
     // Auto import components: https://nuxt.com/docs/guide/directory-structure/components#component-names
     components: [
@@ -134,10 +134,32 @@ export default defineNuxtConfig({
             }
         }
     },
+
+    // Public directory pages are prerendered (keeps the static Netlify generate model).
+    // Authenticated surfaces stay SPA. ISR would need a server runtime — see #1787.
+    routeRules: {
+        '/': { prerender: true },
+        '/about': { prerender: true },
+        '/terms': { prerender: true },
+        '/privacypolicy': { prerender: true },
+        '/submit': { prerender: true },
+        '/login': { ssr: false },
+        '/my-page': { ssr: false },
+        '/my-page/**': { ssr: false },
+        '/moderation': { ssr: false },
+        '/moderation/**': { ssr: false }
+    },
     sourcemap: {
         client: true
     },
     compatibilityDate: '2025-01-17',
+
+    nitro: {
+        prerender: {
+            crawlLinks: true,
+            routes: ['/', '/about', '/terms', '/privacypolicy', '/submit']
+        }
+    },
 
     vite: { plugins: [
         tailwindcss()

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -3,3 +3,9 @@
         <LoginForm />
     </div>
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/moderation.vue
+++ b/pages/moderation.vue
@@ -74,7 +74,8 @@ import { definePageMeta, useI18n } from '#imports'
 
 // tell nuxt to our moderation layout
 definePageMeta({
-    layout: 'my-page'
+    layout: 'my-page',
+    ssr: false
 })
 
 const { t } = useI18n()

--- a/pages/moderation/create-facility/index.vue
+++ b/pages/moderation/create-facility/index.vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/moderation/create-healthcare-professional/index.vue
+++ b/pages/moderation/create-healthcare-professional/index.vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/moderation/edit-facility/[id].vue
+++ b/pages/moderation/edit-facility/[id].vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/moderation/edit-healthcare-professional/[id].vue
+++ b/pages/moderation/edit-healthcare-professional/[id].vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/moderation/edit-submission/[id].vue
+++ b/pages/moderation/edit-submission/[id].vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/my-page.vue
+++ b/pages/my-page.vue
@@ -80,7 +80,8 @@ import { definePageMeta, useI18n } from '#imports'
 
 definePageMeta({
     layout: 'my-page',
-    key: 'my-page'
+    key: 'my-page',
+    ssr: false
 })
 
 const { t } = useI18n()

--- a/pages/my-page/create-facility/index.vue
+++ b/pages/my-page/create-facility/index.vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/my-page/create-healthcare-professional/index.vue
+++ b/pages/my-page/create-healthcare-professional/index.vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/my-page/edit-facility/[id].vue
+++ b/pages/my-page/edit-facility/[id].vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/my-page/edit-healthcare-professional/[id].vue
+++ b/pages/my-page/edit-healthcare-professional/[id].vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/pages/my-page/edit-submission/[id].vue
+++ b/pages/my-page/edit-submission/[id].vue
@@ -1,3 +1,9 @@
 <template>
     <NuxtPage />
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+    ssr: false
+})
+</script>

--- a/stores/onboardingStore.ts
+++ b/stores/onboardingStore.ts
@@ -1,4 +1,4 @@
-import { defineStore } from 'pinia'
+import { defineStore, skipHydrate } from 'pinia'
 import { ref } from 'vue'
 
 const ONBOARDING_STORAGE_KEY = 'onboardingState'
@@ -8,27 +8,44 @@ export enum OnboardingState {
     NotStarted = 'not-started'
 }
 
-export const useOnboardingStore = defineStore('onboarding', () => {
-    // State
-    const onboardingState = ref(getInitialState())
+function readStoredState(): OnboardingState | null {
+    if (!import.meta.client)
+        return null
 
-    // Actions
+    const stored = localStorage.getItem(ONBOARDING_STORAGE_KEY)
+    if (!stored)
+        return null
+
+    try {
+        const parsed = JSON.parse(stored) as OnboardingState
+        if (parsed === OnboardingState.Completed || parsed === OnboardingState.NotStarted)
+            return parsed
+    } catch {
+        // ignore corrupt storage
+    }
+
+    return null
+}
+
+export const useOnboardingStore = defineStore('onboarding', () => {
+    // localStorage is the source of truth. Skip Pinia payload hydration so a
+    // server-rendered "not-started" value cannot overwrite a completed visit.
+    const onboardingState = skipHydrate(ref(OnboardingState.NotStarted))
+
+    function hydrateFromStorage() {
+        const stored = readStoredState()
+        if (stored)
+            onboardingState.value = stored
+    }
+
     function setOnboardingState(value: OnboardingState) {
         onboardingState.value = value
 
-        if (import.meta.client) {
+        if (import.meta.client)
             localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(value))
-        }
     }
 
-    return { onboardingState, setOnboardingState }
+    hydrateFromStorage()
+
+    return { onboardingState, setOnboardingState, hydrateFromStorage }
 })
-
-// Initialize from localStorage or default to 'not started'
-const getInitialState = (): OnboardingState => {
-    if (!import.meta.client)
-        return OnboardingState.NotStarted
-
-    const stored = localStorage.getItem(ONBOARDING_STORAGE_KEY)
-    return stored ? JSON.parse(stored) : OnboardingState.NotStarted
-}

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -12,13 +12,24 @@ export function moderationSuccessToastPattern(expectedMessage: string, keySuffix
 }
 
 /**
- * Skip onboarding by setting localStorage. Call before visiting app pages that check onboarding.
+ * Persist completed onboarding before the app boots.
+ * With SSR, a first `goto('/')` would serialize "not-started" into the payload
+ * and ignore a later localStorage write — set storage via init script instead.
  */
 export async function skipOnboarding(page: Page) {
-    await page.goto('/')
-    await page.evaluate(() => {
-        localStorage.setItem('onboardingState', '"completed"')
-    })
+    const completed = JSON.stringify('completed')
+    await page.addInitScript((value) => {
+        localStorage.setItem('onboardingState', value)
+    }, completed)
+
+    // Already on a document (e.g. moderation setup): apply immediately too.
+    try {
+        await page.evaluate((value) => {
+            localStorage.setItem('onboardingState', value)
+        }, completed)
+    } catch {
+        // No document yet; addInitScript covers the first navigation.
+    }
 }
 
 /** Run moderation tests: always in CI; locally only when Auth0 credentials are present. */

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -18,13 +18,13 @@ export function moderationSuccessToastPattern(expectedMessage: string, keySuffix
  */
 export async function skipOnboarding(page: Page) {
     const completed = JSON.stringify('completed')
-    await page.addInitScript((value) => {
+    await page.addInitScript(value => {
         localStorage.setItem('onboardingState', value)
     }, completed)
 
     // Already on a document (e.g. moderation setup): apply immediately too.
     try {
-        await page.evaluate((value) => {
+        await page.evaluate(value => {
             localStorage.setItem('onboardingState', value)
         }, completed)
     } catch {

--- a/tests/vitest/piniaTests/onboardingStore.spec.ts
+++ b/tests/vitest/piniaTests/onboardingStore.spec.ts
@@ -1,0 +1,28 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { expect } from 'chai'
+import { OnboardingState, useOnboardingStore } from '@/stores/onboardingStore'
+
+describe('onboardingStore', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        localStorage.clear()
+    })
+
+    it('defaults to not-started when storage is empty', () => {
+        const store = useOnboardingStore()
+        expect(store.onboardingState).to.equal(OnboardingState.NotStarted)
+    })
+
+    it('hydrates a completed visit from localStorage', () => {
+        localStorage.setItem('onboardingState', JSON.stringify(OnboardingState.Completed))
+        const store = useOnboardingStore()
+        store.hydrateFromStorage()
+        expect(store.onboardingState).to.equal(OnboardingState.Completed)
+    })
+
+    it('persists completion to localStorage', () => {
+        const store = useOnboardingStore()
+        store.setOnboardingState(OnboardingState.Completed)
+        expect(JSON.parse(localStorage.getItem('onboardingState') || '')).to.equal(OnboardingState.Completed)
+    })
+})


### PR DESCRIPTION
## Summary
- Stacked on #1800 (`brammer/remove-ssr-blockers`). Do not merge until that PR lands.
- Sets `ssr: true` and prerenders public pages (`/`, `/about`, `/terms`, `/privacypolicy`, `/submit`) so crawlers get real HTML (`<h1>` + body text). Keeps the current static Netlify `nuxi generate` model; ISR would need a server runtime (see #1787).
- `login`, `my-page*`, and `moderation*` stay client-only via `routeRules` and `definePageMeta({ ssr: false })`.

Closes #1787

## Test plan
- [ ] Confirm this PR targets `brammer/remove-ssr-blockers`, not `main`
- [ ] `curl http://localhost:3000/about` (and `/`, `/terms`) includes an `<h1>` and visible copy
- [ ] `/login`, `/my-page`, `/moderation` still work as SPA (Auth0 login end to end)
- [ ] No hydration mismatch warnings on public pages
- [ ] Map / bottom sheet still render after #1800 client-only components
- [ ] `yarn test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public pages are now server-rendered and prerendered for faster initial loading.
  * Authenticated and interactive pages continue to load client-side for reliable state handling.
  * Onboarding progress now hydrates safely from local storage and persists across visits.

* **Bug Fixes**
  * Prevented incorrect onboarding or completed-app screens from appearing before hydration.
  * Improved handling of invalid or corrupted saved onboarding data.

* **Tests**
  * Added coverage for onboarding defaults, hydration, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->