### PR TITLE
fix: direct navigation to non-prerendered routes returns 404

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,15 +3,13 @@
 
 [build.environment]
   NETLIFY_USE_YARN="true"
-  YARN_VERSION="3.4.1"
+  YARN_VERSION="4.12.0"
   NODE_VERSION="22.12.0"
 
-# The following redirect is intended for use with most SPAs that handle
-# routing internally.
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+# SPA fallbacks for non-prerendered routes live in public/_redirects so they
+# land in the publish directory ahead of Nitro's /* → /404.html 404 rule.
+# Do not add a toml /* → /index.html 200 catch-all: it either loses to that
+# 404 rule or turns unknown URLs into soft 200s. See #1785.
 
 [[headers]]
   # Define which paths this specific [[headers]] block will cover.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -128,6 +128,22 @@ export default defineNuxtConfig({
             }
         }
     },
+
+    // Public directory pages are prerendered (keeps the static Netlify generate model).
+    // Authenticated surfaces stay SPA. ISR would need a server runtime — see #1787.
+    // Non-prerendered app routes (e.g. /u/*) are SPA-rewritten in public/_redirects — see #1785.
+    routeRules: {
+        '/': { prerender: true },
+        '/about': { prerender: true },
+        '/terms': { prerender: true },
+        '/privacypolicy': { prerender: true },
+        '/submit': { prerender: true },
+        '/login': { ssr: false },
+        '/my-page': { ssr: false },
+        '/my-page/**': { ssr: false },
+        '/moderation': { ssr: false },
+        '/moderation/**': { ssr: false }
+    },
     sourcemap: {
         client: true
     },

--- a/public/_redirects
+++ b/public/_redirects
@@ -3,7 +3,9 @@
 # writes `/* /404.html 404` into `_redirects`, which is processed before
 # netlify.toml — so a toml `/* → /index.html 200` catch-all never wins.
 # Specific 200 rewrites here run first; keep the 404 catch-all last.
-# Add new dynamic prefixes here rather than a blanket 200 rewrite (see #1785).
+# CI `nuxi start` uses `serve`, which ignores this file — keep public/serve.json
+# in sync for the same fallbacks (see #1785).
+# Add new dynamic prefixes here rather than a blanket 200 rewrite.
 /u/*            /200.html   200
 /login          /200.html   200
 /login/*        /200.html   200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,16 @@
+# SPA fallbacks for client-routed pages that `nuxi generate` does not prerender.
+# This file is copied into the publish directory. Nitro's netlify-static preset
+# writes `/* /404.html 404` into `_redirects`, which is processed before
+# netlify.toml — so a toml `/* → /index.html 200` catch-all never wins.
+# Specific 200 rewrites here run first; keep the 404 catch-all last.
+# Add new dynamic prefixes here rather than a blanket 200 rewrite (see #1785).
+/u/*            /200.html   200
+/login          /200.html   200
+/login/*        /200.html   200
+/my-page        /200.html   200
+/my-page/*      /200.html   200
+/moderation     /200.html   200
+/moderation/*   /200.html   200
+
+# Unknown paths stay a real 404 (not a soft 200 SPA shell).
+/*              /404.html   404

--- a/public/serve.json
+++ b/public/serve.json
@@ -1,0 +1,11 @@
+{
+  "rewrites": [
+    { "source": "/u/:username", "destination": "/200.html" },
+    { "source": "/login", "destination": "/200.html" },
+    { "source": "/login/:path*", "destination": "/200.html" },
+    { "source": "/my-page", "destination": "/200.html" },
+    { "source": "/my-page/:path*", "destination": "/200.html" },
+    { "source": "/moderation", "destination": "/200.html" },
+    { "source": "/moderation/:path*", "destination": "/200.html" }
+  ]
+}

--- a/tests/e2e/profileDirectEntry.spec.ts
+++ b/tests/e2e/profileDirectEntry.spec.ts
@@ -1,0 +1,24 @@
+import enUS from '../../i18n/locales/en.json' with { type: 'json' }
+import { test, expect } from '@playwright/test'
+import { skipOnboarding } from './fixtures'
+
+test.describe('Direct entry to dynamic routes', () => {
+    test('loads a profile URL on first request', async ({ page }) => {
+        await skipOnboarding(page)
+
+        const response = await page.goto('/u/direct-entry-user')
+
+        expect(response?.status()).toBe(200)
+        await expect(page).toHaveURL(/\/u\/direct-entry-user/)
+        await expect(page.getByRole('heading', { name: enUS.profile.edit })).toBeVisible()
+    })
+
+    test('unknown paths return a real 404', async ({ page }) => {
+        await skipOnboarding(page)
+
+        const response = await page.goto('/nonexistent-page-xyz')
+
+        expect(response?.status()).toBe(404)
+        await expect(page.getByRole('heading', { name: enUS.errorPage.title })).toBeVisible()
+    })
+})

--- a/tests/vitest/helpers/spaFallbackConfig.ts
+++ b/tests/vitest/helpers/spaFallbackConfig.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+export type ServeRewrite = { source: string, destination: string }
+
+export type ServeJson = { rewrites?: ServeRewrite[] }
+
+function publicPath(filename: string): string {
+    return join(process.cwd(), 'public', filename)
+}
+
+/** Netlify publish-dir redirects (ignored by `nuxi start` / `serve`). */
+export function readRedirects(): string {
+    return readFileSync(publicPath('_redirects'), 'utf8')
+}
+
+/** vercel/serve config used by `nuxi start` after generate (Playwright CI). */
+export function readServeJson(): ServeJson {
+    return JSON.parse(readFileSync(publicPath('serve.json'), 'utf8')) as ServeJson
+}
+
+export function redirectRuleIndex(redirects: string, pattern: RegExp): number {
+    return pattern.exec(redirects)?.index ?? -1
+}

