### PR TITLE
feat(seo): generate sitemap.xml from the API

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,7 +2,8 @@ import { defineNuxtConfig } from 'nuxt/config'
 import i18nLocales from './i18n'
 import tailwindcss from '@tailwindcss/vite'
 import { VIEWPORT_BREAKPOINTS, VIEWPORT_FALLBACK_BREAKPOINT } from './utils/viewport'
-import { SITE_DESCRIPTION, SITE_SOCIAL_IMAGE, SITE_TITLE } from './utils/site'
+import { publicSitemapUrls, SITEMAP_EXCLUDE } from './utils/sitemap'
+import { SITE_DESCRIPTION, SITE_ORIGIN, SITE_SOCIAL_IMAGE, SITE_TITLE } from './utils/site'
 
 /**
  * The analytics tag, only when it is actually configured.
@@ -46,6 +47,7 @@ export default defineNuxtConfig({
 
     modules: [
         '@nuxtjs/i18n',
+        '@nuxtjs/sitemap',
         '@pinia/nuxt',
         'nuxt-viewport',
         'nuxt-svgo',
@@ -162,6 +164,10 @@ export default defineNuxtConfig({
         '@fontsource/noto-sans-jp/700.css',
         '~/assets/css/tailwind.css'
     ],
+    site: {
+        url: SITE_ORIGIN,
+        name: SITE_TITLE
+    },
 
     runtimeConfig: {
         public: {
@@ -215,7 +221,7 @@ export default defineNuxtConfig({
     nitro: {
         prerender: {
             crawlLinks: true,
-            routes: ['/', '/about', '/terms', '/privacypolicy', '/submit', '/npo']
+            routes: ['/', '/about', '/terms', '/privacypolicy', '/submit', '/npo', '/sitemap.xml']
         }
     },
 
@@ -247,6 +253,20 @@ export default defineNuxtConfig({
             fallbackLocale: 'en-US',
             alwaysRedirect: true
         }
+    },
+    sitemap: {
+        // One loc per public page until #1796 adds locale prefixes. Entity URLs
+        // join via /api/__sitemap__/directory once #1789 / #1790 set path prefixes.
+        autoI18n: false,
+        excludeAppSources: true,
+        exclude: [...SITEMAP_EXCLUDE],
+        urls: publicSitemapUrls(),
+        sources: ['/api/__sitemap__/directory'],
+        // Google's per-file cap. A sitemap index is unnecessary until locale × entity
+        // URLs cross this; keep /sitemap.xml stable for robots.txt until then.
+        defaultSitemapsChunkSize: 50000,
+        discoverImages: false,
+        discoverVideos: false
     },
 
     storybook: {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "@nuxt/test-utils": "^3.21.0",
         "@nuxt/types": "^2.18.1",
         "@nuxtjs/i18n": "^10.2.1",
+        "@nuxtjs/sitemap": "^8.5.0",
         "@nuxtjs/storybook": "^9.0.1",
         "@pinia/testing": "^1.0.3",
         "@playwright/test": "^1.49.0",

--- a/server/api/__sitemap__/directory.ts
+++ b/server/api/__sitemap__/directory.ts
@@ -1,0 +1,4 @@
+import { defineSitemapEventHandler } from '#imports'
+import { loadDirectorySitemapUrls } from '~/utils/sitemapDirectory'
+
+export default defineSitemapEventHandler(() => loadDirectorySitemapUrls())

--- a/tests/e2e/seo.spec.ts
+++ b/tests/e2e/seo.spec.ts
@@ -20,6 +20,27 @@ test.describe('Discovery and social meta', () => {
         expect(body).toContain(`Sitemap: ${SITE_SITEMAP_URL}`)
     })
 
+    test('sitemap.xml lists every public URL and none of the private trees', async ({ request }) => {
+        const response = await request.get('/sitemap.xml')
+
+        expect(response.status()).toBe(200)
+        expect(response.headers()['content-type']).toMatch(/xml/)
+
+        const body = await response.text()
+        expect(body).toMatch(/<urlset\b/)
+
+        const locs = [...body.matchAll(/<loc>\s*([^<]+)\s*<\/loc>/g)].map(match => match[1].trim())
+        const paths = locs.map(loc => {
+            const pathname = new URL(loc).pathname
+            return pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname || '/'
+        })
+
+        expect(paths.sort()).toEqual([...publicPaths].sort())
+        expect(body).not.toContain(`${new URL(locs[0] ?? 'http://localhost/').origin}/login`)
+        expect(body).not.toContain('/my-page')
+        expect(body).not.toContain('/moderation')
+    })
+
     test('the social preview image is reachable', async ({ request }) => {
         const response = await request.get('/findadoc-social.png')
         expect(response.status()).toBe(200)

--- a/tests/vitest/unit/sitemap.spec.ts
+++ b/tests/vitest/unit/sitemap.spec.ts
@@ -1,0 +1,114 @@
+import { expect } from 'chai'
+import { PAGE_META_TITLE_ROUTES } from '@/utils/pageTitles'
+import { isNoindexRoute, ROBOTS_DISALLOW_PATHS } from '@/utils/seo'
+import { publicSitemapUrls, SITEMAP_EXCLUDE } from '@/utils/sitemap'
+import {
+    collectPagedRows,
+    directoryKindsToFetch,
+    DIRECTORY_SITEMAP_PATHS,
+    loadDirectorySitemapUrls,
+    SITEMAP_DIRECTORY_PAGE_SIZE,
+    sitemapUrlFromEntry
+} from '@/utils/sitemapDirectory'
+
+describe('publicSitemapUrls', () => {
+    it('lists every titled public page and none of the robots-disallowed trees', () => {
+        const locs = publicSitemapUrls().map(entry => entry.loc)
+
+        expect(locs.sort()).to.deep.equal(Object.values(PAGE_META_TITLE_ROUTES).slice().sort())
+        for (const loc of locs) {
+            expect(isNoindexRoute(loc), loc).to.equal(false)
+        }
+    })
+})
+
+describe('SITEMAP_EXCLUDE', () => {
+    it('covers every robots.txt disallow prefix', () => {
+        for (const path of ROBOTS_DISALLOW_PATHS) {
+            expect(SITEMAP_EXCLUDE).to.include(path)
+            expect(SITEMAP_EXCLUDE).to.include(`${path}/**`)
+        }
+    })
+})
+
+describe('sitemapUrlFromEntry', () => {
+    const paths = { facility: '/facilities', professional: '/professionals' }
+
+    it('omits entries until the entity page prefix exists', () => {
+        expect(sitemapUrlFromEntry({ kind: 'facility', id: 'abc', updatedDate: '2026-08-01' })).to.equal(undefined)
+        expect(DIRECTORY_SITEMAP_PATHS.facility).to.equal(undefined)
+        expect(DIRECTORY_SITEMAP_PATHS.professional).to.equal(undefined)
+    })
+
+    it('uses updatedDate as lastmod when the prefix is set', () => {
+        expect(sitemapUrlFromEntry(
+            { kind: 'facility', id: 'abc', updatedDate: '2026-08-01T00:00:00.000Z' },
+            paths
+        )).to.deep.equal({ loc: '/facilities/abc', lastmod: '2026-08-01T00:00:00.000Z' })
+    })
+
+    it('omits lastmod when the API did not send updatedDate', () => {
+        expect(sitemapUrlFromEntry({ kind: 'professional', id: 'p1' }, paths))
+            .to.deep.equal({ loc: '/professionals/p1' })
+    })
+})
+
+describe('collectPagedRows', () => {
+    it('pages at 100 until totalCount is exhausted', async () => {
+        const offsets: number[] = []
+        const rows = Array.from({ length: 250 }, (_, index) => ({ id: String(index) }))
+
+        const collected = await collectPagedRows(async offset => {
+            offsets.push(offset)
+            return {
+                rows: rows.slice(offset, offset + SITEMAP_DIRECTORY_PAGE_SIZE),
+                totalCount: rows.length
+            }
+        })
+
+        expect(SITEMAP_DIRECTORY_PAGE_SIZE).to.equal(100)
+        expect(offsets).to.deep.equal([0, 100, 200])
+        expect(collected.map(row => row.id)).to.deep.equal(rows.map(row => row.id))
+    })
+})
+
+describe('loadDirectorySitemapUrls', () => {
+    it('does not hit the API while entity routes are unset', async () => {
+        let called = false
+        const urls = await loadDirectorySitemapUrls({
+            fetchFacilities: async () => {
+                called = true
+                return { rows: [], totalCount: 0 }
+            },
+            fetchProfessionals: async () => {
+                called = true
+                return { rows: [], totalCount: 0 }
+            }
+        })
+
+        expect(directoryKindsToFetch()).to.deep.equal([])
+        expect(called).to.equal(false)
+        expect(urls).to.deep.equal([])
+    })
+
+    it('pages facilities and maps lastmod once a prefix exists', async () => {
+        const urls = await loadDirectorySitemapUrls(
+            {
+                fetchFacilities: async offset => ({
+                    rows: offset === 0
+                        ? [{ id: 'f1', updatedDate: '2026-08-01T00:00:00.000Z' }]
+                        : [],
+                    totalCount: 1
+                }),
+                fetchProfessionals: async () => {
+                    throw new Error('professionals should not be fetched')
+                }
+            },
+            { facility: '/facilities', professional: undefined }
+        )
+
+        expect(urls).to.deep.equal([
+            { loc: '/facilities/f1', lastmod: '2026-08-01T00:00:00.000Z' }
+        ])
+    })
+})

--- a/utils/sitemap.ts
+++ b/utils/sitemap.ts
@@ -1,0 +1,17 @@
+import { PAGE_META_TITLE_ROUTES } from './pageTitles'
+import { ROBOTS_DISALLOW_PATHS } from './seo'
+
+/**
+ * Private and non-enumerable trees the sitemap must never list. Matches
+ * `robots.txt` plus `/u` (SPA profiles we cannot enumerate from the API yet).
+ */
+export const SITEMAP_EXCLUDE = [
+    ...ROBOTS_DISALLOW_PATHS.flatMap(path => [path, `${path}/**`]),
+    '/u',
+    '/u/**'
+] as const
+
+/** Public indexable paths. The same exhaustive map as document titles. */
+export function publicSitemapUrls(): Array<{ loc: string }> {
+    return Object.values(PAGE_META_TITLE_ROUTES).map(loc => ({ loc }))
+}

