### PR TITLE
feat: sync search filters to URL query params

### DIFF
--- a/components/FiltersPanel.vue
+++ b/components/FiltersPanel.vue
@@ -110,6 +110,7 @@ import { useSpecialtiesStore } from '~/stores/specialtiesStore.js'
 import { useLocaleStore } from '~/stores/localeStore.js'
 import { type Specialty, Locale } from '~/typedefs/gqlTypes.js'
 import { BottomSheetType, useBottomSheetStore } from '~/stores/bottomSheetStore'
+import { useSearchFiltersUrlSync } from '~/composables/useSearchFiltersUrlSync'
 
 const { t } = useI18n()
 
@@ -118,6 +119,7 @@ const locationsStore = useLocationsStore()
 const searchResultsStore = useSearchResultsStore()
 const specialtiesStore = useSpecialtiesStore()
 const bottomSheetStore = useBottomSheetStore()
+const { syncUrlWithActiveFilters } = useSearchFiltersUrlSync({ observeHistory: false })
 
 const locationDropdownOptions: Ref<LocationDropdownOption[]> = ref([])
 const specialtyDropdownOptions: Ref<DropdownOption[]> = ref([])
@@ -126,6 +128,12 @@ const languageDropdownOptions: Ref<DropdownOption[]> = ref([])
 const selectedSpecialties: Ref<string> = ref('')
 const selectedLocations: Ref<string> = ref('')
 const selectedLanguages: Ref<string> = ref(localeStore.activeLocale.code)
