### PR TITLE
chore(ci): add typecheck script and workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -21,6 +21,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare "$(node -p "require('./package.json').packageManager")" --activate
+          expected="$(node -p "require('./package.json').packageManager.split('@').pop()")"
+          actual="$(yarn --version)"
+          echo "Using Yarn ${actual}"
+          if [ "${actual}" != "${expected}" ]; then
+            echo "::error::Yarn version mismatch: expected ${expected}, got ${actual}"
+            exit 1
+          fi
       - name: Install Yarn/ Node ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,32 @@
+name: Typecheck
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: Typecheck ✅
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.12.0]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Yarn/ Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+      - name: Install Dependencies
+        run: yarn install --immutable
+      - name: Run Typecheck
+        run: yarn typecheck

--- a/components/moderation-panel/ModMainContent.vue
+++ b/components/moderation-panel/ModMainContent.vue
@@ -101,7 +101,7 @@ function syncSelectedModerationViewFromQuery() {
 const setActiveScreenBasedOnRoute = async () => {
     await nextTick()
     // grab the relevant part of the path
-    const pathSnippet = routePathForModerationScreen.value.split('/')[2]
+    const pathSnippet = routePathForModerationScreen.value.split('/')[2] ?? ''
 
     // for routes that require a selected ID, check before entering the switch
     const editRoutes = ['edit-submission', 'edit-facility', 'edit-healthcare-professional']

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "lint:locales": "node i18n/checkLocaleKeys.js",
         "lint:cleanlocales": "node i18n/cleanUnusedLocaleKeys.js",
         "lint:ci": "yarn prepare:ci && ESLINT_USE_FLAT_CONFIG=true eslint . -c eslint.config.js",
+        "typecheck": "nuxi prepare && nuxi typecheck",
         "prod:build": "yarn && yarn generate && nuxi generate",
         "prod:start": "nuxi start",
         "ci:build": "yarn && yarn generate && nuxi generate",
@@ -105,6 +106,7 @@
         "vite": "^7.3.0",
         "vitest": "^4.0.16",
         "vue-eslint-parser": "^10.2.0",
+        "vue-tsc": "^3.3.11",
         "wait-on": "^8.0.1"
     }
 }

--- a/plugins/unsaved-changes-plugin.client.ts
+++ b/plugins/unsaved-changes-plugin.client.ts
@@ -1,9 +1,17 @@
 import { useModerationSubmissionUnsavedStore } from '~/stores/moderationSubmissionUnsavedStore'