--- a/utils/sitemapDirectory.ts
+++ b/utils/sitemapDirectory.ts
@@ -1,0 +1,204 @@
+import { gql, GraphQLClient } from 'graphql-request'
+import type { FacilitySearchFilters, HealthcareProfessionalSearchFilters } from '~/typedefs/gqlTypes'
+
+/**
+ * Same cap the directory store uses. The API silently truncates or errors above this
+ * (see `FACILITY_PAGE_SIZE` in `stores/searchResultsStore.ts`).
+ */
+export const SITEMAP_DIRECTORY_PAGE_SIZE = 100
+
+/**
+ * Entity URL prefixes. `undefined` until the matching page tree ships:
+ * facility #1789, professional #1790. The sitemap fetch is skipped while every
+ * prefix is unset so `nuxi generate` does not advertise URLs that 404.
+ *
+ * Hub and facet pages (#1791, #1792) add their own prefixes here the same way.
+ */
+export const DIRECTORY_SITEMAP_PATHS = {
+    facility: undefined as string | undefined,
+    professional: undefined as string | undefined
+}
+
+export type SitemapDirectoryKind = keyof typeof DIRECTORY_SITEMAP_PATHS
+
+export type SitemapDirectoryEntry = {
+    kind: SitemapDirectoryKind
+    id: string
+    updatedDate?: string | null
+}
+
+export type SitemapDirectoryUrl = {
+    loc: string
+    lastmod?: string
+}
+
+type DirectoryPage<T> = {
+    rows: T[]
+    totalCount: number
+}
+
+export function directorySitemapLoc(
+    kind: SitemapDirectoryKind,
+    id: string,
+    paths: typeof DIRECTORY_SITEMAP_PATHS = DIRECTORY_SITEMAP_PATHS
+): string | undefined {
+    const prefix = paths[kind]
+    if (!prefix) {
+        return undefined
+    }
+    return `${prefix}/${id}`
+}
+
+export function sitemapUrlFromEntry(
+    entry: SitemapDirectoryEntry,
+    paths: typeof DIRECTORY_SITEMAP_PATHS = DIRECTORY_SITEMAP_PATHS
+): SitemapDirectoryUrl | undefined {
+    const loc = directorySitemapLoc(entry.kind, entry.id, paths)
+    if (!loc) {
+        return undefined
+    }
+
+    const lastmod = entry.updatedDate?.trim()
+    return lastmod ? { loc, lastmod } : { loc }
+}
+
+/**
+ * First page reports the total; further pages use the size the server actually
+ * returned so a lower cap still finishes instead of truncating.
+ */
+export async function collectPagedRows<T>(
+    requestPage: (offset: number) => Promise<DirectoryPage<T>>
+): Promise<T[]> {
+    const first = await requestPage(0)
+    const pageSize = first.rows.length
+
+    if (!pageSize || first.totalCount <= pageSize) {
+        return first.rows
+    }
+
+    const rows = [...first.rows]
+    for (let offset = pageSize; offset < first.totalCount; offset += pageSize) {
+        const page = await requestPage(offset)
+        rows.push(...page.rows)
+    }
+    return rows
+}
+
+export function directoryKindsToFetch(
+    paths: typeof DIRECTORY_SITEMAP_PATHS = DIRECTORY_SITEMAP_PATHS
+): SitemapDirectoryKind[] {
+    return (Object.keys(paths) as SitemapDirectoryKind[])
+        .filter(kind => Boolean(paths[kind]))
+}
+
+const sitemapFacilitiesQuery = gql`
+    query SitemapFacilities($filters: FacilitySearchFilters!, $countFilters: FacilitySearchFilters!) {
+        facilities(filters: $filters) {
+            id
+            updatedDate
+        }
+        facilitiesTotalCount(filters: $countFilters)
+    }
+`
+
+const sitemapProfessionalsQuery = gql`
+    query SitemapProfessionals(
+        $filters: HealthcareProfessionalSearchFilters!
+        $countFilters: HealthcareProfessionalSearchFilters!
+    ) {
+        healthcareProfessionals(filters: $filters) {
+            id
+            updatedDate
+        }
+        healthcareProfessionalsTotalCount(filters: $countFilters)
+    }
+`
+
+function directoryApiUrl(): string {
+    return process.env.NUXT_USE_LOCAL_API ? 'http://127.0.0.1:4000' : 'https://api.findadoc.jp'
+}
+
+type DirectoryFetcher = {
+    fetchFacilities: (offset: number) => Promise<DirectoryPage<{ id: string, updatedDate?: string | null }>>
+    fetchProfessionals: (offset: number) => Promise<DirectoryPage<{ id: string, updatedDate?: string | null }>>
+}
+
+function graphqlDirectoryFetcher(apiUrl = directoryApiUrl()): DirectoryFetcher {
+    const client = new GraphQLClient(apiUrl)
+
+    return {
+        async fetchFacilities(offset) {
+            const filters = {
+                limit: SITEMAP_DIRECTORY_PAGE_SIZE,
+                offset
+            } satisfies FacilitySearchFilters
+
+            const data = await client.request<{
+                facilities: Array<{ id: string, updatedDate?: string | null }>
+                facilitiesTotalCount: number
+            }>(sitemapFacilitiesQuery, {
+                filters,
+                countFilters: {} satisfies FacilitySearchFilters
+            })
+
+            return {
+                rows: data.facilities ?? [],
+                totalCount: data.facilitiesTotalCount ?? data.facilities?.length ?? 0
+            }
+        },
+        async fetchProfessionals(offset) {
+            const filters = {
+                limit: SITEMAP_DIRECTORY_PAGE_SIZE,
+                offset
+            } satisfies HealthcareProfessionalSearchFilters
+
+            const data = await client.request<{
+                healthcareProfessionals: Array<{ id: string, updatedDate?: string | null }>
+                healthcareProfessionalsTotalCount: number
+            }>(sitemapProfessionalsQuery, {
+                filters,
+                countFilters: {} satisfies HealthcareProfessionalSearchFilters
+            })
+
+            return {
+                rows: data.healthcareProfessionals ?? [],
+                totalCount: data.healthcareProfessionalsTotalCount ?? data.healthcareProfessionals?.length ?? 0
+            }
+        }
+    }
+}
+
+export async function loadDirectorySitemapUrls(
+    fetcher: DirectoryFetcher = graphqlDirectoryFetcher(),
+    paths: typeof DIRECTORY_SITEMAP_PATHS = DIRECTORY_SITEMAP_PATHS
+): Promise<SitemapDirectoryUrl[]> {
+    const kinds = directoryKindsToFetch(paths)
+    if (kinds.length === 0) {
+        return []
+    }
+
+    const entries: SitemapDirectoryEntry[] = []
+
+    if (kinds.includes('facility')) {
+        const facilities = await collectPagedRows(offset => fetcher.fetchFacilities(offset))
+        entries.push(...facilities.map(row => ({
+            kind: 'facility' as const,
+            id: row.id,
+            updatedDate: row.updatedDate
+        })))
+    }
+
+    if (kinds.includes('professional')) {
+        const professionals = await collectPagedRows(offset => fetcher.fetchProfessionals(offset))
+        entries.push(...professionals.map(row => ({
+            kind: 'professional' as const,
+            id: row.id,
+            updatedDate: row.updatedDate
+        })))
+    }
+
+    return entries.flatMap(entry => {
+        const url = sitemapUrlFromEntry(entry, paths)
+        return url ? [url] : []
+    })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -480,6 +480,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@clack/core@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@clack/core@npm:1.4.3"
+  dependencies:
+    fast-wrap-ansi: "npm:^0.2.0"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10/9d875718cb161e0eca97c3ed3ba3063211436c4224a04556b840e045f18505c8fdb645754d9459181069b3a3b6699962d0f47e38e2502cb0acfef1649b3557b3
+  languageName: node
+  linkType: hard
+
 "@clack/prompts@npm:1.0.0-alpha.8":
   version: 1.0.0-alpha.8
   resolution: "@clack/prompts@npm:1.0.0-alpha.8"
@@ -499,6 +509,18 @@ __metadata:
     picocolors: "npm:^1.0.0"
     sisteransi: "npm:^1.0.5"
   checksum: 10/3159002db77f029e47a1bde7aebb7b233bffed867c41ded3daf9986accfa4bda0b248ed5f17d483cd34446a480a37764f2c94df0a7960f5744cf30f426c14ed6
+  languageName: node
+  linkType: hard
+
+"@clack/prompts@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "@clack/prompts@npm:1.7.0"
+  dependencies:
+    "@clack/core": "npm:1.4.3"
+    fast-string-width: "npm:^3.0.2"
+    fast-wrap-ansi: "npm:^0.2.0"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10/2bfc89d6755a1e10166a3b7a6cc883a09c1d4d82c08fbe98763284d522f256a58ed20c5ee4ab36f2a6e06bc1b3f0c16b02657159f7d593dab12c55260755f0c2
   languageName: node
   linkType: hard
 
@@ -2678,6 +2700,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nodable/entities@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@nodable/entities@npm:3.0.0"
+  checksum: 10/185fef58192584a95c3417d6c59b89bfd0108910da1c2a48ac1c32988d0ff8a9bb4dada0ad27157af49cf18a1765140c61acd7deb6e61f99def08094cc2265db
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -2783,6 +2812,18 @@ __metadata:
   peerDependencies:
     vite: ">=6.0"
   checksum: 10/9aabdcf7eed7ec33ecaa874ee944fa18193b42a7a75ff02cc1d0af8fc2ef4067b7f0a6df437f5131ef6f7f95d1fdc91c183ca9e16811b5017cb4a9bebfc0a18c
+  languageName: node
+  linkType: hard
+
+"@nuxt/devtools-kit@npm:4.0.0-alpha.7":
+  version: 4.0.0-alpha.7
+  resolution: "@nuxt/devtools-kit@npm:4.0.0-alpha.7"
+  dependencies:
+    "@nuxt/kit": "npm:^4.4.6"
+    tinyexec: "npm:^1.2.2"
+  peerDependencies:
+    vite: ">=6.0"
+  checksum: 10/b06c6b06b33f5f0819dbfd701a528597d3083235f569b872995b13792c0d7f28f28d86b8956230e07393bff9fccb60efde744688c00759e4a75f4933a0a71275
   languageName: node
   linkType: hard
 
@@ -2995,6 +3036,35 @@ __metadata:
     unctx: "npm:^2.4.1"
     untyped: "npm:^2.0.0"
   checksum: 10/f2ee4a8f1f2364748994ad382a2b668968b661fa2eda3f5381f8dc8071d553c571c0f10cf11cb747e8c7a0b3011689921b154fcb717a6d0af96e58611434499d
+  languageName: node
+  linkType: hard
+
+"@nuxt/kit@npm:^4.4.6, @nuxt/kit@npm:^4.5.2":
+  version: 4.5.2
+  resolution: "@nuxt/kit@npm:4.5.2"
+  dependencies:
+    c12: "npm:^3.3.4"
+    consola: "npm:^3.4.2"
+    defu: "npm:^6.1.7"
+    destr: "npm:^2.0.5"
+    errx: "npm:^0.1.2"
+    exsolve: "npm:^1.1.1"
+    ignore: "npm:^7.0.6"
+    jiti: "npm:^2.7.0"
+    klona: "npm:^2.0.6"
+    mlly: "npm:^1.8.2"
+    nostics: "npm:^1.2.0"
+    ohash: "npm:^2.0.11"
+    pathe: "npm:^2.0.3"
+    pkg-types: "npm:^2.3.1"
+    rc9: "npm:^3.0.1"
+    scule: "npm:^1.3.0"
+    tinyglobby: "npm:^0.2.17"
+    ufo: "npm:^1.6.4"
+    unctx: "npm:^3.0.0"
+    untyped: "npm:^2.0.0"
+    verkit: "npm:^0.3.1"
+  checksum: 10/d5e33e28c2930a33aac1a611ec021542b9c724e42beb5b56e00216530240f2dd8afe3dee894c486ebcd53d75e432c207007beb0429bc757c0b8a6d2c117bd54c
   languageName: node
   linkType: hard
 
@@ -3295,6 +3365,31 @@ __metadata:
     vue-i18n: "npm:^11.1.11"
     vue-router: "npm:^4.6.3"
   checksum: 10/d7a57d39547b922a583b479dfbc67b130b8bbb3b453bd7dacb272b735a38552114b0a833639c5bcac181016753565b444aa445d1f60e906fc70d7d2453be6e6e
+  languageName: node
+  linkType: hard
+
+"@nuxtjs/sitemap@npm:^8.5.0":
+  version: 8.5.0
+  resolution: "@nuxtjs/sitemap@npm:8.5.0"
+  dependencies:
+    "@nuxt/kit": "npm:^4.5.2"
+    consola: "npm:^3.4.2"
+    defu: "npm:^6.1.7"
+    nuxt-site-config: "npm:^4.2.3"
+    nuxtseo-shared: "npm:^5.3.14"
+    ofetch: "npm:^1.5.1"
+    pathe: "npm:^2.0.3"
+    pkg-types: "npm:^2.3.1"
+    radix3: "npm:^1.1.2"
+    sitemapd: "npm:^0.2.2"
+    ufo: "npm:^1.6.4"
+    ultrahtml: "npm:^1.7.0"
+  peerDependencies:
+    zod: ">=3"
+  peerDependenciesMeta:
+    zod:
+      optional: true
+  checksum: 10/55ebad76ce474440f19820b42a7933fdbcc26f85b720a16362393504eb814ad798c9fb8d9c065d150caa15d52ec9e83a51cc21de23e214481abceb3ce5bf32f2
   languageName: node
   linkType: hard
 
@@ -6702,6 +6797,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"anynum@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "anynum@npm:1.0.1"
+  checksum: 10/096acef76cc8b9f34d43ec37ae9ba7a3d4e2e8c722a0dd59a78995248a8eb4021713ee91b55de106366ac4eaa47578ceb0fffe9829ef01d78b20f9fd6d412a88
+  languageName: node
+  linkType: hard
+
 "arch@npm:^2.2.0":
   version: 2.2.0
   resolution: "arch@npm:2.2.0"
@@ -7021,6 +7123,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"birpc@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "birpc@npm:4.2.0"
+  checksum: 10/ce6ecbb054a1dc89dd073fc6387f0c6e78c51fbbeb3f377ccec14ccba29907f25d1edbe54fb33e28b66600d9ae6000c81699b46023bf3e1c7f1b9e80b7b76554
+  languageName: node
+  linkType: hard
+
 "bluebird@npm:3.7.2":
   version: 3.7.2
   resolution: "bluebird@npm:3.7.2"
@@ -7206,6 +7315,31 @@ __metadata:
     magicast:
       optional: true
   checksum: 10/058026b87656fba996ab9f05d2f5c037f057a314df2ea7410bd812a6eb5881faa585485a337cbbc291a4c0e90c1ecbe5ae704104db72005e9c41c6373414b990
+  languageName: node
+  linkType: hard
+
+"c12@npm:^3.3.4":
+  version: 3.3.4
+  resolution: "c12@npm:3.3.4"
+  dependencies:
+    chokidar: "npm:^5.0.0"
+    confbox: "npm:^0.2.4"
+    defu: "npm:^6.1.6"
+    dotenv: "npm:^17.3.1"
+    exsolve: "npm:^1.0.8"
+    giget: "npm:^3.2.0"
+    jiti: "npm:^2.6.1"
+    ohash: "npm:^2.0.11"
+    pathe: "npm:^2.0.3"
+    perfect-debounce: "npm:^2.1.0"
+    pkg-types: "npm:^2.3.0"
+    rc9: "npm:^3.0.1"
+  peerDependencies:
+    magicast: "*"
+  peerDependenciesMeta:
+    magicast:
+      optional: true
+  checksum: 10/2cf8fc91abd3bca463dae455209a2ca73fa6a035a22ea7506cc2e422caef31d0032fd9eb7855e58d0488eca2858335dd8f1c2604d4e74d134b9521e89fcdb1d5
   languageName: node
   linkType: hard
 
@@ -7504,6 +7638,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"citty@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "citty@npm:0.2.2"
+  checksum: 10/5e17b66ddb65274170e1ab83baec49ef70a07074b4323e29595063d06dfb7710527f3f403b2647acef06eb66871c8ba81d361d24c7166540f78815572da15221
+  languageName: node
+  linkType: hard
+
 "clean-regexp@npm:^1.0.0":
   version: 1.0.0
   resolution: "clean-regexp@npm:1.0.0"
@@ -7766,6 +7907,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"confbox@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "confbox@npm:0.2.4"
+  checksum: 10/10243036f2eca8f02c85f1c8c99f492d2b690e41b5fb9c6bf91afbaca8972eb760bf9fafb7b669433c1ea0c98f12e910d4d1e73b017cd06b72150d080a2c78b6
+  languageName: node
+  linkType: hard
+
+"confbox@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "confbox@npm:0.3.1"
+  checksum: 10/42c0580cc7bd20009df6c8264247db4fda37a63abcc2d94d7503a41eb00a915ec3328e62d495b8e00de7022e941fee6045545f9351d5e644e77d31ae4a543d0d
+  languageName: node
+  linkType: hard
+
 "config-chain@npm:^1.1.13":
   version: 1.1.13
   resolution: "config-chain@npm:1.1.13"
@@ -7822,6 +7977,13 @@ __metadata:
   version: 1.2.2
   resolution: "cookie-es@npm:1.2.2"
   checksum: 10/0fd742c11caa185928e450543f84df62d4b2c1fc7b5041196b57b7db04e1c6ac6585fb40e4f579a2819efefd2d6a9cbb4d17f71240d05f4dcd8f74ae81341a20
+  languageName: node
+  linkType: hard
+
+"cookie-es@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "cookie-es@npm:1.2.3"
+  checksum: 10/899f72d6354de72522ccf01c990c4f6caf8dd3180bd3cb426ea4be495af5acab6e74631e319b969285001ddecf9ea8a0657f71bf4dcd433238f2acc638f36d6f
   languageName: node
   linkType: hard
 
@@ -8362,6 +8524,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"defu@npm:^6.1.6, defu@npm:^6.1.7":
+  version: 6.1.7
+  resolution: "defu@npm:6.1.7"
+  checksum: 10/09480a5fbe6318f622f30017f9386df6ae92ed895fb1ccc61e1ff0d5016b28a321c751749fdd52c996ddd4eafc2c95b77dc0c8cc109881a231c23c7fd630deb9
+  languageName: node
+  linkType: hard
+
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
@@ -8574,6 +8743,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dotenv@npm:^17.3.1":
+  version: 17.4.2
+  resolution: "dotenv@npm:17.4.2"
+  checksum: 10/ca1b6f54d58e39914901e1518958e86083aca8deb5aa2e7f2a51acd53291d97852479b0ab26ed949b6a45a0e9adcc7b0d1c3c72375e8ea670f7005e341c6daba
+  languageName: node
+  linkType: hard
+
 "dpop@npm:^2.1.1":
   version: 2.1.1
   resolution: "dpop@npm:2.1.1"
@@ -8750,6 +8926,13 @@ __metadata:
   version: 0.1.0
   resolution: "errx@npm:0.1.0"
   checksum: 10/96dc94ff92e6f665b7c1ec49bfe38dcee69e9234b2dfb2c51d994fa26089a8690bcee44fc46ca27b8c3314e102db3b743fbaf07575e1d44c2b16ab898ac67889
+  languageName: node
+  linkType: hard
+
+"errx@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "errx@npm:0.1.2"
+  checksum: 10/4a0c9ff64628d90be6a1db4fb98400040c9dd1d906e71bc7d5adf3a53c9bdcd6b16a9b1df33d999ddcbf8fce4e3c0585faba2ed18eaef200763cd0f527b7d925
   languageName: node
   linkType: hard
 
@@ -9662,6 +9845,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"exsolve@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "exsolve@npm:1.1.1"
+  checksum: 10/23d3811f646c29bb3f8639e330bf97ee35bce70dbc1c43e586131eccb928c358c464cb44d88ecb298544506cc8d0f6a66a38afbf076bd7f1d2ec15e5a1ad8dbc
+  languageName: node
+  linkType: hard
+
 "external-editor@npm:^3.0.3":
   version: 3.1.0
   resolution: "external-editor@npm:3.1.0"
@@ -9747,10 +9937,61 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-string-truncated-width@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "fast-string-truncated-width@npm:3.0.3"
+  checksum: 10/3a1631e48927cb558b612a90ee78a61a660823c39b024bfc113935760b5b64805dbf03c4e696c33005294db578417687432e9d13567f1a582c2c75015e8a7648
+  languageName: node
+  linkType: hard
+
+"fast-string-width@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fast-string-width@npm:3.0.2"
+  dependencies:
+    fast-string-truncated-width: "npm:^3.0.2"
+  checksum: 10/5b9019769f2b00b96d43575c202f4e035a0e55eba7669a9a32351de9fa0805d0959a2afcaec6e4db5ee9b9a4c08d8e77f95abeb04b5bae2f76635cf04ddb4b80
+  languageName: node
+  linkType: hard
+
 "fast-uri@npm:^3.0.1":
   version: 3.1.7
   resolution: "fast-uri@npm:3.1.7"
   checksum: 10/6d62ea818841e1b460f60482fd31582faa23ea9d9b33f856412b24c42da11fd72bd003be6696390ec896dbe4e9e78d3bb8d93bf70a511c7f69e5e807ac9b284f
+  languageName: node
+  linkType: hard
+
+"fast-wrap-ansi@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "fast-wrap-ansi@npm:0.2.2"
+  dependencies:
+    fast-string-width: "npm:^3.0.2"
+  checksum: 10/c72272e4ee9c047ec4609adea9beb779f058e0aaee37d9e99d2306c401b34ad2b158ba6969860e35f8be7a0b0ba7512b71315d403e58a45a9f0eba0dc5b4befd
+  languageName: node
+  linkType: hard
+
+"fast-xml-builder@npm:^1.2.0":
+  version: 1.3.1
+  resolution: "fast-xml-builder@npm:1.3.1"
+  dependencies:
+    path-expression-matcher: "npm:^1.6.2"
+    xml-naming: "npm:^0.3.0"
+  checksum: 10/6e2774b07a089c325dbf9d193325a1bf78592e7f3877dfdb643f4898d89a154aa17054cea7270b8b3cc4a7a1145988b0d8a5a974c7086f0e28a6af22a536f55f
+  languageName: node
+  linkType: hard
+
+"fast-xml-parser@npm:^5.10.1":
+  version: 5.11.1
+  resolution: "fast-xml-parser@npm:5.11.1"
+  dependencies:
+    "@nodable/entities": "npm:^3.0.0"
+    fast-xml-builder: "npm:^1.2.0"
+    is-unsafe: "npm:^2.0.0"
+    path-expression-matcher: "npm:^1.6.2"
+    strnum: "npm:^2.4.2"
+    xml-naming: "npm:^0.3.0"
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: 10/9e0854bb49140bb2bdbe527fd71c74c502d5c8766587e6cad49e0175d5b1ee5e751f896445262d6ecdb7a407a644f7c25da5f20ad0feadd08787d3a9505f7dc4
   languageName: node
   linkType: hard
 
@@ -9918,6 +10159,7 @@ __metadata:
     "@nuxt/test-utils": "npm:^3.21.0"
     "@nuxt/types": "npm:^2.18.1"
     "@nuxtjs/i18n": "npm:^10.2.1"
+    "@nuxtjs/sitemap": "npm:^8.5.0"
     "@nuxtjs/storybook": "npm:^9.0.1"
     "@pinia/nuxt": "npm:^0.11.3"
     "@pinia/testing": "npm:^1.0.3"
@@ -10258,6 +10500,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"giget@npm:^3.2.0":
+  version: 3.3.1
+  resolution: "giget@npm:3.3.1"
+  bin:
+    giget: dist/cli.mjs
+  checksum: 10/94601ade8152e1e4b68f35b7b1fa90dbe9ecf0da8f575c5c9805b68842d6150be641365100f59e97ee6fda8959722ec1d250bf7d13ccb14ccc617b300b8445d7
+  languageName: node
+  linkType: hard
+
 "git-up@npm:^8.1.0":
   version: 8.1.1
   resolution: "git-up@npm:8.1.1"
@@ -10519,6 +10770,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"h3@npm:^1.15.11":
+  version: 1.15.11
+  resolution: "h3@npm:1.15.11"
+  dependencies:
+    cookie-es: "npm:^1.2.3"
+    crossws: "npm:^0.3.5"
+    defu: "npm:^6.1.6"
+    destr: "npm:^2.0.5"
+    iron-webcrypto: "npm:^1.2.1"
+    node-mock-http: "npm:^1.0.4"
+    radix3: "npm:^1.1.2"
+    ufo: "npm:^1.6.3"
+    uncrypto: "npm:^0.1.3"
+  checksum: 10/8a13eef49f076eedf1aa6b32ab9190c647cbae517ed2945c951905ef018e2949dd0baa73d0954dc17eaf432d1657e3a09a10ebe5ac5532365083d3560d17d8b5
+  languageName: node
+  linkType: hard
+
 "has-bigints@npm:^1.0.2":
   version: 1.1.0
   resolution: "has-bigints@npm:1.1.0"
@@ -10757,6 +11025,13 @@ __metadata:
   version: 7.0.5
   resolution: "ignore@npm:7.0.5"
   checksum: 10/f134b96a4de0af419196f52c529d5c6120c4456ff8a6b5a14ceaaa399f883e15d58d2ce651c9b69b9388491d4669dda47285d307e827de9304a53a1824801bc6
+  languageName: node
+  linkType: hard
+
+"ignore@npm:^7.0.6":
+  version: 7.0.8
+  resolution: "ignore@npm:7.0.8"
+  checksum: 10/100573dc4ab73ffe0f2231194850a45c6687ac74deb3dce1050add0f849e42d5e530acf59d5612c959afdb83149dec92cfcaf8b44f02d7b57b03fb46fbe9cbc3
   languageName: node
   linkType: hard
 
@@ -11291,6 +11566,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-unsafe@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "is-unsafe@npm:2.0.2"
+  checksum: 10/ebd5b9abfa1e66b221649c9e7f6ed5f1de51dc9913a5c35b192be81b2aeeccb99ef97ae11535d1aa32817e43f73538fb9271c709148f634173b78cebe2eebd2e
+  languageName: node
+  linkType: hard
+
 "is-upper-case@npm:^2.0.2":
   version: 2.0.2
   resolution: "is-upper-case@npm:2.0.2"
@@ -11462,6 +11744,15 @@ __metadata:
   bin:
     jiti: lib/jiti-cli.mjs
   checksum: 10/8cd72c5fd03a0502564c3f46c49761090f6dadead21fa191b73535724f095ad86c2fa89ee6fe4bc3515337e8d406cc8fb2d37b73fa0c99a34584bac35cd4a4de
+  languageName: node
+  linkType: hard
+
+"jiti@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "jiti@npm:2.7.0"
+  bin:
+    jiti: lib/jiti-cli.mjs
+  checksum: 10/6d75a8dbd61dbee031aa0937fabb748ff8ddf370b971958cc704f5cf26b4c5bdc9dcd0563059b2627a2bd41d946fa0bc64f912fdc8981ca7945a9d63c74ad0f9
   languageName: node
   linkType: hard
 
@@ -12614,6 +12905,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mlly@npm:^1.8.2":
+  version: 1.8.2
+  resolution: "mlly@npm:1.8.2"
+  dependencies:
+    acorn: "npm:^8.16.0"
+    pathe: "npm:^2.0.3"
+    pkg-types: "npm:^1.3.1"
+    ufo: "npm:^1.6.3"
+  checksum: 10/e13b79edb113ac9d3ce8b5998d490cd979e907d31b562b9c6630e59623d32710cc83be1da46755ccd3143c57d50debcf98a9903d55e6e07e57910dc3369d96c1
+  languageName: node
+  linkType: hard
+
 "mocked-exports@npm:^0.1.1":
   version: 0.1.1
   resolution: "mocked-exports@npm:0.1.1"
@@ -12977,6 +13280,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nostics@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "nostics@npm:1.2.0"
+  checksum: 10/eddb85764b5862ae30fc3f442e1b54df907bbc6ec0c8bfc8f7a4dd4892afe241eadd0e68888f846e1cf6ab96f3e0f7ccb435ef87654604c1b4cc297fefc00556
+  languageName: node
+  linkType: hard
+
 "npm-run-path@npm:^4.0.1":
   version: 4.0.1
   resolution: "npm-run-path@npm:4.0.1"
@@ -13037,6 +13347,39 @@ __metadata:
     pathe: "npm:^2.0.3"
     ufo: "npm:^1.6.1"
   checksum: 10/022226f93c629fcb90aa1630ec61835e5fb0c6aa3d59a90d1c5ed76d4b3e34f424b82ee53e8e00da291f8b6a74fc8425f7d7f05aa00af135e236b6fed7e7489f
+  languageName: node
+  linkType: hard
+
+"nuxt-site-config-kit@npm:4.2.3":
+  version: 4.2.3
+  resolution: "nuxt-site-config-kit@npm:4.2.3"
+  dependencies:
+    "@nuxt/kit": "npm:^4.5.2"
+    site-config-stack: "npm:4.2.3"
+    std-env: "npm:^4.2.0"
+    ufo: "npm:^1.6.4"
+  checksum: 10/70a307f86b44ae42c4c04ea6e998b98b145b8e77967cfda367d339a8630ab6ceff49155ac7b266bf943590d4706c0a423da875bfa1e0eb6f8b26dc43294a7861
+  languageName: node
+  linkType: hard
+
+"nuxt-site-config@npm:^4.2.3":
+  version: 4.2.3
+  resolution: "nuxt-site-config@npm:4.2.3"
+  dependencies:
+    "@nuxt/devalue": "npm:^2.0.2"
+    "@nuxt/kit": "npm:^4.5.2"
+    consola: "npm:^3.4.2"
+    defu: "npm:^6.1.7"
+    h3: "npm:^1.15.11"
+    nuxt-site-config-kit: "npm:4.2.3"
+    nuxtseo-shared: "npm:^5.3.12"
+    pathe: "npm:^2.0.3"
+    pkg-types: "npm:^2.3.1"
+    site-config-stack: "npm:4.2.3"
+    ufo: "npm:^1.6.4"
+  peerDependencies:
+    vue: ^3.5.30
+  checksum: 10/71202c9e05c2707e7f48431011e95e2a2637d2ca2d41cd1699d8b0c295fb0b8c4ea1b02b76c909450b42db1608ca46bb2b23a2b116f0e525d2b76c75936d5908
   languageName: node
   linkType: hard
 
@@ -13151,6 +13494,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nuxtseo-shared@npm:^5.3.12, nuxtseo-shared@npm:^5.3.14":
+  version: 5.3.14
+  resolution: "nuxtseo-shared@npm:5.3.14"
+  dependencies:
+    "@clack/prompts": "npm:^1.7.0"
+    "@nuxt/devtools-kit": "npm:4.0.0-alpha.7"
+    "@nuxt/kit": "npm:^4.5.2"
+    birpc: "npm:^4.0.0"
+    consola: "npm:^3.4.2"
+    defu: "npm:^6.1.7"
+    nypm: "npm:^0.6.9"
+    ofetch: "npm:^1.5.1"
+    pathe: "npm:^2.0.3"
+    pkg-types: "npm:^2.3.1"
+    radix3: "npm:^1.1.2"
+    sirv: "npm:^3.0.2"
+    std-env: "npm:^4.2.0"
+    ufo: "npm:^1.6.4"
+  peerDependencies:
+    "@nuxt/schema": ^3.16.0 || ^4.0.0 || ^5.0.0
+    nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
+    nuxt-site-config: ^3.2.0 || ^4.0.0
+    vue: ^3.5.0
+    zod: ^3.23.0 || ^4.0.0
+  peerDependenciesMeta:
+    nuxt-site-config:
+      optional: true
+    zod:
+      optional: true
+  checksum: 10/f8e65cc89795184cdd9527d85b4065129fa977fee4b5a2d8b5c2617d9a0ae405c06d6522cd2e1c21fa8acf861654a2cf4ed0f4d96eacd63ee89c94d04b13c1aa
+  languageName: node
+  linkType: hard
+
 "nypm@npm:^0.6.0, nypm@npm:^0.6.2":
   version: 0.6.2
   resolution: "nypm@npm:0.6.2"
@@ -13163,6 +13539,19 @@ __metadata:
   bin:
     nypm: dist/cli.mjs
   checksum: 10/3bbf25b02b9eab5565a9a11c1f0946d0065cc6a9028e8f438ebf5256f3139cfac0763a3852984a7ae92c761ab1c2ce881272f9b1a863107e195e7f7cae05b598
+  languageName: node
+  linkType: hard
+
+"nypm@npm:^0.6.9":
+  version: 0.6.9
+  resolution: "nypm@npm:0.6.9"
+  dependencies:
+    citty: "npm:^0.2.2"
+    pathe: "npm:^2.0.3"
+    tinyexec: "npm:^1.2.4"
+  bin:
+    nypm: ./dist/cli.mjs
+  checksum: 10/8d608043e4a0229acce8f2818f500e6dc27633aa8e1804a469c76b6f6e9ee7f587e57a4cd74127fe06cb889e64a2beb2a81ffd1d8f41393370f0023ce437ecbc
   languageName: node
   linkType: hard
 
@@ -13849,6 +14238,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-expression-matcher@npm:^1.6.2":
+  version: 1.6.2
+  resolution: "path-expression-matcher@npm:1.6.2"
+  checksum: 10/d7786b170933dd82ed897144daed7d54dbe2e7b7d8684182ee9bf51a966cc92548788e2f49280922202a0186409008d816aefa37ed4650e4038184181a73c4bd
+  languageName: node
+  linkType: hard
+
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
@@ -13994,6 +14390,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"perfect-debounce@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "perfect-debounce@npm:2.1.0"
+  checksum: 10/1e45b92ab585fa1bfafaf01783b693b6d164a4da3b80865487f716a010d95e3d8b1131693258e342da25da671312c194cddb103c4743161f57dcf26574273fe6
+  languageName: node
+  linkType: hard
+
 "picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -14012,6 +14415,13 @@ __metadata:
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
   checksum: 10/57b99055f40b16798f2802916d9c17e9744e620a0db136554af01d19598b96e45e2f00014c91d1b8b13874b80caa8c295b3d589a3f72373ec4aaf54baa5962d5
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.4":
+  version: 4.0.7
+  resolution: "picomatch@npm:4.0.7"
+  checksum: 10/66e1df34bc39c72fa3756be4069f7887ea3e35e94bba1c3f6167763007698cb04b8a0a365161d186fda6e9571a2d3efb606b2966eb6a7dea6252911224dc2f48
   languageName: node
   linkType: hard
 
@@ -14056,6 +14466,17 @@ __metadata:
     exsolve: "npm:^1.0.7"
     pathe: "npm:^2.0.3"
   checksum: 10/4b36e4eb12693a1beb145573c564ec6fb74b1008d3b457eaa1f0072331edf05cb7c479c47fe0c4bfdec76c2caff5b68215ff270e5fe49634c07984a7a0197118
+  languageName: node
+  linkType: hard
+
+"pkg-types@npm:^2.3.1":
+  version: 2.3.2
+  resolution: "pkg-types@npm:2.3.2"
+  dependencies:
+    confbox: "npm:^0.3.0"
+    exsolve: "npm:^1.1.1"
+    pathe: "npm:^2.0.3"
+  checksum: 10/492075121ea6ac690b82a0c6c6dfe8cae73935fb820dfc3d5d822452ae8af9f86a98b0d642294e78c82d3960350e1de2108378fb6c09d10a2d59feecdb913983
   languageName: node
   linkType: hard
 
@@ -14754,6 +15175,16 @@ __metadata:
     defu: "npm:^6.1.4"
     destr: "npm:^2.0.3"
   checksum: 10/0694d2a80579983a5e4f0452092d9f6a06b785b104b32f48f3d6bb263f637e53d9ebd1fd77a41b157b84c1c7e8e4ecc87c3824907738653a296e6d2faf3d1844
+  languageName: node
+  linkType: hard
+
+"rc9@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "rc9@npm:3.1.0"
+  dependencies:
+    defu: "npm:^6.1.7"
+    destr: "npm:^2.0.5"
+  checksum: 10/0917a78dafec4b907e97b6af2a062810c9538893bfe61d762e7af34d81acdc2c0a8c9d57e8746dfee56369e0dec4338eb362406c4296f1bdaa0763b7ab57e090
   languageName: node
   linkType: hard
 
@@ -15630,6 +16061,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"site-config-stack@npm:4.2.3":
+  version: 4.2.3
+  resolution: "site-config-stack@npm:4.2.3"
+  dependencies:
+    ufo: "npm:^1.6.4"
+  peerDependencies:
+    vue: ^3.5.30
+  checksum: 10/1b574a6ad9675e5745ee64da480186e4e734c0240967340cd3defa3f7d8a187deac1b772fb37f30e32601863a3a9e3320d74ebd17c191c12b4542c92c372de80
+  languageName: node
+  linkType: hard
+
+"sitemapd@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "sitemapd@npm:0.2.2"
+  dependencies:
+    fast-xml-parser: "npm:^5.10.1"
+  checksum: 10/c9bf8044bb808f12a1d2ad332f4b7d56c1ce7707a8d29b7fe2474d01684364506ed1910f24b9d2f155779e709e51a6d8b1b83fd561903dfdb5b93901de5eed05
+  languageName: node
+  linkType: hard
+
 "slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -15859,6 +16310,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"std-env@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "std-env@npm:4.2.0"
+  checksum: 10/d30c3ae49c5568b4e61dca628eaafe12944dbcfe76980e5b1b1499b48e23f85f1ee01fe2306eeef5964a80b763948bbf2ba40490bc53709f45cf989071c9e4e7
+  languageName: node
+  linkType: hard
+
 "stop-iteration-iterator@npm:^1.0.0":
   version: 1.1.0
   resolution: "stop-iteration-iterator@npm:1.1.0"
@@ -16052,6 +16510,15 @@ __metadata:
   dependencies:
     js-tokens: "npm:^9.0.1"
   checksum: 10/6eb00906a1c343a1050579d1d6023e067a2d72152edb92e64cad49535115beb2e77905ace24aa459f29b66e75edba75ef9d8eca90575b0322640d64a5d37e131
+  languageName: node
+  linkType: hard
+
+"strnum@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "strnum@npm:2.4.2"
+  dependencies:
+    anynum: "npm:^1.0.1"
+  checksum: 10/c624b2f1a4ba0962cfa66e645b583782e868d0f0ab2e038c3c554e81c2040c3e48463d1e078ff1d6ab4932a0b352f34bc51fdd4f8bbd9bf8da66bf9332c85cf4
   languageName: node
   linkType: hard
 
@@ -16305,6 +16772,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinyexec@npm:^1.2.2, tinyexec@npm:^1.2.4":
+  version: 1.3.1
+  resolution: "tinyexec@npm:1.3.1"
+  checksum: 10/9c7a8ce2633f76c776d9ff663531c7b34d605f41909c2f97a27397e8c12bcaf721dae7680b6683232ffe7a6d465090be9926d5ffd00b5d7be9336a43b45289b1
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.14, tinyglobby@npm:^0.2.15":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
@@ -16312,6 +16786,16 @@ __metadata:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.3"
   checksum: 10/d72bd826a8b0fa5fa3929e7fe5ba48fceb2ae495df3a231b6c5408cd7d8c00b58ab5a9c2a76ba56a62ee9b5e083626f1f33599734bed1ffc4b792406408f0ca2
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10/f85e8a217d675c3f78d5f0ad25ea4557e7e023ed13ddc2b014da10bd0312eea53a34cd52356af07ccdff777f1243012547656282a4ca70936f68bf5065fbaa71
   languageName: node
   linkType: hard
 
@@ -16606,10 +17090,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ufo@npm:^1.6.4":
+  version: 1.6.4
+  resolution: "ufo@npm:1.6.4"
+  checksum: 10/dbf85425e00dd106abb852c0ea4cef6e58b395b9a43858049a8be0b0825e5cc4b53cf58a41da695c3c2a9ab4f8605923b64812be1358c39a56b3920504759d3a
+  languageName: node
+  linkType: hard
+
 "ultrahtml@npm:^1.6.0":
   version: 1.6.0
   resolution: "ultrahtml@npm:1.6.0"
   checksum: 10/8b9c5e03f4ac0e4cf789b938b5e589c050c9f12d98a60996931d5af6d93b675f91af9609508d603f08f6b9d0c07611335dcb6c85f6472f414d02fe620f432c9e
+  languageName: node
+  linkType: hard
+
+"ultrahtml@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "ultrahtml@npm:1.7.0"
+  checksum: 10/08332cb417a9097fd06770526b01358db204dd007b57e1cd217897cf865570e4fdd4c737f068cc2904c98a83563cfe2294e151ecadccb9f666b8788cc8f6cc6b
   languageName: node
   linkType: hard
 
@@ -16636,6 +17134,27 @@ __metadata:
     magic-string: "npm:^0.30.21"
     unplugin: "npm:^2.3.11"
   checksum: 10/201ca8b01f4a4476105c8eff04687973c9a8bce8327cacb77dea766e1c01caa1a31493359d08aaeb69d12d99d465b8d2dd856332f6341bf119dbb3310475cd02
+  languageName: node
+  linkType: hard
+
+"unctx@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "unctx@npm:3.0.1"
+  peerDependencies:
+    magic-string: ">=0.30.21"
+    oxc-parser: ">=0.140.0"
+    rolldown: ^1.1.5
+    unplugin: ^3.3.0
+  peerDependenciesMeta:
+    magic-string:
+      optional: true
+    oxc-parser:
+      optional: true
+    rolldown:
+      optional: true
+    unplugin:
+      optional: true
+  checksum: 10/d5e1183ee907cf6a82144dcbc1ab3031bf4e8b6738452145a15613aeadf57b9586ca9282b6e0af6c42e8c1839518ded84a513e2614cdc8d54c5135a1270b094d
   languageName: node
   linkType: hard
 
@@ -17100,6 +17619,13 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10/31389debef15a480849b8331b220782230b9815a8e0dbb7b9a8369559aed2e9a7800cd904d4371ea74f4c3527db456dc8e7ac5befce5f0d289014dbdf47b2242
+  languageName: node
+  linkType: hard
+
+"verkit@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "verkit@npm:0.3.2"
+  checksum: 10/23e57c28094da170e381e27c020cddde0543fbac377b111c325a18440da4502d21c58446ef25794ecc1f2434df1d6297edf760910245ac5b90199a9bb18d8634
   languageName: node
   linkType: hard
 
@@ -17955,6 +18481,13 @@ __metadata:
   version: 5.0.0
   resolution: "xml-name-validator@npm:5.0.0"
   checksum: 10/43f30f3f6786e406dd665acf08cd742d5f8a46486bd72517edb04b27d1bcd1599664c2a4a99fc3f1e56a3194bff588b12f178b7972bc45c8047bdc4c3ac8d4a1
+  languageName: node
+  linkType: hard
+
+"xml-naming@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "xml-naming@npm:0.3.0"
+  checksum: 10/1a09c3f14747bf243d4bbcfdb9917c40e9cbb4b6464f2b9fe6927976770dfa38eedfe94190b5b6db470f22429fd4bda688b1831ca36a769a6745ccb9bb595150
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
✅ Resolves #1788

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed

`/sitemap.xml` was a 404. `@nuxtjs/sitemap` now prerenders it from the same public path map as page titles (`/`, `/about`, `/submit`, `/terms`, `/privacypolicy`, `/npo`, `/search`). Login, my-page, moderation, and `/u` are excluded.

Entity URLs are not listed yet — those pages do not exist (#1789–#1792). The GraphQL pager (limit 100, `updatedDate` → `lastmod`) lives in `utils/sitemapDirectory.ts` and is skipped until those prefixes are set, so generate does not advertise 404s or depend on the API for unused data.

A sitemap index is not enabled. Seven URLs (and ~1,100 after entity pages) stay under Google's 50,000 cap; `/sitemap.xml` stays the URL `robots.txt` already names. Index + chunking wait until #1796 multiplies locales past that cap.

## 🧪 Testing instructions

- [x] `yarn vitest run -c vitest.unit.config.ts tests/vitest/unit/sitemap.spec.ts`
- [ ] Playwright `tests/e2e/seo.spec.ts` on CI (`GET /sitemap.xml` is 200 XML, loc set equals the public pages, no `/login` / `/my-page` / `/moderation`)
- [ ] After the Netlify preview is up: `curl -sI https://<preview>/sitemap.xml` is 200 and the body validates (e.g. https://www.xml-sitemaps.com/validate-xml-sitemap.html)
- [ ] Post-merge ops (needs Search Console access, not doable from this PR): submit `https://www.findadoc.jp/sitemap.xml` in Google Search Console


Made with [Cursor](https://cursor.com)