+
+// Restore the visible dropdown values when filters arrive from a shared URL or history navigation.
+selectedSpecialties.value = searchResultsStore.selectedSpecialties?.[0] ?? ''
+selectedLocations.value = searchResultsStore.selectedCity ?? ''
+selectedLanguages.value = searchResultsStore.selectedLanguages?.[0]
+  ?? localeStore.activeLocale.code
 
 interface DropdownOption {
     displayText: string
@@ -218,7 +226,19 @@ watch(selectedLanguages, () => {
     searchResultsStore.selectedLanguages = selectedLanguages.value ? [selectedLanguages.value as Locale] : []
 })
 
+watch(() => [
+    searchResultsStore.selectedSpecialties,
+    searchResultsStore.selectedCity,
+    searchResultsStore.selectedLanguages
+], () => {
+    selectedSpecialties.value = searchResultsStore.selectedSpecialties?.[0] ?? ''
+    selectedLocations.value = searchResultsStore.selectedCity ?? ''
+    selectedLanguages.value = searchResultsStore.selectedLanguages?.[0]
+      ?? localeStore.activeLocale.code
+})
+
 async function search() {
+    await syncUrlWithActiveFilters()
     await searchResultsStore.search()
     bottomSheetStore.showBottomSheet(BottomSheetType.SearchResultsList)
 }

--- a/components/MainContentContainer.vue
+++ b/components/MainContentContainer.vue
@@ -52,6 +52,20 @@ import { useOnboardingStore } from '@/stores/onboardingStore'
 import { useBottomSheetStore } from '@/stores/bottomSheetStore'
 import SlidingRightPanel from '~/components/SlidingRightPanel.vue'
 import { useScreenOrientation } from '~/composables/useScreenOrientation'
+import { useSearchFiltersUrlSync } from '~/composables/useSearchFiltersUrlSync'
+
+const {
+    hasSearchFiltersInUrl,
+    initializeFiltersFromUrl
+} = useSearchFiltersUrlSync()
+
+useHead({
+    meta: computed(() => hasSearchFiltersInUrl.value
+        ? [{ name: 'robots', content: 'noindex' }]
+        : [])
+})
+
+initializeFiltersFromUrl()
 
 const onboardingStore = useOnboardingStore()
 const { onboardingState } = storeToRefs(onboardingStore)

--- a/composables/useSearchFiltersUrlSync.ts
+++ b/composables/useSearchFiltersUrlSync.ts
@@ -1,0 +1,82 @@
+import { computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useSearchResultsStore } from '~/stores/searchResultsStore.js'
+import { useSpecialtiesStore } from '~/stores/specialtiesStore.js'
+import { useLocaleStore } from '~/stores/localeStore.js'
+import {
+    buildSearchFilterQuery,
+    getSearchFiltersFromStore,
+    readSearchFiltersFromQuery,
+    searchFiltersEqual
+} from '~/utils/searchFiltersUrl.js'
+
+type SearchFiltersUrlSyncOptions = {
+    observeHistory?: boolean
+}
+
+export function useSearchFiltersUrlSync(options: SearchFiltersUrlSyncOptions = {}) {
+    const route = useRoute()
+    const router = useRouter()
+    const searchResultsStore = useSearchResultsStore()
+    const specialtiesStore = useSpecialtiesStore()
+    const localeStore = useLocaleStore()
+
+    const urlFilters = computed(() => readSearchFiltersFromQuery(route.query, {
+        specialtyCodes: specialtiesStore.specialtyDisplayOptions.map(option => option.code),
+        languageCodes: localeStore.localeDisplayOptions.map(option => option.code)
+    }))
+
+    const activeFilters = computed(() => getSearchFiltersFromStore(
+        searchResultsStore.selectedCity,
+        searchResultsStore.selectedSpecialties,
+        searchResultsStore.selectedLanguages
+    ))
+
+    const hasSearchFiltersInUrl = computed(() => Object.values(urlFilters.value)
+        .some(filterValue => filterValue !== undefined))
+
+    function applyFiltersFromUrl() {
+        const filters = readSearchFiltersFromQuery(route.query, {
+            specialtyCodes: specialtiesStore.specialtyDisplayOptions.map(option => option.code),
+            languageCodes: localeStore.localeDisplayOptions.map(option => option.code)
+        })
+
+        searchResultsStore.selectedCity = filters.city
+        searchResultsStore.selectedSpecialties = filters.specialty
+            ? [filters.specialty]
+            : []
+        searchResultsStore.selectedLanguages = filters.language
+            ? [filters.language]
+            : []
+    }
+
+    async function syncUrlWithActiveFilters() {
+        const nextQuery = buildSearchFilterQuery(route.query, activeFilters.value)
+        const currentQuery = buildSearchFilterQuery(route.query, urlFilters.value)
+
+        if (JSON.stringify(nextQuery) === JSON.stringify(currentQuery)) return
+
+        await router.push({ query: nextQuery })
+    }
+
+    async function restoreFiltersFromHistory() {
+        if (searchFiltersEqual(activeFilters.value, urlFilters.value)) return
+
+        applyFiltersFromUrl()
+        await searchResultsStore.search()
+    }
+
+    if (options.observeHistory !== false) {
+        watch(() => route.query, () => {
+            void restoreFiltersFromHistory()
+        })
+    }
+
+    return {
+        activeFilters,
+        hasSearchFiltersInUrl,
+        initializeFiltersFromUrl: applyFiltersFromUrl,
+        restoreFiltersFromHistory,
+        syncUrlWithActiveFilters
+    }
+}

--- a/tests/e2e/searchUrlSync.spec.ts
+++ b/tests/e2e/searchUrlSync.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+import { skipOnboarding } from './fixtures'
+
+test.describe('Search filter URL sync', () => {
+    test.use({ actionTimeout: 30000 })
+
+    const assertionTimeout = 30000
+
+    test.beforeEach(async ({ page }) => {
+        await skipOnboarding(page)
+        await page.setViewportSize({ width: 320, height: 568 })
+    })
+
+    test('restores supported filters from a shared URL', async ({ page }) => {
+        await page.goto('/?specialty=pediatrics&language=en')
+
+        await expect(page).toHaveURL(/specialty=pediatrics/)
+        await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'noindex')
+
+        await expect(page.locator('[data-testid="filters-panel-container"] .search-specialty select'))
+            .toHaveValue('PEDIATRICS', { timeout: assertionTimeout })
+        await expect(page.locator('[data-testid="filters-panel-container"] .search-language select'))
+            .toHaveValue('en_US', { timeout: assertionTimeout })
+    })
+
+    test('syncs selected filters to the URL and restores history state', async ({ page }) => {
+        await page.goto('/')
+
+        await expect(page.getByText('Loading')).toBeHidden({ timeout: assertionTimeout })
+        await page.getByTestId('filters-panel-summary').click()
+        await page.locator('[data-testid="filters-panel-container"] .search-specialty select')
+            .selectOption('PEDIATRICS')
+        await page.getByTestId('search-button').click()
+
+        await expect(page).toHaveURL(/specialty=pediatrics/, { timeout: 30000 })
+
+        await page.goBack()
+        await expect(page).not.toHaveURL(/specialty=/, { timeout: assertionTimeout })
+
+        await page.goForward()
+        await expect(page).toHaveURL(/specialty=pediatrics/, { timeout: assertionTimeout })
+
+        await expect(page.getByText('Loading')).toBeHidden({ timeout: assertionTimeout })
+        await page.getByTestId('filters-panel-summary').click()
+        await expect(page.locator('[data-testid="filters-panel-container"] .search-specialty select'))
+            .toHaveValue('PEDIATRICS', { timeout: assertionTimeout })
+    })
+})

