### PR TITLE
fix(seo): give every page a unique, branded title

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -7,6 +7,16 @@
 
 <script setup lang="ts">
 import { initializeGqlClient } from './utils/graphql.js'
+import { SITE_TITLE } from '~/utils/site'
 
 initializeGqlClient()
+
+// Wrap each page's title with the brand name. Pages without an explicit
+// title fall back to the brand name alone, so we never render a broken
+// " | Brand" or a doubled "Brand | Brand" title. This must be set at
+// runtime (not in nuxt.config) because function templates are not
+// serializable into the generated app config.
+useHead({
+    titleTemplate: (title?: string) => title ? `${title} | ${SITE_TITLE}` : SITE_TITLE
+})
 </script>

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "日本的医疗服务",
+    "aboutTitle": "关于我们",
+    "submitTitle": "提交医疗服务",
+    "termsTitle": "服务条款",
+    "privacyTitle": "隐私政策"
+  },
   "common": {
     "menu": "菜单",
     "siteName": "Find a Doc Japan",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "Gesundheitsdienstleistungen in Japan",
+    "aboutTitle": "Über uns",
+    "submitTitle": "Anbieter einreichen",
+    "termsTitle": "Nutzungsbedingungen",
+    "privacyTitle": "Datenschutzerklärung"
+  },
   "common": {
     "menu": "Menü",
     "siteName": "Find a Doc Japan",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "Health Services in Japan",
+    "aboutTitle": "About Us",
+    "submitTitle": "Submit a Provider",
+    "termsTitle": "Terms of Service",
+    "privacyTitle": "Privacy Policy"
+  },
   "common": {
     "menu": "Menu",
     "siteName": "Find a Doc Japan",

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "Services de santé au Japon",
+    "aboutTitle": "À propos",
+    "submitTitle": "Soumettre un professionnel",
+    "termsTitle": "Conditions d'utilisation",
+    "privacyTitle": "Politique de confidentialité"
+  },
   "common": {
     "menu": "Menu",
     "siteName": "Find a Doc Japan",

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "Servizi sanitari in Giappone",
+    "aboutTitle": "Chi siamo",
+    "submitTitle": "Invia un professionista",
+    "termsTitle": "Termini di servizio",
+    "privacyTitle": "Informativa sulla privacy"
+  },
   "common": {
     "menu": "Menu",
     "siteName": "Find a Doc Japan",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "日本の医療サービス",
+    "aboutTitle": "私たちについて",
+    "submitTitle": "医療提供者の登録",
+    "termsTitle": "利用規約",
+    "privacyTitle": "プライバシーポリシー"
+  },
   "common": {
     "menu": "メニュー",
     "siteName": "Find a Doc Japan",

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "Serviços de saúde no Japão",
+    "aboutTitle": "Sobre nós",
+    "submitTitle": "Enviar um profissional",
+    "termsTitle": "Termos de serviço",
+    "privacyTitle": "Política de Privacidade"
+  },
   "common": {
     "menu": "Menu",
     "siteName": "Find a Doc Japan",

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "Медицинские услуги в Японии",
+    "aboutTitle": "О нас",
+    "submitTitle": "Добавить специалиста",
+    "termsTitle": "Условия использования",
+    "privacyTitle": "Политика конфиденциальности"
+  },
   "common": {
     "menu": "Меню",
     "siteName": "Find a Doc Japan",

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "Mga Serbisyong Pangkalusugan sa Japan",
+    "aboutTitle": "Tungkol sa Amin",
+    "submitTitle": "Magsumite ng Provider",
+    "termsTitle": "Mga Tuntunin ng Serbisyo",
+    "privacyTitle": "Patakaran sa Privacy"
+  },
   "common": {
     "menu": "Menu",
     "siteName": "Find a Doc Japan",

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -1,4 +1,11 @@
 {
+  "pageMeta": {
+    "homeTitle": "Dịch vụ y tế tại Nhật Bản",
+    "aboutTitle": "Về chúng tôi",
+    "submitTitle": "Gửi thông tin nhà cung cấp",
+    "termsTitle": "Điều khoản dịch vụ",
+    "privacyTitle": "Chính sách bảo mật"
+  },
   "common": {
     "menu": "Menu",
     "siteName": "Find a Doc Japan",

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,8 +2,8 @@ import { defineNuxtConfig } from 'nuxt/config'
 import i18nLocales from './i18n'
 import tailwindcss from '@tailwindcss/vite'
 import { VIEWPORT_BREAKPOINTS, VIEWPORT_FALLBACK_BREAKPOINT } from './utils/viewport'
+import { SITE_TITLE } from './utils/site'
 
-const SITE_TITLE = 'Find a Doc, Japan!'
 const SITE_DESCRIPTION
     = 'Health service information for the international community in Japan'
 
@@ -34,8 +34,6 @@ export default defineNuxtConfig({
     app: {
     // Global page headers: https://nuxt.com/docs/getting-started/seo-meta
         head: {
-            titleTemplate: 'Health Services in Japan',
-            title: SITE_TITLE,
             htmlAttrs: {
                 lang: 'en'
             },

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -531,6 +531,11 @@ interface Member {
 
 const { t } = useI18n()
 const { scrollTo } = useSmoothScroll()
+
+useHead({
+    title: () => t('pageMeta.aboutTitle')
+})
+
 const contributors = ref<Member[]>(shuffleArray(data.members))
 const cofounders = ref<Member[]>(data.cofounders)
 const boardMembers = ref<Member[]>(data.board)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,4 +13,10 @@ import { definePageMeta } from '#imports'
 definePageMeta({
     layout: 'onboarding'
 })
+
+const { t } = useI18n()
+
+useHead({
+    title: () => t('pageMeta.homeTitle')
+})
 </script>

--- a/pages/privacypolicy.vue
+++ b/pages/privacypolicy.vue
@@ -72,4 +72,8 @@
 
 <script setup lang="ts">
 const { t } = useI18n()
+
+useHead({
+    title: () => t('pageMeta.privacyTitle')
+})
 </script>

--- a/pages/submit.vue
+++ b/pages/submit.vue
@@ -9,4 +9,10 @@
 import { useSubmissionStore } from '~/stores/submissionStore'
 
 const submissionStore = useSubmissionStore()
+
+const { t } = useI18n()
+
+useHead({
+    title: () => t('pageMeta.submitTitle')
+})
 </script>

--- a/pages/terms.vue
+++ b/pages/terms.vue
@@ -198,3 +198,11 @@
         </div>
     </div>
 </template>
+
+<script setup lang="ts">
+const { t } = useI18n()
+
+useHead({
+    title: () => t('pageMeta.termsTitle')
+})
+</script>

--- a/utils/site.ts
+++ b/utils/site.ts
@@ -1,0 +1,2 @@
+// The brand name used in the global title template and social meta tags.
+export const SITE_TITLE = 'Find a Doc, Japan!'


### PR DESCRIPTION
## Problem

`titleTemplate` had no `%s` placeholder, so it replaced the title outright on every page. The result (verified on the live site in #1783): every public page shared the single title `Health Services in Japan`, and the brand name "Find a Doc" never appeared in any `<title>` tag.

Closes #1783

## Approach

1. **Global template moved to runtime.** Function-style `titleTemplate` must be set at runtime (via `useHead` in `app.vue`), because head config from `nuxt.config.ts` is serialized into the app manifest and functions are dropped there. I verified this: a function template in `nuxt.config.ts` silently never applied, while the same function in `app.vue` works for every page.

   A string template (`'%s | Find a Doc, Japan!'`) cannot be used alone, because pages without an explicit title then render a broken `" | Find a Doc, Japan!"`. I tested all three combinations locally:

   | Config | Result |
   |---|---|
   | `%s` string + no page title | `"< \| Find a Doc, Japan!"` (broken) |
   | `%s` string + global `title: SITE_TITLE` | `"Find a Doc, Japan! \| Find a Doc, Japan!"` (doubled) |
   | function + no page title | `"Find a Doc, Japan!"` (clean fallback) ✅ |

   The function template handles both cases: pages with a title get wrapped with the brand, pages without fall back to the brand alone. This also removes the global `title` entry that would produce a doubled title once SSR lands (#1787).

2. **Per-page titles.** Each public page (`index`, `about`, `submit`, `terms`, `privacypolicy`) now sets its own title via `useHead({ title: () => t('pageMeta.*') })`, reactive to locale changes. This establishes the per-page head convention the issue asked for — the repo previously had zero `useHead` usages.

3. **Translated titles.** Added a `pageMeta` namespace with translations for all 10 locales (en, ja, cn, de, fr, it, pt, ru, tl, vi), rather than hardcoding English. `SITE_TITLE` was also extracted to `utils/site.ts` so the brand name has a single source of truth shared by `nuxt.config.ts` and `app.vue`.

## Verification

Ran locally (`nuxi dev`) and read `document.title` for each route:

| Route | Title |
|---|---|
| `/` | `Health Services in Japan \| Find a Doc, Japan!` |
| `/about` | `About Us \| Find a Doc, Japan!` |
| `/submit` | `Submit a Provider \| Find a Doc, Japan!` |
| `/terms` | `Terms of Service \| Find a Doc, Japan!` |
| `/privacypolicy` | `Privacy Policy \| Find a Doc, Japan!` |
| `/my-page` (no explicit title) | `Find a Doc, Japan!` (fallback) |

All titles are unique, include the brand, and stay under 60 characters.

- `yarn lint:ci` ✅ (2 pre-existing a11y warnings in `WelcomeScreen.vue`, untouched by this PR)
- `yarn lint:locales` ✅
- `yarn test:unit` ✅ 47/47

One pre-existing oddity worth noting for the SEO epic: `/login` shows `"Find a Doc, Japan"` (no `!`). I traced it with a `document.title` setter breakpoint — it is written outside of unhead's update cycle, both before and after this change, so I left it out of scope here.
