### PR TITLE
fix: render the layout slot so app.vue's children mount

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -1,5 +1,3 @@
 <template>
-    <NuxtLayout name="error-layout">
-        <NuxtPage />
-    </NuxtLayout>
+    <NuxtLayout name="error-layout" />
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -13,7 +13,7 @@
         <TopNav class="shrink-0" />
 
         <main class="flex-1 overflow-y-auto">
-            <NuxtPage />
+            <slot />
         </main>
 
         <Footer class="shrink-0" />

--- a/layouts/my-page.vue
+++ b/layouts/my-page.vue
@@ -5,7 +5,7 @@
     >
         <TopNav class="shrink-0" />
         <main class="flex-1 min-h-0 overflow-hidden flex flex-col">
-            <NuxtPage />
+            <slot />
         </main>
     </div>
 </template>

--- a/layouts/onboarding.vue
+++ b/layouts/onboarding.vue
@@ -6,7 +6,7 @@
         data-testid="app"
         class="h-screen w-full font-sans text-primary-text bg-primary-bg"
     >
-        <NuxtPage />
+        <slot />
     </div>
 </template>
 


### PR DESCRIPTION
## Problem

All three layouts render their own `<NuxtPage />` instead of `<slot />`.

`app.vue` already does this:

```vue
<NuxtLayout>
    <NuxtPage />
    <ConfirmationDialog />
</NuxtLayout>
```

which passes those children to the layout as its **default slot**. Because each layout renders a *second* `<NuxtPage />` and never renders `<slot />`, that slot content is discarded and a second router-view is instantiated inside the layout.

Pages still appear, which is why this went unnoticed. What it costs is every *other* child of that slot.

## The user-visible consequence

`ConfirmationDialog` is rendered in exactly one place in the entire repo — `app.vue:4`, inside that slot. So **it has never mounted**.

`composables/useUnsavedChanges.ts` depends on it:

```ts
const tryLeave = (onLeave: () => void | Promise<void>) => {
    if (isDirty.value) {
        useNuxtApp().$withConfirmation(() => {
            makeNonDirty()
            void onLeave()          // <- only reachable from the dialog
        }, { ... })
    } else {
        void onLeave()
    }
}
```

`$withConfirmation` sets reactive state that only `ConfirmationDialog` reads. With no dialog mounted, a moderator with unsaved changes who tries to leave gets **no dialog and no navigation** — the guard silently swallows the action. The clean path (`!isDirty`) works, so the bug only shows up when there is something to lose.

## Verification

Placed a marker element beside `<ConfirmationDialog />` inside the slot and loaded both layouts:

| Layout | Slot rendered (before) | Slot rendered (after) | Page content |
|---|---|---|---|
| `default` via `/about` | **false** | true | present in both |
| `onboarding` via `/` | **false** | true | present in both |

Page content renders in both cases — that is the second `<NuxtPage />` doing its job, and why the symptom stayed hidden. The marker was removed before committing.

## Also

`error.vue` passed a `<NuxtPage />` into `error-layout`, which renders no slot of its own. It was inert, and an error page should not re-render the route that just failed, so it is dropped:

```vue
<NuxtLayout name="error-layout" />
```

## Why now

Beyond the dialog, the double router-view instantiation is a likely source of hydration mismatch once SSR is enabled, and it breaks layout transitions and page-level `key`/transition control. It is cheaper to fix as four lines now than to debug inside an SSR migration.

## Tests

Lint clean. Unit 47/47, snapshots 4/4, and **35/35 e2e** — including the `onboarding` and `home` specs, which drive these layouts directly.