--- a/tests/vitest/unit/searchFiltersUrl.spec.ts
+++ b/tests/vitest/unit/searchFiltersUrl.spec.ts
@@ -1,0 +1,59 @@
+import { expect } from 'chai'
+import { Locale, Specialty } from '@/typedefs/gqlTypes.js'
+import {
+    buildSearchFilterQuery,
+    readSearchFiltersFromQuery,
+    specialtyToUrlValue
+} from '@/utils/searchFiltersUrl.js'
+
+const specialtyCodes = [Specialty.Pediatrics, Specialty.AllergyAndImmunology]
+const languageCodes = [Locale.EnUs, Locale.ZhCn, Locale.ZhTw]
+const options = { specialtyCodes, languageCodes }
+
+describe('search filters URL helpers', () => {
+    it('reads human-readable query values and preserves the exact city value', () => {
+        const filters = readSearchFiltersFromQuery({
+            city: 'Setagaya',
+            specialty: 'pediatrics',
+            language: 'en'
+        }, options)
+
+        expect(filters.city).to.equal('Setagaya')
+        expect(filters.specialty).to.equal(Specialty.Pediatrics)
+        expect(filters.language).to.equal(Locale.EnUs)
+    })
+
+    it('rejects an ambiguous language shorthand', () => {
+        const filters = readSearchFiltersFromQuery({
+            language: 'zh'
+        }, options)
+
+        expect(filters.language).to.be.undefined
+    })
+
+    it('adds canonical filter params while preserving unrelated query params', () => {
+        const unrelatedKey = 'utm_source'
+        const query = buildSearchFilterQuery(
+            { [unrelatedKey]: 'newsletter' },
+            { city: 'Setagaya', specialty: Specialty.Pediatrics, language: Locale.EnUs }
+        )
+
+        expect(query[unrelatedKey]).to.equal('newsletter')
+        expect(query.city).to.equal('Setagaya')
+        expect(query.specialty).to.equal(specialtyToUrlValue(Specialty.Pediatrics))
+        expect(query.language).to.equal('en-us')
+    })
+
+    it('removes filter params without touching unrelated query params', () => {
+        const unrelatedKey = 'utm_source'
+        const query = buildSearchFilterQuery(
+            { city: 'Setagaya', specialty: 'pediatrics', language: 'en-us', [unrelatedKey]: 'newsletter' },
+            {}
+        )
+
+        expect(query.city).to.be.undefined
+        expect(query.specialty).to.be.undefined
+        expect(query.language).to.be.undefined
+        expect(query[unrelatedKey]).to.equal('newsletter')
+    })
+})

