### PR TITLE
fix: stop ConfirmationDialog crashing every prerendered route

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,7 +1,15 @@
 <template>
     <NuxtLayout>
         <NuxtPage />
-        <ConfirmationDialog />
+        <!--
+            Client-only: the dialog reads $confirmationDialog, which is provided by a
+            .client plugin and is therefore undefined during SSR. It has nothing to
+            render server-side anyway — it only ever appears in response to a user
+            action.
+        -->
+        <ClientOnly>
+            <ConfirmationDialog />
+        </ClientOnly>
     </NuxtLayout>
 </template>
 

--- a/components/modals/ConfirmationDialog.vue
+++ b/components/modals/ConfirmationDialog.vue
@@ -80,17 +80,24 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, onUnmounted } from 'vue'
+import { computed, ref, shallowRef, watch, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { vCloseOnOutsideClick } from '~/composables/closeOnOutsideClick'
 
 const modal = ref<HTMLElement | null>(null)
 
-const {
-    confirmation,
-    cancelAction,
-    confirmAction
-} = useNuxtApp().$confirmationDialog
+/*
+ * Destructuring $confirmationDialog directly threw during SSR — it comes from a
+ * .client plugin, so it is undefined on the server, and the crash took down every
+ * prerendered route. The ClientOnly wrapper in app.vue is the real guard; this
+ * fallback keeps the component from being able to break a build again if it is ever
+ * rendered somewhere else.
+ */
+const confirmationDialog = useNuxtApp().$confirmationDialog
+
+const confirmation = confirmationDialog?.confirmation ?? shallowRef(undefined)
+const cancelAction = confirmationDialog?.cancelAction ?? (() => {})
+const confirmAction = confirmationDialog?.confirmAction ?? (() => {})
 
 const { t } = useI18n()
 


### PR DESCRIPTION
**`nuxi generate` is currently broken on `main`.** Every SSR route returns 500, the build emits only `200.html` and `404.html`, and the Playwright workflow — the only job that builds the site — has been red since #1809.

Two files.

## The error

```
TypeError: Cannot destructure property 'confirmation' of
'useNuxtApp(...).$confirmationDialog' as it is undefined.
    at setup (.nuxt/prerender/chunks/build/server.mjs:7460:7)
```

`ConfirmationDialog.vue` destructures `$confirmationDialog`, which is provided by `show-confirmation-dialog-plugin.**client**.ts` and is therefore `undefined` on the server. `app.vue` renders the dialog inside `NuxtLayout`'s default slot, so it is part of every page.

Nitro reports this only as `[500] Server Error` — the stack above came from a temporary `vue:error` hook, which is not part of this PR.

## Why it took three merges to surface

Each of these was green on its own:

| | |
|---|---|
| Before #1809 | No layout rendered `<slot />`, so `ConfirmationDialog` **never mounted anywhere**. The fault was latent. |
| #1809 | Fixed the layouts to render `<slot />` — the dialog now mounts. |
| #1802 | Enabled `ssr: true`. The dialog now mounts **on the server**. |

The combination crashes at setup on every route. Worth noting the latent bug was in the dialog all along; #1809 is what made it reachable.

## Fix

**`app.vue`** wraps the dialog in `<ClientOnly>`. It has nothing to render server-side — it only ever appears in response to a user action — and this matches how #1802 already handles `MapContainer`.

**`ConfirmationDialog.vue`** also falls back to inert handlers when the injection is missing, so it cannot take down a build again if it is ever rendered somewhere else.

## Result

`nuxi generate` now prerenders **26 routes**:

| | Before | After |
|---|---|---|
| `/about` visible text | 0 chars | **3,192 chars**, 6 `<h1>` |
| `/terms` visible text | 0 chars | **3,476 chars**, 1 `<h1>` |
| HTML files emitted | 2 | 11 |

That restores what #1802 was meant to deliver — real prerendered content for crawlers, rather than an empty shell.

**`/` still prerenders empty.** On `main` it is `MainContentContainer` inside `<ClientOnly>`, so there is deliberately no server-rendered content on the homepage. That is a separate problem, addressed by the homepage work.

## Tests

Lint clean (2 pre-existing a11y warnings in `WelcomeScreen.vue`, untouched). Unit 58/58, snapshots 4/4, e2e 32/32 — and, for the first time in several commits, `nuxi generate` completes.