--- a/tests/vitest/unit/netlifyRedirects.spec.ts
+++ b/tests/vitest/unit/netlifyRedirects.spec.ts
@@ -1,21 +1,16 @@
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
+/// <reference types="vitest/globals" />
 import { expect } from 'chai'
+import {
+    readRedirects,
+    readServeJson,
+    redirectRuleIndex
+} from '../helpers/spaFallbackConfig'
 
-function readRedirects(): string {
-    return readFileSync(join(process.cwd(), 'public/_redirects'), 'utf8')
-}
-
-function ruleIndex(redirects: string, pattern: RegExp): number {
-    const match = pattern.exec(redirects)
-    return match?.index ?? -1
-}
-
-describe('Netlify SPA fallbacks', () => {
+describe('SPA fallbacks', () => {
     it('rewrites profile deep links to the SPA shell before the 404 catch-all', () => {
         const redirects = readRedirects()
-        const spa = ruleIndex(redirects, /^\/u\/\*\s+\/200\.html\s+200/m)
-        const notFound = ruleIndex(redirects, /^\/\*\s+\/404\.html\s+404/m)
+        const spa = redirectRuleIndex(redirects, /^\/u\/\*\s+\/200\.html\s+200/m)
+        const notFound = redirectRuleIndex(redirects, /^\/\*\s+\/404\.html\s+404/m)
 
         expect(spa).to.be.greaterThan(-1)
         expect(notFound).to.be.greaterThan(-1)
@@ -27,12 +22,18 @@ describe('Netlify SPA fallbacks', () => {
         for (const path of ['/login', '/my-page', '/moderation']) {
             const exact = new RegExp(`^${path}\\s+/200\\.html\\s+200`, 'm')
             const nested = new RegExp(`^${path}/\\*\\s+/200\\.html\\s+200`, 'm')
-            expect(ruleIndex(redirects, exact), `${path} exact rewrite`).to.be.greaterThan(-1)
-            expect(ruleIndex(redirects, nested), `${path} nested rewrite`).to.be.greaterThan(-1)
+            expect(redirectRuleIndex(redirects, exact), `${path} exact rewrite`).to.be.greaterThan(-1)
+            expect(redirectRuleIndex(redirects, nested), `${path} nested rewrite`).to.be.greaterThan(-1)
         }
     })
 
     it('does not use a blanket 200 catch-all', () => {
         expect(readRedirects()).to.not.match(/^\/\*\s+\/(?:index|200)\.html\s+200/m)
+    })
+
+    it('mirrors profile SPA fallbacks in serve.json for nuxi start / CI', () => {
+        const rewrites = readServeJson().rewrites ?? []
+        expect(rewrites.some(rule => rule.source.startsWith('/u/') && rule.destination === '/200.html')).to.equal(true)
+        expect(rewrites.some(rule => rule.source === '/**' || rule.source === '*')).to.equal(false)
     })
 })

--- a/tests/vitest/unit/netlifyRedirects.spec.ts
+++ b/tests/vitest/unit/netlifyRedirects.spec.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { expect } from 'chai'
+
+function readRedirects(): string {
+    return readFileSync(join(process.cwd(), 'public/_redirects'), 'utf8')
+}
+
+function ruleIndex(redirects: string, pattern: RegExp): number {
+    const match = pattern.exec(redirects)
+    return match?.index ?? -1
+}
+
+describe('Netlify SPA fallbacks', () => {
+    it('rewrites profile deep links to the SPA shell before the 404 catch-all', () => {
+        const redirects = readRedirects()
+        const spa = ruleIndex(redirects, /^\/u\/\*\s+\/200\.html\s+200/m)
+        const notFound = ruleIndex(redirects, /^\/\*\s+\/404\.html\s+404/m)
+
+        expect(spa).to.be.greaterThan(-1)
+        expect(notFound).to.be.greaterThan(-1)
+        expect(spa).to.be.lessThan(notFound)
+    })
+
+    it('rewrites other non-prerendered app routes to the SPA shell', () => {
+        const redirects = readRedirects()
+        for (const path of ['/login', '/my-page', '/moderation']) {
+            const exact = new RegExp(`^${path}\\s+/200\\.html\\s+200`, 'm')
+            const nested = new RegExp(`^${path}/\\*\\s+/200\\.html\\s+200`, 'm')
+            expect(ruleIndex(redirects, exact), `${path} exact rewrite`).to.be.greaterThan(-1)
+            expect(ruleIndex(redirects, nested), `${path} nested rewrite`).to.be.greaterThan(-1)
+        }
+    })
+
+    it('does not use a blanket 200 catch-all', () => {
+        expect(readRedirects()).to.not.match(/^\/\*\s+\/(?:index|200)\.html\s+200/m)
+    })
+})


### PR DESCRIPTION
## Summary
- Serve SPA fallbacks (`/200.html` 200) for non-prerendered client routes (`/u/*`, login, my-page, moderation) via `public/_redirects`, so they win over Nitro’s generated `/* → /404.html 404`.
- Drop the toml `/* → /index.html` 200 catch-all so unknown paths stay a real 404 instead of a soft 200.
- Align Netlify `YARN_VERSION` with `packageManager` (`4.12.0`).
- Add a unit test for redirect order and a Playwright regression for direct entry to `/u/:username`.

Closes #1785

Stacked on #1802 (`brammer/enable-hybrid-rendering`). Merge #1800 then #1802 before this, or retarget to `main` after those land.

## Test plan
- [ ] Direct entry to `/u/<any-username>` returns 200 and renders the profile page
- [ ] Browser refresh on `/u/<username>` still renders
- [ ] Direct entry to `/login`, `/my-page`, `/moderation` returns 200 (SPA shell)
- [ ] `/nonexistent-page-xyz` still returns 404 (not a soft 200)
- [ ] `yarn vitest run -c vitest.unit.config.ts tests/vitest/unit/netlifyRedirects.spec.ts`
- [ ] `yarn playwright test tests/e2e/profileDirectEntry.spec.ts`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direct access to profile, login, personal-page, and moderation routes on static hosting.
  * Unknown routes now return a proper 404 page instead of loading the application shell.

* **New Features**
  * Added matching fallback behavior for supported static hosting environments.

* **Tests**
  * Added coverage for dynamic-route entry points, unknown paths, and hosting fallback configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->