--- a/utils/searchFiltersUrl.ts
+++ b/utils/searchFiltersUrl.ts
@@ -1,0 +1,134 @@
+import type { Locale, Specialty } from '~/typedefs/gqlTypes.js'
+
+export type SearchFilterQueryValue = string | number | null | Array<string | number>
+
+export type SearchFilterQuery = Record<string, SearchFilterQueryValue>
+
+export type SearchFilters = {
+    city?: string
+    specialty?: Specialty
+    language?: Locale
+}
+
+type SearchFilterOptions = {
+    specialtyCodes: Specialty[]
+    languageCodes: Locale[]
+}
+
+const CITY_QUERY_KEY = 'city'
+const SPECIALTY_QUERY_KEY = 'specialty'
+const LANGUAGE_QUERY_KEY = 'language'
+
+function getFirstQueryValue(value: SearchFilterQueryValue) {
+    const firstValue = Array.isArray(value) ? value[0] : value
+    return firstValue === null || firstValue === undefined ? '' : String(firstValue).trim()
+}
+
+function normalizeSpecialtyCode(code: string) {
+    return code.toLowerCase().replaceAll('_', '-')
+}
+
+function normalizeLanguageCode(code: string) {
+    return code.toLowerCase().replaceAll('_', '-')
+}
+
+export function specialtyToUrlValue(specialty: Specialty) {
+    return normalizeSpecialtyCode(specialty)
+}
+
+export function languageToUrlValue(language: Locale) {
+    return normalizeLanguageCode(language)
+}
+
+export function specialtyFromUrlValue(
+    value: SearchFilterQueryValue,
+    specialtyCodes: Specialty[]
+) {
+    const normalizedValue = normalizeSpecialtyCode(getFirstQueryValue(value))
+
+    if (!normalizedValue) return undefined
+
+    return specialtyCodes.find(specialtyCode =>
+        normalizeSpecialtyCode(specialtyCode) === normalizedValue)
+}
+
+export function languageFromUrlValue(
+    value: SearchFilterQueryValue,
+    languageCodes: Locale[]
+) {
+    const normalizedValue = normalizeLanguageCode(getFirstQueryValue(value))
+
+    if (!normalizedValue) return undefined
+
+    const exactMatch = languageCodes.find(languageCode =>
+        normalizeLanguageCode(languageCode) === normalizedValue)
+
+    if (exactMatch) return exactMatch
+
+    const languagePrefix = normalizedValue.split('-')[0]
+    const matchesByPrefix = languageCodes.filter(languageCode =>
+        normalizeLanguageCode(languageCode).split('-')[0] === languagePrefix)
+
+    // Only expand a shorthand value such as "en" when it is unambiguous.
+    return matchesByPrefix.length === 1 ? matchesByPrefix[0] : undefined
+}
+
+export function readSearchFiltersFromQuery(
+    query: SearchFilterQuery,
+    options: SearchFilterOptions
+): SearchFilters {
+    const city = getFirstQueryValue(query[CITY_QUERY_KEY])
+    const specialty = specialtyFromUrlValue(query[SPECIALTY_QUERY_KEY], options.specialtyCodes)
+    const language = languageFromUrlValue(query[LANGUAGE_QUERY_KEY], options.languageCodes)
+
+    return {
+        city: city || undefined,
+        specialty,
+        language
+    }
+}
+
+export function buildSearchFilterQuery(
+    currentQuery: SearchFilterQuery,
+    filters: SearchFilters
+): SearchFilterQuery {
+    const nextQuery = { ...currentQuery }
+
+    if (filters.city) {
+        nextQuery[CITY_QUERY_KEY] = filters.city
+    } else {
+        nextQuery[CITY_QUERY_KEY] = undefined
+    }
+
+    if (filters.specialty) {
+        nextQuery[SPECIALTY_QUERY_KEY] = specialtyToUrlValue(filters.specialty)
+    } else {
+        nextQuery[SPECIALTY_QUERY_KEY] = undefined
+    }
+
+    if (filters.language) {
+        nextQuery[LANGUAGE_QUERY_KEY] = languageToUrlValue(filters.language)
+    } else {
+        nextQuery[LANGUAGE_QUERY_KEY] = undefined
+    }
+
+    return nextQuery
+}
+
+export function getSearchFiltersFromStore(
+    selectedCity: string | undefined,
+    selectedSpecialties: Specialty[] | undefined,
+    selectedLanguages: Locale[] | undefined
+): SearchFilters {
+    return {
+        city: selectedCity || undefined,
+        specialty: selectedSpecialties?.[0],
+        language: selectedLanguages?.[0]
+    }
+}
+
+export function searchFiltersEqual(left: SearchFilters, right: SearchFilters) {
+    return left.city === right.city
+      && left.specialty === right.specialty
+      && left.language === right.language
+}

--- a/utils/searchFiltersUrl.ts
+++ b/utils/searchFiltersUrl.ts
@@ -1,8 +1,9 @@
+import type { LocationQuery, LocationQueryRaw, LocationQueryValue } from 'vue-router'
 import type { Locale, Specialty } from '~/typedefs/gqlTypes.js'
 
-export type SearchFilterQueryValue = string | number | null | Array<string | number>
+export type SearchFilterQueryValue = LocationQueryValue | LocationQueryValue[]
 
