### PR TITLE
fix: return all matching facilities when a city filter is active

### DIFF
--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -18,6 +18,21 @@ type FacilitySearchResult = Facility & {
     healthcareProfessionals: HealthcareProfessional[]
 }
 
+/**
+ * Narrows facilities to a single city, matching either the English or Japanese city name.
+ *
+ * Must be applied only after all batches have been fetched — see `fetchAllFacilities`.
+ */
+function filterFacilitiesByCity(facilities: Facility[], searchCity?: string): Facility[] {
+    if (!searchCity) {
+        return facilities
+    }
+
+    return facilities.filter(facility =>
+        facility.contact?.address.cityEn === searchCity
+        || facility.contact?.address.cityJa === searchCity)
+}
+
 export const useSearchResultsStore = defineStore('searchResultsStore', () => {
     const toast = useAppToast()
 
@@ -74,16 +89,21 @@ export const useSearchResultsStore = defineStore('searchResultsStore', () => {
         let hasMoreBatches = true
 
         while (hasMoreBatches) {
-            const batch = await queryFacilities(searchCity, healthcareProfessionalIDs, batchSize, offset)
+            const batch = await queryFacilities(healthcareProfessionalIDs, batchSize, offset)
 
             allFacilities.push(...batch)
 
-            // If we got less than batchSize, we've reached the end
+            /*
+             * Paginate on how many rows the server returned, never on how many survive the city
+             * filter below. Filtering first and then comparing against batchSize ends the loop as
+             * soon as a batch is partially filtered out, which silently truncated every
+             * city-filtered search to the first batch.
+             */
             hasMoreBatches = batch.length === batchSize
             offset += batchSize
         }
 
-        return allFacilities
+        return filterFacilitiesByCity(allFacilities, searchCity)
     }
 
     // We have the numbers of HelathcareProfessional on runtime
@@ -249,7 +269,6 @@ export const useSearchResultsStore = defineStore('searchResultsStore', () => {
     }
 
     async function queryFacilities(
-    searchCity?: string,
     healthcareProfessionalIDs?: string[],
     limit: number = 100,
     offset: number = 0
@@ -280,14 +299,7 @@ export const useSearchResultsStore = defineStore('searchResultsStore', () => {
 
             notifyServerErrorsIfPresent(serverResponse.errors)
 
-            const facilitiesSearchResults = serverResponse.data.facilities ?? []
-
-            const locationFilteredSearchResults = searchCity
-                ? facilitiesSearchResults.filter(facility =>
-                    facility.contact?.address.cityEn === searchCity || facility.contact?.address.cityJa === searchCity)
-                : facilitiesSearchResults
-
-            return locationFilteredSearchResults
+            return serverResponse.data.facilities ?? []
         } catch (error) {
             console.error(useTranslation('searchResultsErrors.gettingFacilities'), `${JSON.stringify(error)}`)
             // eslint-disable-next-line no-alert

--- a/tests/vitest/piniaTests/searchResultsStore.spec.ts
+++ b/tests/vitest/piniaTests/searchResultsStore.spec.ts
@@ -1,0 +1,158 @@
+import { setActivePinia, createPinia } from 'pinia'
+import { expect } from 'chai'
+import { vi, beforeEach, describe, it } from 'vitest'
+import type { Facility, HealthcareProfessional } from '~/typedefs/gqlTypes'
+
+const graphQLClientRequestWithRetry = vi.fn()
+
+vi.mock('~/utils/graphql', () => ({
+    gqlClient: { request: vi.fn() },
+    graphQLClientRequestWithRetry: (...args: unknown[]) => graphQLClientRequestWithRetry(...args)
+}))
+
+vi.mock('../../../utils/graphql.js', () => ({
+    gqlClient: { request: vi.fn() },
+    graphQLClientRequestWithRetry: (...args: unknown[]) => graphQLClientRequestWithRetry(...args)
+}))
+
+const { useSearchResultsStore } = await import('~/stores/searchResultsStore')
+
+const TOTAL_FACILITIES = 250
+const TARGET_CITY = 'Meguro'
+/** Deliberately past the 100-item first batch — this is what the pagination bug hid. */
+const TARGET_CITY_FIRST_INDEX = 150
+const TARGET_CITY_COUNT = 11
+
+function buildFacility(index: number): Facility {
+    const isInTargetCity = index >= TARGET_CITY_FIRST_INDEX
+      && index < TARGET_CITY_FIRST_INDEX + TARGET_CITY_COUNT
+
+    return {
+        id: `facility-${index}`,
+        nameEn: `Clinic ${index}`,
+        nameJa: `クリニック${index}`,
+        mapLatitude: 35.6,
+        mapLongitude: 139.7,
+        healthcareProfessionalIds: [`professional-${index}`],
+        contact: {
+            address: {
+                cityEn: isInTargetCity ? TARGET_CITY : `Other City ${index}`,
+                cityJa: isInTargetCity ? '目黒' : `他の市${index}`,
+                prefectureEn: 'Tokyo',
+                prefectureJa: '東京都',
+                postalCode: '000-0000',
+                addressLine1En: '1-1-1',
+                addressLine2En: '',
+                addressLine1Ja: '1-1-1',
+                addressLine2Ja: ''
+            }
+        }
+    } as unknown as Facility
+}
+
+const allFacilities = Array.from({ length: TOTAL_FACILITIES }, (_, index) => buildFacility(index))
+
+function buildProfessional(facilityIndex: number): HealthcareProfessional {
+    return {
+        id: `professional-${facilityIndex}`,
+        names: [{ firstName: 'Test', middleName: '', lastName: `Doctor ${facilityIndex}`, locale: 'en_US' }],
+        facilityIds: [`facility-${facilityIndex}`],
+        specialties: [],
+        spokenLanguages: [],
+        degrees: [],
+        acceptedInsurance: []
+    } as unknown as HealthcareProfessional
+}
+
+/** Stands in for the API: honours limit/offset so the store's real pagination loop runs. */
+function respondTo(queryDocument: string, variables: { filters?: Record<string, unknown> }) {
+    const filters = variables?.filters ?? {}
+
+    if (queryDocument.includes('MapPoints')) {
+        return { data: { facilities: allFacilities.map(facility => ({ id: facility.id })) }, errors: [], hasErrors: false }
+    }
+
+    if (queryDocument.includes('QueryFacilities')) {
+        const offset = (filters.offset as number) ?? 0
+        const limit = (filters.limit as number) ?? 100
+
+        return { data: { facilities: allFacilities.slice(offset, offset + limit) }, errors: [], hasErrors: false }
+    }
+
+    if (queryDocument.includes('searchHealthcareProfessionals')) {
+        const requestedIds = (filters.ids as string[]) ?? []
+        const professionals = requestedIds.map(id =>
+            buildProfessional(Number(id.replace('professional-', ''))))
+
+        return { data: { healthcareProfessionals: professionals }, errors: [], hasErrors: false }
+    }
+
+    throw new Error(`Unexpected query: ${queryDocument}`)
+}
+
+describe('searchResultsStore', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia())
+        graphQLClientRequestWithRetry.mockReset()
+        graphQLClientRequestWithRetry.mockImplementation(
+            (_requestFn: unknown, queryDocument: string, variables: { filters?: Record<string, unknown> }) =>
+                Promise.resolve(respondTo(queryDocument, variables))
+        )
+    })
+
+    describe('city filtering across paginated batches', () => {
+        /*
+         * Regression test. `fetchAllFacilities` used to decide whether more batches remained by
+         * comparing the length of an already city-filtered batch against the batch size. Any
+         * active city filter therefore stopped pagination after the first 100 facilities, so
+         * cities that appear only later in the result set returned zero matches.
+         */
+        it('finds facilities in a city that appears only after the first batch', async () => {
+            const searchResultsStore = useSearchResultsStore()
+
+            searchResultsStore.selectedCity = TARGET_CITY
+
+            await searchResultsStore.search()
+
+            expect(searchResultsStore.totalResults).to.equal(TARGET_CITY_COUNT)
+            expect(searchResultsStore.searchResultsList).to.have.lengthOf(TARGET_CITY_COUNT)
+            searchResultsStore.searchResultsList.forEach(facility => {
+                expect(facility.contact?.address.cityEn).to.equal(TARGET_CITY)
+            })
+        })
+
+        it('pages through every batch rather than stopping at the first', async () => {
+            const searchResultsStore = useSearchResultsStore()
+
+            searchResultsStore.selectedCity = TARGET_CITY
+
+            await searchResultsStore.search()
+
+            const facilityRequestOffsets = graphQLClientRequestWithRetry.mock.calls
+                .filter(call => String(call[1]).includes('QueryFacilities'))
+                .map(call => (call[2] as { filters: { offset: number } }).filters.offset)
+
+            expect(facilityRequestOffsets).to.deep.equal([0, 100, 200])
+        })
+
+        it('matches on the Japanese city name as well as the English one', async () => {
+            const searchResultsStore = useSearchResultsStore()
+
+            searchResultsStore.selectedCity = '目黒'
+
+            await searchResultsStore.search()
+
+            expect(searchResultsStore.totalResults).to.equal(TARGET_CITY_COUNT)
+        })
+
+        it('returns every facility when no city is selected', async () => {
+            const searchResultsStore = useSearchResultsStore()
+
+            searchResultsStore.selectedCity = undefined
+
+            await searchResultsStore.search()
+
+            expect(searchResultsStore.totalResults).to.equal(TOTAL_FACILITIES)
+        })
+    })
+})


### PR DESCRIPTION
## Problem

Searching by city silently returned only a fraction of the matching clinics, and for some cities returned nothing at all.

`fetchAllFacilities` decided whether more batches remained by comparing the length of an **already city-filtered** batch against the requested batch size:

```ts
const batch = await queryFacilities(searchCity, ids, batchSize, offset)
allFacilities.push(...batch)
hasMoreBatches = batch.length === batchSize   // batch is already filtered
```

`queryFacilities` applied the city filter client-side before returning. So with a city selected, the first batch of 100 came back as however many matched — almost always fewer than 100 — and the loop exited after a single request.

**Only the first 100 of 465 facilities were ever considered when a city filter was active.** Cities that happen not to appear in that first page returned zero results, rendered to the user as "no clinics found".

Measured against production data:

| City | Returned before | Actually in DB |
|---|---|---|
| Chuo Ward | 5 | 21 |
| Minato City | 7 | 20 |
| Shibuya | 6 | 14 |
| **Meguro** | **0** | **11** |
| **Kagoshima** | **0** | **8** |
| Setagaya | 1 | 10 |
| Shinjuku | 3 | 10 |

This was also inconsistent with the location dropdown, which is populated from a separate `limit: 1000` fetch and therefore sees all 465. The dropdown offered "Meguro (11)" and selecting it produced an empty state.

## Fix

Paginate on what the server returned, and apply the city filter once after every batch has been fetched.

- `queryFacilities` no longer filters — it is now a plain paged fetch.
- `filterFacilitiesByCity` applies the city match (English or Japanese name) to the fully accumulated list.

## Tests

Adds `tests/vitest/piniaTests/searchResultsStore.spec.ts`, which mocks the GraphQL layer with a 250-facility dataset where the target city appears only at index 150 — past the first batch — and drives the store's real pagination loop.

Verified the tests fail against the old code:

```
× finds facilities in a city that appears only after the first batch
    AssertionError: expected +0 to equal 11
× pages through every batch rather than stopping at the first
    AssertionError: expected [ +0 ] to deeply equal [ +0, 100, 200 ]
× matches on the Japanese city name as well as the English one
    AssertionError: expected +0 to equal 11
✓ returns every facility when no city is selected
```

The unfiltered case passes both before and after, confirming no behaviour change when no city is selected.

Full unit suite: 51/51 passing. Lint clean.

## Scope

Deliberately targeted. The root cause is that filtering happens on the client at all — every search currently fetches the entire database over ~10 round trips (~5.9 s, ~570 KB) and filters in the browser. Moving location filtering server-side is tracked separately (it needs a `cityEn`/`prefectureEn` field on `FacilitySearchFilters`, which the API does not yet expose) and will delete this code path entirely.

Not addressed here, and still live: `"Chuo Ward"` (21 facilities) and `"Chuo City"` (9) are the same place stored under two names, so both appear as separate dropdown entries. That is a data normalisation task on the server side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved city-based facility searches across multiple result pages.
  - Searches now check all available pages before applying city filters.
  - Prevented facilities from later pages from being omitted when earlier results are filtered.
  - Added support for matching Japanese city names.
  - Unfiltered searches now correctly return all available facilities.

- **Tests**
  - Added coverage for pagination, city filtering, Japanese names, and unfiltered searches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->