+import type { Pinia } from 'pinia'
+import type { Composer } from 'vue-i18n'
+import type { Router } from 'vue-router'
 
 export default defineNuxtPlugin({
     name: 'unsaved-changes',
     enforce: 'post',
     setup(nuxtApp) {
+        const app = nuxtApp as unknown as {
+            $pinia?: Pinia
+            $router: Router
+            $i18n?: Composer
+        }
         const activeDirtyIds = reactive(new Map<symbol, 'create' | 'update'>())
 
         const isGloballyDirty = computed(() => activeDirtyIds.size > 0)
@@ -24,13 +32,14 @@ export default defineNuxtPlugin({
             if (registeredRouterGuard) return
             registeredRouterGuard = true
 
-            const submissionUnsavedStore = useModerationSubmissionUnsavedStore(nuxtApp.$pinia)
+            const submissionUnsavedStore = useModerationSubmissionUnsavedStore(app.$pinia)
 
-            nuxtApp.$router.beforeEach(() => {
+            app.$router.beforeEach(() => {
                 if (!isGloballyDirty.value) return true
 
                 return new Promise<boolean>(resolve => {
-                    const message = nuxtApp.$i18n?.t('modEditFacilityOrHPTopbar.hasUnsavedChanges')
+                    const t = app.$i18n?.t
+                    const message = t?.('modEditFacilityOrHPTopbar.hasUnsavedChanges')
                       ?? 'You have unsaved changes'
                     const confirm = nuxtApp.$withConfirmation
                     if (typeof confirm !== 'function') {

--- a/stores/moderationSubmissionUnsavedStore.ts
+++ b/stores/moderationSubmissionUnsavedStore.ts
@@ -28,7 +28,7 @@ export const useModerationSubmissionUnsavedStore = defineStore('moderationSubmis
             registerEditFormTryLeave(null)
             return
         }
-        registerEditFormTryLeave(onLeave => onLeave(fn))
+        registerEditFormTryLeave(fn)
     }
 
     function runLeaveOr(onLeave: () => void | Promise<void>) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["vitest/globals"]
   },
   "ts-node": {
     "esm": true,

--- a/utils/arrayUtils.ts
+++ b/utils/arrayUtils.ts
@@ -36,8 +36,11 @@ export function shuffleArray<T>(inputArray: T[]): T[] {
 
     // Fisher-Yates shuffle algorithm
     for (let i = copiedArray.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [copiedArray[i], copiedArray[j]] = [copiedArray[j], copiedArray[i]]
+        const j = Math.floor(Math.random() * (i + 1))
+        const currentItem = copiedArray[i] as T
+        const randomItem = copiedArray[j] as T
+        copiedArray[i] = randomItem
+        copiedArray[j] = currentItem
     }
     return copiedArray
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6106,6 +6106,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@volar/language-core@npm:2.4.28":
+  version: 2.4.28
+  resolution: "@volar/language-core@npm:2.4.28"
+  dependencies:
+    "@volar/source-map": "npm:2.4.28"
+  checksum: 10/6c735027df0dfee142654e0aa9265111a82c21134366c08f4764743f74875ba8314fdc98865d37bf83ac7409dfea90b8538181a966681f3d01f68bbd999fef3a
+  languageName: node
+  linkType: hard
+
 "@volar/source-map@npm:2.4.15":
   version: 2.4.15
   resolution: "@volar/source-map@npm:2.4.15"
@@ -6120,6 +6129,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@volar/source-map@npm:2.4.28":
+  version: 2.4.28
+  resolution: "@volar/source-map@npm:2.4.28"
+  checksum: 10/494b086be7ef6a46993941144a6961dcf9ecc4c830e2279031004496a7480727d6b0dc3f16776bf83aafe005084655c5664198f362a2c975d8267855de7b0a27
+  languageName: node
+  linkType: hard
+
 "@volar/typescript@npm:2.4.15":
   version: 2.4.15
   resolution: "@volar/typescript@npm:2.4.15"
@@ -6128,6 +6144,17 @@ __metadata:
     path-browserify: "npm:^1.0.1"
     vscode-uri: "npm:^3.0.8"
   checksum: 10/f5b7dccc6abfca8c1943076690788a6a05e8ecea880be2244c2588bb47835a399927092e200e3774abc33ed56551804c8acfff6d90685ff5acafc3409832ccc6
+  languageName: node
+  linkType: hard
+
+"@volar/typescript@npm:2.4.28":
+  version: 2.4.28
+  resolution: "@volar/typescript@npm:2.4.28"
+  dependencies:
+    "@volar/language-core": "npm:2.4.28"
+    path-browserify: "npm:^1.0.1"
+    vscode-uri: "npm:^3.0.8"
+  checksum: 10/6176e1fccc3c060a6393ab33b9befb828542a813a72201f0a83a8e6607055ac98a838db32ce9f54fe305df51cd1fa0eefc30d5e16dd2391af0563c76746f6679
   languageName: node
   linkType: hard
 
@@ -6354,6 +6381,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/language-core@npm:3.3.11":
+  version: 3.3.11
+  resolution: "@vue/language-core@npm:3.3.11"
+  dependencies:
+    "@volar/language-core": "npm:2.4.28"
+    "@vue/compiler-dom": "npm:^3.5.0"
+    "@vue/shared": "npm:^3.5.0"
+    alien-signals: "npm:^3.2.1"
+    muggle-string: "npm:^0.4.1"
+    path-browserify: "npm:^1.0.1"
+    picomatch: "npm:^4.0.4"
+  checksum: 10/18d1c4041a7804e80c4154794d80df97302ee6e52cacb8830b89b9695b7b4bf615a3ab617bab3ff5ea4ab95e65ce72341abe7fe77758f229f4dfe8d4cea3d542
+  languageName: node
+  linkType: hard
+
 "@vue/language-core@npm:^3.1.3, @vue/language-core@npm:^3.2.1":
   version: 3.2.1
   resolution: "@vue/language-core@npm:3.2.1"
@@ -6575,6 +6617,13 @@ __metadata:
   version: 3.1.2
   resolution: "alien-signals@npm:3.1.2"
   checksum: 10/5095cc62a2d81a19f1c4187fdd87e73c07dbeb290995c413f179b9d7c498ce721067097e5ad4a00b3e4d2e91c88f5f041c5e6e7a1652cd027fa6ee1660e7274d
+  languageName: node
+  linkType: hard
+
+"alien-signals@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "alien-signals@npm:3.2.1"
+  checksum: 10/9c8b14c460e748f40d85bbe4e607f81a4177d8ca1c056eab86f9792297003ef10717690019e23cacf19bb68babba97d1cb0bb03c35ca495d736cb6809efb7291
   languageName: node
   linkType: hard
 
@@ -9813,6 +9862,7 @@ __metadata:
     vue-server-renderer: "npm:^2.7.16"
     vue-template-compiler: "npm:^2.7.16"
     vue-toastification: "npm:^2.0.0-rc.5"
+    vue-tsc: "npm:^3.3.11"
     vue3-google-map: "npm:^0.27.0"
     wait-on: "npm:^8.0.1"
   languageName: unknown
@@ -13788,6 +13838,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"picomatch@npm:^4.0.4":
+  version: 4.0.7
+  resolution: "picomatch@npm:4.0.7"
+  checksum: 10/66e1df34bc39c72fa3756be4069f7887ea3e35e94bba1c3f6167763007698cb04b8a0a365161d186fda6e9571a2d3efb606b2966eb6a7dea6252911224dc2f48
+  languageName: node
+  linkType: hard
+
 "pify@npm:^5.0.0":
   version: 5.0.0
   resolution: "pify@npm:5.0.0"
@@ -17278,6 +17335,20 @@ __metadata:
   peerDependencies:
     vue: ^3.0.2
   checksum: 10/da2698e8a24f3de99269d71327879c389236179225dca9112d1de971fcd2e809d83670e1195f3c59a232f8b53c5625b93d573e809da7cb587527b5d339ec9bdb
+  languageName: node
+  linkType: hard
+
+"vue-tsc@npm:^3.3.11":
+  version: 3.3.11
+  resolution: "vue-tsc@npm:3.3.11"
+  dependencies:
+    "@volar/typescript": "npm:2.4.28"
+    "@vue/language-core": "npm:3.3.11"
+  peerDependencies:
+    typescript: ">=5.0.0"
+  bin:
+    vue-tsc: bin/vue-tsc.js
+  checksum: 10/040ab3469c392475541f479187e1c0aee460d57ede3c8de44b09ccc89fc53c2052ec1c36de00841ea955275cc5dba69f3889f23d7134f7d41b513223308f57c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do?

- Adds a `typecheck` script using `nuxi prepare && nuxi typecheck`.
- Adds a GitHub Actions workflow to run typechecks on pushes and PRs targeting `main`.
- Adds `vue-tsc` as a dev dependency.
- Fixes existing TypeScript errors so the new check starts green.
- Removes the unsupported Nuxt 2 `hid` meta option and the removed `@nuxtjs/i18n` v10 `lazy` option.

### How has it been tested?

- `yarn typecheck`
- `yarn lint:ci`
- `yarn test:unit`

Closes #1801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation handling in the moderation panel when routes do not match an expected pattern.
  - Improved reliability when leaving moderation forms with unsaved changes.

- **Chores**
  - Added automated type checking for pushes and pull requests.
  - Updated project tooling and font support to improve development consistency and interface rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->