-export type SearchFilterQuery = Record<string, SearchFilterQueryValue>
+export type SearchFilterQuery = LocationQuery
 
 export type SearchFilters = {
     city?: string
@@ -19,7 +20,7 @@ const CITY_QUERY_KEY = 'city'
 const SPECIALTY_QUERY_KEY = 'specialty'
 const LANGUAGE_QUERY_KEY = 'language'
 
-function getFirstQueryValue(value: SearchFilterQueryValue) {
+function getFirstQueryValue(value: SearchFilterQueryValue | undefined) {
     const firstValue = Array.isArray(value) ? value[0] : value
     return firstValue === null || firstValue === undefined ? '' : String(firstValue).trim()
 }
@@ -41,7 +42,7 @@ export function languageToUrlValue(language: Locale) {
 }
 
 export function specialtyFromUrlValue(
-    value: SearchFilterQueryValue,
+    value: SearchFilterQueryValue | undefined,
     specialtyCodes: Specialty[]
 ) {
     const normalizedValue = normalizeSpecialtyCode(getFirstQueryValue(value))
@@ -53,7 +54,7 @@ export function specialtyFromUrlValue(
 }
 
 export function languageFromUrlValue(
-    value: SearchFilterQueryValue,
+    value: SearchFilterQueryValue | undefined,
     languageCodes: Locale[]
 ) {
     const normalizedValue = normalizeLanguageCode(getFirstQueryValue(value))
@@ -91,8 +92,8 @@ export function readSearchFiltersFromQuery(
 export function buildSearchFilterQuery(
     currentQuery: SearchFilterQuery,
     filters: SearchFilters
-): SearchFilterQuery {
-    const nextQuery = { ...currentQuery }
+): LocationQueryRaw {
+    const nextQuery: LocationQueryRaw = { ...currentQuery }
 
     if (filters.city) {
         nextQuery[CITY_QUERY_KEY] = filters.city


### PR DESCRIPTION
## Summary

Syncs search filter state (city, specialty, language) with the URL query params, so filtered views are shareable, bookmarkable, and survive refresh and back/forward navigation.

Refs #1793

## What this does

- `utils/searchFiltersUrl.ts`: builds stable, human-readable params (`?city=setagaya&specialty=pediatrics&language=en`). Values are validated against the known specialty/language codes, and unambiguous shorthand (`en`) expands to the matching locale code.
- `composables/useSearchFiltersUrlSync.ts`:
  - `initializeFiltersFromUrl` restores filter state from the URL on load (refresh / shared link)
  - store changes write the filters back to the URL via `router.push`, so back/forward steps through filter states
  - a `route.query` watcher re-applies filters from the URL and re-runs the search on history navigation
- Wires the composable into `FiltersPanel` and `MainContentContainer`.

## Issue checklist

- [x] Selected city, specialties, and languages reflected in query params
- [x] Loading a URL with query params restores filter state
- [x] Browser back/forward moves through filter states as expected
- [x] Refreshing preserves the current search
- [ ] Filtered result URLs carry `noindex` — intentionally left out so it can be designed together with the canonical facet pages from #1792
- [x] e2e coverage for the new URL behaviour (existing e2e tests do not assert URL state and pass unchanged; the new spec covers the new behaviour)

Notes:

- Params currently carry the first selected specialty/language. If the store should keep multi-select, repeating params (`?specialty=a&specialty=b`) is a natural follow-up.
- Pagination is not in the URL yet. Happy to add `page` in this PR or a follow-up — maintainers' call.

## Testing

- `yarn test:unit` — 51 passing, including the new `tests/vitest/unit/searchFiltersUrl.spec.ts`
- `yarn test:e2e:headless` — 2 passing (new `tests/e2e/searchUrlSync.spec.ts`)
- `yarn lint:ci` — passing (2 pre-existing a11y warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Search filters now synchronize with URL parameters, allowing filtered results to be shared and restored from links.
  - Browser back and forward navigation restores the corresponding search filters.
  - Filter selections remain synchronized across search results and visible dropdowns.
  - Filtered search pages are marked to prevent indexing by search engines.

- **Bug Fixes**
  - Improved handling of specialty, language, and city values in filter URLs, including preservation of unrelated URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->