### PR TITLE
feat: AA-compliant palette, brand typeface, and Japanese font support

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -28,16 +28,31 @@
   --color-warning: rgb(var(--theme-color-warning));
   --color-info: rgb(var(--theme-color-info));
   --color-blue: #245A7D;
+
+  /* Brand typeface. Noto Sans has no CJK coverage, so Noto Sans JP is stacked explicitly. */
+  --font-sans: "Noto Sans", "Noto Sans JP", -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Roboto, sans-serif;
 }
 
 @font-face {
-  font-family: notosans;
-  src: url('../fonts/Noto_Sans/NotoSans-Regular.ttf');
+  font-family: "Noto Sans";
+  font-weight: 400;
+  font-display: swap;
+  src: url('../fonts/Noto_Sans/NotoSans-Regular.ttf') format('truetype');
 }
 
 @font-face {
-  font-family: notosans-bold;
-  src: url('../fonts/Noto_Sans/NotoSans-Bold.ttf');
+  font-family: "Noto Sans";
+  font-weight: 600;
+  font-display: swap;
+  src: url('../fonts/Noto_Sans/NotoSans-SemiBold.ttf') format('truetype');
+}
+
+@font-face {
+  font-family: "Noto Sans";
+  font-weight: 700;
+  font-display: swap;
+  src: url('../fonts/Noto_Sans/NotoSans-Bold.ttf') format('truetype');
 }
 
 @layer utilities {
@@ -47,20 +62,28 @@
 }
 
 @layer base {
+  html {
+    font-size: 16px;
+  }
+
+  body {
+    @apply text-base leading-relaxed;
+  }
+
   h1 {
-    @apply text-3xl;
+    @apply text-4xl font-bold leading-tight tracking-tight;
   }
 
   h2 {
-    @apply text-2xl;
+    @apply text-3xl font-bold leading-tight tracking-tight;
   }
 
   h3 {
-    @apply text-xl;
+    @apply text-xl font-semibold leading-snug;
   }
 
   h4 {
-    @apply text-lg font-semibold;
+    @apply text-lg font-semibold leading-snug;
   }
 
   button {
@@ -74,8 +97,8 @@
 
     /* general branding colors */
     --theme-color-primary:
-      /* #0EB0C0 */
-      14 176 192;
+      /* #0A7D89 - AA 4.65:1 on the page ground */
+      10 125 137;
     --theme-color-secondary:
       /* #FB9999 */
       251 153 153;
@@ -86,8 +109,8 @@
       /* #FFFFFF */
       255 255 255;
     --theme-color-primary-hover:
-      /* #0891a0 */
-      8 145 160;
+      /* #08646E - AA 6.55:1 */
+      8 100 110;
     --theme-color-secondary-inverted:
       /* #7f1d1d */
       127 29 29;
@@ -97,35 +120,35 @@
 
     /* element specific colors */
     --theme-color-text-base:
-      /* #1e293b */
-      30 41 59;
+      /* #12212B - AA 15.66:1 */
+      18 33 43;
     --theme-color-text-muted:
-      /* #64748b */
-      100 116 139;
+      /* #4F636B - AA 6.01:1 */
+      79 99 107;
     --theme-color-text-inverted:
       /* #ffffff */
       255 255 255;
     --theme-color-bg-primary:
-      /* #f8fafc */
-      248 250 252;
+      /* #F7FAFB */
+      247 250 251;
     --theme-color-bg-secondary:
       /* #ffffff */
       255 255 255;
     --theme-color-bg-accent:
-      /* #e2e8f0 */
-      226 232 240;
+      /* #DFE7EA */
+      223 231 234;
     --theme-color-success:
-      /* #10b981 */
-      16 185 129;
+      /* #0B815A - AA 4.65:1 */
+      11 129 90;
     --theme-color-error:
-      /* #ef4444 */
-      239 68 68;
+      /* #E21313 - AA 4.62:1 */
+      226 19 19;
     --theme-color-warning:
-      /* #f59e0b */
-      245 158 11;
+      /* #9E6506 - AA 4.64:1 */
+      158 101 6;
     --theme-color-info:
-      /* #3b82f6 */
-      59 130 246;
+      /* #1368F4 - AA 4.64:1 */
+      19 104 244;
   }
 
   .theme-original-dark {

--- a/components/SearchResultsList.vue
+++ b/components/SearchResultsList.vue
@@ -46,12 +46,22 @@
                 <div
                     v-for="(searchResult, index) in searchResultsStore.paginatedResults"
                     :key="searchResult.id"
-                    class="flex flex-col drop-shadow-md my-4 mx-4 py-1 min-h-36 rounded-md border-t-2
-                            border-primary/10 transition-all cursor-pointer"
+                    class="flex flex-col drop-shadow-md my-4 mx-4 py-1 min-h-36 rounded-md
+                            transition-all cursor-pointer"
                     :class="[
+                        /*
+                         * Every border utility lives in this branch, never in the static class
+                         * above. Tailwind emits `border-primary` and `border-primary/10` at equal
+                         * specificity, so a base-class border colour silently wins over the
+                         * selected one depending on stylesheet order, not template order.
+                         *
+                         * The selected card is marked by a solid 2px border rather than a tint:
+                         * the previous 10% coral wash carried the state at 1.07:1 against the
+                         * page, and encoded it in hue alone.
+                         */
                         searchResultsStore.activeFacilityId === searchResult.id
-                            ? 'bg-secondary/10 hover:bg-secondary/30 border-2 border-secondary/10'
-                            : 'bg-primary-bg hover:bg-primary-hover/50',
+                            ? 'border-2 border-primary bg-primary/5 hover:bg-primary/10'
+                            : 'border-t-2 border-primary/10 bg-primary-bg hover:bg-primary-hover/50',
                     ]"
                     role="button"
                     tabindex="0"

--- a/components/onboarding/WelcomeScreen.vue
+++ b/components/onboarding/WelcomeScreen.vue
@@ -33,21 +33,22 @@
                     <button
                         id="welcome-screen-arrow-button"
                         type="button"
-                        class="relative group flex items-center self-start focus:outline-none
-                        bg-secondary hover:bg-secondary/90 transition-colors
+                        class="relative group flex items-center self-start
+                        focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-text-inverted
+                        bg-secondary-bg hover:bg-accent-bg transition-colors
                         px-6 py-3 landscape:mt-24 mt-14
                         rounded-full welcome-lets-go z-10"
                         :aria-label="t('onboarding.letsGoButtonText')"
                         @click="expandBackground"
                     >
                         <!-- Button text -->
-                        <span class="text-xl font-bold text-primary-text-inverted">
+                        <span class="text-xl font-bold text-primary">
                             {{ t('onboarding.letsGoButtonText') }}
                         </span>
                         <!-- Right-pointing Arrow SVG -->
                         <svg
                             aria-hidden="true"
-                            class="w-6 h-6 pt-1 text-primary-text-inverted transform
+                            class="w-6 h-6 pt-1 text-primary transform
                                 group-hover:translate-x-1 transition-transform"
                             fill="none"
                             stroke="currentColor"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -109,7 +109,13 @@ export default defineNuxtConfig({
     },
 
     // Global CSS: https://go.nuxtjs.dev/config-css
-    css: ['~/assets/css/tailwind.css'],
+    css: [
+        // Noto Sans JP, self-hosted. Each weight ships ~124 unicode-range subsets, so a
+        // Latin-only visitor fetches ~16 KB and never downloads the ~1 MB CJK chunk.
+        '@fontsource/noto-sans-jp/400.css',
+        '@fontsource/noto-sans-jp/700.css',
+        '~/assets/css/tailwind.css'
+    ],
 
     runtimeConfig: {
         public: {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "type": "module",
     "dependencies": {
         "@auth0/auth0-vue": "^2.5.0",
+        "@fontsource/noto-sans-jp": "^5.3.0",
         "@pinia/nuxt": "^0.11.3",
         "@sentry/vue": "^10.58.0",
         "graphql": "^16.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,6 +1201,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fontsource/noto-sans-jp@npm:^5.3.0":
+  version: 5.3.0
+  resolution: "@fontsource/noto-sans-jp@npm:5.3.0"
+  checksum: 10/16ffa0e3a705f0e2e738723781708b025847b5350b672d7d4ad4c610e400939caffe46122a73edd94f1a23fd3f9c7cf2dd06d4c98b8acf9cf8f47399b700fac1
+  languageName: node
+  linkType: hard
+
 "@googlemaps/js-api-loader@npm:^2.0.1":
   version: 2.0.2
   resolution: "@googlemaps/js-api-loader@npm:2.0.2"
@@ -9741,6 +9748,7 @@ __metadata:
   resolution: "findadoc-web@workspace:."
   dependencies:
     "@auth0/auth0-vue": "npm:^2.5.0"
+    "@fontsource/noto-sans-jp": "npm:^5.3.0"
     "@graphql-codegen/cli": "npm:^6.1.0"
     "@graphql-codegen/typescript": "npm:^5.0.7"
     "@graphql-codegen/typescript-resolvers": "npm:^5.1.5"


### PR DESCRIPTION
## Problem

The default palette fails WCAG AA at its most common use.

White-on-primary measures **2.63:1**, where AA requires 4.5:1 for text and 3.0:1 even for non-text UI. Every primary button and link on the site clears neither. All four semantic colours fail too.

| Token | Today | Ratio | Proposed | Ratio |
|---|---|---|---|---|
| `--color-primary` | `#0EB0C0` | 2.51 ✕ | `#0A7D89` | 4.65 ✓ |
| `--color-success` | `#10B981` | 2.54 ✕ | `#0B815A` | 4.65 ✓ |
| `--color-error` | `#EF4444` | 3.76 ✕ | `#E21313` | 4.62 ✓ |
| `--color-warning` | `#F59E0B` | 2.15 ✕ | `#9E6506` | 4.64 ✓ |
| `--color-info` | `#3B82F6` | 3.68 ✕ | `#1368F4` | 4.64 ✓ |

Ratios are measured against the page ground `#F7FAFB`, not pure white. Pure white is ~0.23 more forgiving, and measuring against it is how these values passed review while still failing in the product.

Separately, the site has **no brand typeface at all**. `--font-sans` was never defined, so all 114 `font-sans` usages fell through to the system stack — the site rendered in San Francisco, Segoe or Roboto depending on the visitor, and Japanese fell to a second, different fallback again.

## Changes

**Colour.** Darken the brand hue until it clears AA, keeping hue and saturation identical — 185.4° → 185.7°, both 86.4% saturation — so it reads as the same teal at a different tint, not a new colour. Neutrals gain a slight teal bias so surfaces sit with the brand rather than against it.

**Typography.** Define `--font-sans`, and register the Noto Sans faces already sitting unused in `assets/fonts/`. Add `@fontsource/noto-sans-jp` for CJK, which Noto Sans does not cover.

The JP font ships 124 `unicode-range` subsets per weight, so the browser fetches only what it renders. Measured on the running app:

| Visitor | JP subsets fetched | Renders `必要な医療` |
|---|---|---|
| Japanese | 43 — **461 KB** | true |
| English | 4 — **33 KB** | false |

An English visitor never downloads the CJK chunks.

**Two contrast fixes this exposed.**

The onboarding CTA was a coral pill with a white label on a teal field. The label measured 2.08:1 and the pill's own edge 2.35:1 — both failing — leaving it separated from its background almost entirely by hue. It is the only control on a first-time visitor's screen. Now a white fill with a deep-teal label: **6.87:1** and **4.88:1**.

The selected search result was marked with `bg-secondary/10` and a matching border, putting the state indicator at **1.07:1** against the page. The border is now solid primary at **4.65:1**, so selection is carried by a visible edge rather than a tint, and no longer by hue alone.

## Reach

No component was restyled. The two component edits are contrast fixes. The token values reach the rest on their own:

| | Reach |
|---|---|
| Semantic token classes | **639 usages across 58 of 78 `.vue` files** |
| `font-sans` | **114 usages across 19 files** |
| `<h1>`/`<h2>` on the base scale | 34 |

## Verification

Before/after screenshots of seven screens, captured from the running dev server at 1440×900 / 2× DPR — "after" from this commit, "before" from `origin/main`, same viewport and waits.

Worth flagging one thing found during that verification: the **first** version of the selected-border fix was a no-op. It left `border-primary/10` on the static class and put `border-primary` in the conditional; Tailwind emits both at equal specificity, so the faint one won and the computed border came back at alpha `0.1`. It looked applied and did nothing, and would have survived a glance at the screenshot. All border utilities now live in the conditional branch, verified as `rgb(10, 125, 137)` on all four sides.

Lint clean (the two remaining `mouse-events-have-key-events` warnings in `WelcomeScreen.vue` are pre-existing — verified by stashing and re-linting). Unit 47/47, snapshots 4/4.

## Not in this PR

- **Body copy is still `text-sm` in 73 places.** Moving it to `text-base` needs per-component judgment and belongs in its own pass, so the "cramped" feel is not fully addressed here.
- **The eleven theme variants are untouched.** Consolidating to light/dark/auto, retiring the two accessibility themes now that the base palette passes, and wiring up `prefers-color-scheme` is a separate change.
- **Logo `viewBox`, one-line wordmark, and the `Find a Doc, Japan` naming corrections** across ten locale files are queued separately so they can be reviewed on their own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography with Noto Sans and improved CJK character support.
  * Refined heading sizes, weights, spacing, and page-wide base styles.
  * Increased contrast across primary, text, background, status, and accent colors.
  * Improved selected search result styling for clearer focus and feedback.
  * Refreshed the onboarding “Let’s Go” button colors and added a visible keyboard-focus outline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->