### PR TITLE
feat(seo): add healthcare professional detail pages

### DIFF
--- a/components/search/DoctorDetails.vue
+++ b/components/search/DoctorDetails.vue
@@ -1,0 +1,212 @@
+<template>
+    <div
+        data-testid="doctor-details"
+        class="flex flex-col gap-8"
+    >
+        <header class="flex flex-col gap-3">
+            <div class="flex flex-col gap-1">
+                <h1
+                    id="doctor-details-title"
+                    class="text-2xl font-bold leading-tight text-primary-text"
+                >
+                    {{ displayName }}
+                </h1>
+                <p
+                    v-if="otherLanguageName"
+                    class="m-0 text-lg text-primary-text-muted"
+                    data-testid="doctor-other-name"
+                >
+                    {{ otherLanguageName }}
+                </p>
+                <p
+                    v-if="degrees"
+                    class="m-0 text-primary-text-muted"
+                >
+                    {{ degrees }}
+                </p>
+            </div>
+        </header>
+
+        <section
+            v-if="specialties.length"
+            class="flex flex-col gap-3"
+        >
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-primary-text-muted">
+                {{ t('doctorPage.specialties') }}
+            </h2>
+            <ul class="m-0 flex list-none flex-wrap gap-1.5 p-0">
+                <li
+                    v-for="specialty in specialties"
+                    :key="specialty"
+                    class="chip chip-primary h-7 px-2.5 text-xs"
+                >
+                    {{ specialty }}
+                </li>
+            </ul>
+        </section>
+
+        <section
+            v-if="languages.length"
+            class="flex flex-col gap-3"
+        >
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-primary-text-muted">
+                {{ t('doctorPage.languages') }}
+            </h2>
+            <ul class="m-0 flex list-none flex-wrap gap-1.5 p-0">
+                <li
+                    v-for="languageName in languages"
+                    :key="languageName"
+                    class="chip h-7 px-2.5 text-xs"
+                >
+                    {{ languageName }}
+                </li>
+            </ul>
+        </section>
+
+        <section
+            v-if="insurance.length"
+            class="flex flex-col gap-3"
+        >
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-primary-text-muted">
+                {{ t('doctorPage.insurance') }}
+            </h2>
+            <ul class="m-0 flex list-none flex-wrap gap-1.5 p-0">
+                <li
+                    v-for="label in insurance"
+                    :key="label"
+                    class="chip h-7 px-2.5 text-xs"
+                >
+                    {{ label }}
+                </li>
+            </ul>
+        </section>
+
+        <section
+            v-if="additionalInfo"
+            class="flex flex-col gap-3"
+        >
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-primary-text-muted">
+                {{ t('doctorPage.additionalInfo') }}
+            </h2>
+            <p class="m-0 whitespace-pre-line text-primary-text">
+                {{ additionalInfo }}
+            </p>
+        </section>
+
+        <section
+            v-if="facilities.length"
+            class="flex flex-col gap-3"
+        >
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-primary-text-muted">
+                {{ t('doctorPage.facilities') }}
+            </h2>
+            <ul class="m-0 flex list-none flex-col gap-3 p-0">
+                <li
+                    v-for="facility in facilities"
+                    :key="facility.id"
+                    data-testid="doctor-facility"
+                    class="card flex flex-col gap-1 p-4"
+                >
+                    <NuxtLink
+                        :to="facility.path"
+                        class="text-lg font-semibold leading-snug text-primary hover:underline"
+                    >
+                        {{ facility.name }}
+                    </NuxtLink>
+                    <p
+                        v-if="facility.address"
+                        class="m-0 text-sm text-primary-text-muted"
+                    >
+                        {{ facility.address }}
+                    </p>
+                </li>
+            </ul>
+        </section>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { localeDisplayOptions } from '~/stores/localeStore'
+import { useSpecialtiesStore } from '~/stores/specialtiesStore'
+import { formatHealthcareProfessionalName } from '~/utils/nameUtils'
+import { isJapaneseLocale, toGqlLocale } from '~/utils/activeLocale'
+import { facilityPath } from '~/utils/clinicPath'
+import type { ProfessionalSearchResult } from '~/utils/doctorProfessional'
+import { Insurance, Locale, type LocalizedName } from '~/typedefs/gqlTypes'
+
+const props = defineProps<{
+    professional: ProfessionalSearchResult
+}>()
+
+const { t, locale } = useI18n()
+const specialtiesStore = useSpecialtiesStore()
+
+const isJapanese = computed(() => isJapaneseLocale(locale.value))
+const gqlLocale = computed(() => toGqlLocale(locale.value))
+
+const displayName = computed(() => formatHealthcareProfessionalName(props.professional.names, gqlLocale.value))
+
+function formatOneName(name: LocalizedName): string {
+    const first = name.firstName?.trim() ?? ''
+    const last = name.lastName?.trim() ?? ''
+    if (!first && !last) {
+        return ''
+    }
+    return name.locale === Locale.JaJp ? `${last} ${first}`.trim() : `${first} ${last}`.trim()
+}
+
+const otherLanguageName = computed(() => {
+    const names = (props.professional.names ?? [])
+        .map(formatOneName)
+        .filter(name => name && name !== displayName.value)
+
+    return [...new Set(names)][0] ?? ''
+})
+
+const degrees = computed(() => (props.professional.degrees ?? []).join(', '))
+
+const specialties = computed(() => (props.professional.specialties ?? [])
+    .map(code => specialtiesStore.specialtyDisplayOptions.find(option => option.code === code)?.displayText)
+    .filter((name): name is string => !!name))
+
+const languages = computed(() => (props.professional.spokenLanguages ?? [])
+    .map(code => localeDisplayOptions.find(option => option.code === code)?.simpleText)
+    .filter((name): name is string => !!name))
+
+function insuranceLabel(code: Insurance): string {
+    switch (code) {
+        case Insurance.InsuranceNotAccepted:
+            return t('doctorPage.insuranceLabels.INSURANCE_NOT_ACCEPTED')
+        case Insurance.InternationalHealthInsurance:
+            return t('doctorPage.insuranceLabels.INTERNATIONAL_HEALTH_INSURANCE')
+        case Insurance.JapaneseHealthInsurance:
+            return t('doctorPage.insuranceLabels.JAPANESE_HEALTH_INSURANCE')
+        case Insurance.TravelInsurance:
+            return t('doctorPage.insuranceLabels.TRAVEL_INSURANCE')
+        case Insurance.Uninsured:
+            return t('doctorPage.insuranceLabels.UNINSURED')
+        default:
+            return code
+    }
+}
+
+const insurance = computed(() => (props.professional.acceptedInsurance ?? []).map(insuranceLabel))
+
+const additionalInfo = computed(() => props.professional.additionalInfoForPatients?.trim() ?? '')
+
+const facilities = computed(() => props.professional.facilities.map(facility => {
+    const address = facility.contact?.address
+    const addressText = isJapanese.value
+        ? `${address?.prefectureJa ?? ''}${address?.cityJa ?? ''}`
+        : [address?.cityEn, address?.prefectureEn].filter(Boolean).join(', ')
+
+    return {
+        id: facility.id,
+        path: facilityPath(facility),
+        name: (isJapanese.value ? facility.nameJa : facility.nameEn) || facility.nameEn,
+        address: addressText
+    }
+}))
+</script>

--- a/components/search/SearchResultCard.vue
+++ b/components/search/SearchResultCard.vue
@@ -58,7 +58,12 @@
                 class="flex flex-col"
             >
                 <span class="leading-snug">
-                    <span class="font-medium">{{ professional.name }}</span>
+                    <NuxtLink
+                        :to="professional.path"
+                        class="relative z-10 font-medium text-primary hover:underline"
+                    >
+                        {{ professional.name }}
+                    </NuxtLink>
                     <span
                         v-if="professional.degrees"
                         class="text-sm text-primary-text-muted"
@@ -87,6 +92,7 @@ import { useSpecialtiesStore } from '~/stores/specialtiesStore'
 import { formatHealthcareProfessionalName } from '~/utils/nameUtils'
 import { isJapaneseLocale, toGqlLocale } from '~/utils/activeLocale'
 import { facilityPath } from '~/utils/clinicPath'
+import { professionalPath } from '~/utils/doctorPath'
 import type { FacilitySearchResult } from '~/utils/searchDirectory'
 
 const props = defineProps<{
@@ -134,6 +140,7 @@ const languages = computed(() => {
 
 const professionals = computed(() => props.result.healthcareProfessionals.map(professional => ({
     id: professional.id,
+    path: professionalPath(professional),
     name: formatHealthcareProfessionalName(professional.names, toGqlLocale(locale.value)),
     degrees: (professional.degrees ?? []).join(', '),
     specialties: (professional.specialties ?? [])

--- a/components/search/SearchResultDetails.vue
+++ b/components/search/SearchResultDetails.vue
@@ -121,10 +121,12 @@
                     class="card flex flex-col gap-3 p-4"
                 >
                     <div class="flex flex-col">
-                        <!-- Names stay text until #1790 ships /doctor/[slug]--[id] pages. -->
-                        <p class="m-0 text-lg font-semibold leading-snug text-primary-text">
+                        <NuxtLink
+                            :to="professional.path"
+                            class="text-lg font-semibold leading-snug text-primary hover:underline"
+                        >
                             {{ professional.name }}
-                        </p>
+                        </NuxtLink>
                         <p
                             v-if="professional.degrees"
                             class="m-0 text-sm text-primary-text-muted"
@@ -186,6 +188,7 @@ import { formatHealthcareProfessionalName } from '~/utils/nameUtils'
 import { isJapaneseLocale, toGqlLocale } from '~/utils/activeLocale'
 import { formatToReadableDate } from '~/utils/dateUtils'
 import { useUmami } from '~/composables/useUmamiTracking'
+import { professionalPath } from '~/utils/doctorPath'
 import { facilityEmail,
     facilityMapsUrl,
     facilityPhone,
@@ -251,6 +254,7 @@ const email = computed(() => facilityEmail(props.facility))
 
 const professionals = computed(() => props.facility.healthcareProfessionals.map(professional => ({
     id: professional.id,
+    path: professionalPath(professional),
     name: formatHealthcareProfessionalName(professional.names, toGqlLocale(locale.value)),
     degrees: (professional.degrees ?? []).join(', '),
     specialties: (professional.specialties ?? [])

--- a/composables/useColorScheme.ts
+++ b/composables/useColorScheme.ts
@@ -8,7 +8,7 @@ const LEGACY_KEYS = ['theme', 'isDarkMode']
 /*
  * Module-level so every ThemeManager (footer, hamburger menu) shares one source of truth.
  * The <html> class is also set by an inline script in <head> before first paint — see
- * nuxt.config.ts — so this composable only has to keep the two in step after hydration.
+ * utils/nuxt/appHead.ts — so this composable only has to keep the two in step after hydration.
  */
 const scheme = ref<ColorScheme>('auto')
 let initialized = false

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -23,3 +23,10 @@ declare module '#clinic-directory' {
     const directory: Record<string, FacilitySearchResult>
     export default directory
 }
+
+declare module '#doctor-directory' {
+    import type { ProfessionalSearchResult } from './utils/clinicPrerender'
+
+    const directory: Record<string, ProfessionalSearchResult>
+    export default directory
+}

--- a/i18n/locales/cn.json
+++ b/i18n/locales/cn.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/i18n/locales/pt.json
+++ b/i18n/locales/pt.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/i18n/locales/ru.json
+++ b/i18n/locales/ru.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/i18n/locales/tl.json
+++ b/i18n/locales/tl.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/i18n/locales/vi.json
+++ b/i18n/locales/vi.json
@@ -514,5 +514,23 @@
   "clinicPage": {
     "backToSearch": "Back to search",
     "metaDescription": "{name} in {city}, {prefecture}. Address, phone and the languages spoken by staff."
+  },
+  "doctorPage": {
+    "backToSearch": "Back to search",
+    "metaDescription": "{name} — {specialties}. Languages spoken: {languages}.",
+    "specialtiesFallback": "healthcare professional",
+    "languagesFallback": "languages listed on the profile",
+    "specialties": "Specialties",
+    "languages": "Languages spoken",
+    "insurance": "Accepted insurance",
+    "additionalInfo": "For patients",
+    "facilities": "Clinics",
+    "insuranceLabels": {
+      "INSURANCE_NOT_ACCEPTED": "Does not accept insurance",
+      "INTERNATIONAL_HEALTH_INSURANCE": "International health insurance",
+      "JAPANESE_HEALTH_INSURANCE": "Japanese health insurance",
+      "TRAVEL_INSURANCE": "Travel insurance",
+      "UNINSURED": "Uninsured / self-pay"
+    }
   }
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,88 +2,14 @@ import { defineNuxtConfig } from 'nuxt/config'
 import i18nLocales from './i18n'
 import tailwindcss from '@tailwindcss/vite'
 import { VIEWPORT_BREAKPOINTS, VIEWPORT_FALLBACK_BREAKPOINT } from './utils/viewport'
-import { isNuxtGenerateCommand, buildClinicPrerenderDirectory } from './utils/clinicPrerender'
 import { publicSitemapUrls, SITEMAP_EXCLUDE } from './utils/sitemap'
 import { SITE_DESCRIPTION, SITE_ORIGIN, SITE_SOCIAL_IMAGE, SITE_TITLE } from './utils/site'
-
-type ClinicPrerenderBuild = Awaited<ReturnType<typeof buildClinicPrerenderDirectory>>
-
-let clinicDirectoryBuild: ClinicPrerenderBuild | undefined
-let clinicDirectoryBuildPromise: Promise<ClinicPrerenderBuild> | undefined
-
-async function clinicDirectoryForGenerate(): Promise<ClinicPrerenderBuild> {
-    if (!isNuxtGenerateCommand()) {
-        return null
-    }
-
-    clinicDirectoryBuildPromise ??= buildClinicPrerenderDirectory().then(built => {
-        clinicDirectoryBuild = built
-        return built
-    })
-
-    return clinicDirectoryBuildPromise
-}
-
-function clinicDirectoryVitePlugin() {
-    return {
-        name: 'clinic-directory',
-        resolveId(id: string) {
-            if (id === '#clinic-directory') {
-                return '\0clinic-directory'
-            }
-        },
-        load(this: { environment?: { name?: string } }, id: string) {
-            if (id !== '\0clinic-directory') {
-                return
-            }
-
-            if (this.environment?.name === 'client') {
-                return 'export default {}'
-            }
-
-            const directory = clinicDirectoryBuild?.directory ?? {}
-            return `export default ${JSON.stringify(directory)}`
-        }
-    }
-}
-
-/**
- * The analytics tag, only when it is actually configured.
- *
- * A bare truthiness check is not enough: the deploy environment sets these to the
- * literal two-character string `""`, which is truthy, so the build emitted
- * `<script src='""'>`. An empty `src` resolves against the current document, so every
- * page requested itself as JavaScript — normally a harmless 404, but fatal on any path
- * covered by an SPA rewrite, where it returns HTML with 200 and the parser throws
- * `Unexpected token '<'` before the app can hydrate.
- */
-function umamiScript() {
-    const clean = (value?: string) => value?.replace(/^["']|["']$/g, '').trim() ?? ''
-    const url = clean(process.env.NUXT_PUBLIC_UMAMI_URL)
-    const siteId = clean(process.env.NUXT_PUBLIC_UMAMI_SITE_ID)
-
-    if (!url || !siteId || process.env.NODE_ENV !== 'production') {
-        return []
-    }
-
-    return [{ src: url, async: true, defer: true, 'data-website-id': siteId }]
-}
-
-/**
- * Applies the stored colour scheme before first paint.
- *
- * Runs inline in <head> so a returning dark-mode visitor never sees a light flash on a
- * prerendered page. Mirrors the migration in composables/useColorScheme.ts: only an explicit
- * dark choice survives from the old five-colourway picker. Anything else means "auto", which
- * is no class at all — the stylesheet then follows prefers-color-scheme.
- */
-const COLOR_SCHEME_BOOTSTRAP = `(function () {
-  try {
-    var s = localStorage.getItem('colorScheme')
-    if (s !== 'dark' && s !== 'light') s = localStorage.getItem('isDarkMode') === 'true' ? 'dark' : ''
-    if (s) document.documentElement.classList.add('theme-' + s)
-  } catch (e) {}
-})()`
+import { COLOR_SCHEME_BOOTSTRAP, umamiScript } from './utils/nuxt/appHead'
+import {
+    applyEntityDirectoryToNitro,
+    applyEntityDirectoryToNuxt,
+    entityDirectoryVitePlugins
+} from './utils/nuxt/entityDirectoryGenerate'
 
 export default defineNuxtConfig({
 
@@ -212,9 +138,10 @@ export default defineNuxtConfig({
     },
 
     runtimeConfig: {
-        // Filled during `nuxi generate` so clinic pages prerender from memory.
+        // Filled during `nuxi generate` so clinic and doctor pages prerender from memory.
         // Private: not sent to the browser. Empty in `nuxi dev` (live GraphQL).
         clinicPrerenderDirectory: {},
+        doctorPrerenderDirectory: {},
         public: {
             isTestingMode: process.env.NUXT_IS_TESTING_MODE,
 
@@ -246,8 +173,9 @@ export default defineNuxtConfig({
          * /search reads its filters from the query string and loads the directory from the
          * API in the browser, so there is nothing to prerender: a static shell would ship an
          * empty result list under a real heading, which is worse for crawlers than no page.
-         * Clinic URLs (`/clinic/…`, #1789) are the indexable entity pages; they are listed
-         * for generate in the nitro:config hook, not here, so unknown IDs stay a real 404.
+         * Clinic URLs (`/clinic/…`, #1789) and doctor URLs (`/doctor/…`, #1790) are the
+         * indexable entity pages; they are listed for generate in the nitro:config hook,
+         * not here, so unknown IDs stay a real 404.
          */
         '/search': { ssr: false },
         '/login': { ssr: false },
@@ -262,8 +190,9 @@ export default defineNuxtConfig({
     nitro: {
         prerender: {
             crawlLinks: true,
-            // Clinic HTML is filled from the generate-time directory cache, not live
-            // facility(id) calls. Parallel prerender is then just disk, not API.
+            // Clinic and doctor HTML is filled from the generate-time directory cache, not
+            // live facility(id)/healthcareProfessional(id) calls. Parallel prerender is then
+            // just disk, not API.
             concurrency: 8,
             routes: ['/', '/about', '/terms', '/privacypolicy', '/submit', '/npo', '/sitemap.xml']
         }
@@ -271,37 +200,16 @@ export default defineNuxtConfig({
 
     vite: { plugins: [
         tailwindcss(),
-        clinicDirectoryVitePlugin()
+        ...entityDirectoryVitePlugins()
     ] },
     telemetry: false,
 
     hooks: {
         async ready(nuxt) {
-            const built = await clinicDirectoryForGenerate()
-            if (!built) {
-                return
-            }
-
-            nuxt.options.runtimeConfig.clinicPrerenderDirectory = built.directory
+            await applyEntityDirectoryToNuxt(nuxt)
         },
         async 'nitro:config'(nitroConfig) {
-            const built = await clinicDirectoryForGenerate()
-            if (!built || nitroConfig.dev) {
-                return
-            }
-
-            console.warn(`[clinic prerender] ${built.paths.length} clinic pages from directory payload`)
-            nitroConfig.runtimeConfig ??= {}
-            nitroConfig.runtimeConfig.clinicPrerenderDirectory = built.directory
-            nitroConfig.virtual = {
-                ...nitroConfig.virtual,
-                '#clinic-directory': `export default ${JSON.stringify(built.directory)}`
-            }
-            nitroConfig.prerender ??= {}
-            const existing = nitroConfig.prerender.routes
-            nitroConfig.prerender.routes = Array.isArray(existing)
-                ? [...existing, ...built.paths]
-                : built.paths
+            await applyEntityDirectoryToNitro(nitroConfig)
         }
     },
     eslint: {
@@ -330,8 +238,8 @@ export default defineNuxtConfig({
         }
     },
     sitemap: {
-        // One loc per public page until #1796 adds locale prefixes. Clinic URLs
-        // join via /api/__sitemap__/directory; professionals wait on #1790.
+        // One loc per public page until #1796 adds locale prefixes. Clinic and
+        // doctor URLs join via /api/__sitemap__/directory.
         autoI18n: false,
         excludeAppSources: true,
         exclude: [...SITEMAP_EXCLUDE],

--- a/pages/clinic/[prefecture]/[city]/[slug].vue
+++ b/pages/clinic/[prefecture]/[city]/[slug].vue
@@ -34,7 +34,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createError, navigateTo, useAsyncData, useHead, useRoute } from '#imports'
 import { fetchClinicById } from '~/utils/clinicFacility'
-import { facilityDocumentTitle, facilityIdFromSlugParam, facilityPath } from '~/utils/clinicPath'
+import { canonicalPathMatches, facilityDocumentTitle, facilityIdFromSlugParam, facilityPath } from '~/utils/clinicPath'
 import { isJapaneseLocale } from '~/utils/activeLocale'
 import { formatPageTitle } from '~/utils/site'
 
@@ -54,11 +54,8 @@ if (!data.value) {
 }
 
 const canonicalPath = facilityPath(data.value)
-const currentPath = route.path.length > 1 && route.path.endsWith('/')
-    ? route.path.slice(0, -1)
-    : route.path
 
-if (currentPath !== canonicalPath) {
+if (!canonicalPathMatches(route.path, canonicalPath)) {
     await navigateTo(canonicalPath, { redirectCode: 301, replace: true })
 }
 

--- a/pages/doctor/[slug].vue
+++ b/pages/doctor/[slug].vue
@@ -31,6 +31,7 @@ import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { createError, navigateTo, useAsyncData, useHead, useRoute } from '#imports'
 import { fetchDoctorById } from '~/utils/doctorProfessional'
+import { canonicalPathMatches } from '~/utils/clinicPath'
 import { professionalDocumentTitle, professionalIdFromSlugParam, professionalPath } from '~/utils/doctorPath'
 import { formatHealthcareProfessionalName } from '~/utils/nameUtils'
 import { toGqlLocale } from '~/utils/activeLocale'
@@ -55,11 +56,8 @@ if (!data.value) {
 }
 
 const canonicalPath = professionalPath(data.value)
-const currentPath = route.path.length > 1 && route.path.endsWith('/')
-    ? route.path.slice(0, -1)
-    : route.path
 
-if (currentPath !== canonicalPath) {
+if (!canonicalPathMatches(route.path, canonicalPath)) {
     await navigateTo(canonicalPath, { redirectCode: 301, replace: true })
 }
 

--- a/pages/doctor/[slug].vue
+++ b/pages/doctor/[slug].vue
@@ -1,0 +1,100 @@
+<template>
+    <div
+        data-testid="doctor-page"
+        class="page-container flex flex-col gap-6 px-4 py-8"
+    >
+        <NuxtLink
+            to="/search"
+            class="btn btn-ghost btn-sm -ml-1 self-start"
+            data-testid="doctor-back-to-search"
+        >
+            <svg
+                class="h-5 w-5 stroke-current"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+            >
+                <path d="M19 12H5m7-7-7 7 7 7" />
+            </svg>
+            {{ t('doctorPage.backToSearch') }}
+        </NuxtLink>
+
+        <DoctorDetails :professional="professional" />
+    </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { createError, navigateTo, useAsyncData, useHead, useRoute } from '#imports'
+import { fetchDoctorById } from '~/utils/doctorProfessional'
+import { professionalDocumentTitle, professionalIdFromSlugParam, professionalPath } from '~/utils/doctorPath'
+import { formatHealthcareProfessionalName } from '~/utils/nameUtils'
+import { toGqlLocale } from '~/utils/activeLocale'
+import { formatPageTitle } from '~/utils/site'
+import { localeDisplayOptions } from '~/stores/localeStore'
+import { useSpecialtiesStore } from '~/stores/specialtiesStore'
+
+const route = useRoute()
+const { t, locale } = useI18n()
+const specialtiesStore = useSpecialtiesStore()
+
+const professionalId = professionalIdFromSlugParam(String(route.params.slug ?? ''))
+
+if (!professionalId) {
+    throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+}
+
+const { data } = await useAsyncData(`doctor-${professionalId}`, () => fetchDoctorById(professionalId))
+
+if (!data.value) {
+    throw createError({ statusCode: 404, statusMessage: 'Page not found' })
+}
+
+const canonicalPath = professionalPath(data.value)
+const currentPath = route.path.length > 1 && route.path.endsWith('/')
+    ? route.path.slice(0, -1)
+    : route.path
+
+if (currentPath !== canonicalPath) {
+    await navigateTo(canonicalPath, { redirectCode: 301, replace: true })
+}
+
+const professional = computed(() => data.value!)
+
+const displayName = computed(() => formatHealthcareProfessionalName(professional.value.names, toGqlLocale(locale.value)))
+
+const metaDescription = computed(() => {
+    const specialties = (professional.value.specialties ?? [])
+        .map(code => specialtiesStore.specialtyDisplayOptions.find(option => option.code === code)?.displayText)
+        .filter((name): name is string => !!name)
+        .join(', ')
+    const languages = (professional.value.spokenLanguages ?? [])
+        .map(code => localeDisplayOptions.find(option => option.code === code)?.simpleText)
+        .filter((name): name is string => !!name)
+        .join(', ')
+
+    return t('doctorPage.metaDescription', {
+        name: displayName.value,
+        specialties: specialties || t('doctorPage.specialtiesFallback'),
+        languages: languages || t('doctorPage.languagesFallback')
+    })
+})
+
+const documentTitle = computed(() => professionalDocumentTitle(displayName.value))
+const brandedTitle = computed(() => formatPageTitle(documentTitle.value))
+
+useHead({
+    title: documentTitle,
+    meta: computed(() => [
+        { name: 'description', content: metaDescription.value, key: 'description' },
+        { property: 'og:title', content: brandedTitle.value, key: 'og:title' },
+        { property: 'og:description', content: metaDescription.value, key: 'og:description' },
+        { name: 'twitter:title', content: brandedTitle.value, key: 'twitter:title' },
+        { name: 'twitter:description', content: metaDescription.value, key: 'twitter:description' }
+    ])
+})
+</script>

--- a/tests/e2e/doctor.spec.ts
+++ b/tests/e2e/doctor.spec.ts
@@ -1,6 +1,9 @@
 import { professionalDocumentTitle, professionalPath } from '../../utils/doctorPath'
 import { formatPageTitle } from '../../utils/site'
+import type { HealthcareProfessional } from '../../typedefs/gqlTypes'
 import { test, expect } from '@playwright/test'
+
+type SeededProfessional = Pick<HealthcareProfessional, 'id' | 'names'>
 
 const UNKNOWN_DOCTOR_PATH
     = '/doctor/missing--00000000-0000-4000-8000-000000000001'
@@ -13,10 +16,7 @@ test.describe('Professional pages', () => {
     })
 
     test('renders a seeded professional when the local API is up', async ({ page, request }) => {
-        let professional: {
-            id: string
-            names?: Array<{ firstName?: string, lastName?: string, locale?: string }>
-        } | undefined
+        let professional: SeededProfessional | undefined
 
         try {
             const response = await request.post('http://127.0.0.1:4000', {
@@ -30,7 +30,7 @@ test.describe('Professional pages', () => {
                 }
             })
             const json = await response.json() as {
-                data?: { healthcareProfessionals?: typeof professional[] }
+                data?: { healthcareProfessionals?: SeededProfessional[] }
             }
             professional = json.data?.healthcareProfessionals?.[0]
         } catch {
@@ -43,22 +43,15 @@ test.describe('Professional pages', () => {
             return
         }
 
-        const path = professionalPath({
-            id: professional.id,
-            names: professional.names ?? []
-        })
-        const english = professional.names?.find(name => name.locale === 'en_US')
-        const displayName = english
-            ? `${english.firstName ?? ''} ${english.lastName ?? ''}`.trim()
-            : `${professional.names?.[0]?.firstName ?? ''} ${professional.names?.[0]?.lastName ?? ''}`.trim()
+        const path = professionalPath(professional)
 
         await page.goto(path)
 
         await expect(page.getByTestId('doctor-page')).toBeVisible()
-        if (displayName) {
-            await expect(page.getByRole('heading', { level: 1, name: displayName })).toBeVisible()
-            await expect(page).toHaveTitle(formatPageTitle(professionalDocumentTitle(displayName)))
-        }
+        const heading = page.getByRole('heading', { level: 1 })
+        await expect(heading).toBeVisible()
+        const headingText = (await heading.innerText()).trim()
+        await expect(page).toHaveTitle(formatPageTitle(professionalDocumentTitle(headingText)))
         await expect(page.getByTestId('doctor-back-to-search')).toBeVisible()
     })
 })

--- a/tests/e2e/doctor.spec.ts
+++ b/tests/e2e/doctor.spec.ts
@@ -1,0 +1,64 @@
+import { professionalDocumentTitle, professionalPath } from '../../utils/doctorPath'
+import { formatPageTitle } from '../../utils/site'
+import { test, expect } from '@playwright/test'
+
+const UNKNOWN_DOCTOR_PATH
+    = '/doctor/missing--00000000-0000-4000-8000-000000000001'
+
+test.describe('Professional pages', () => {
+    test('an unknown id is a real HTTP 404, not an SPA 200', async ({ request }) => {
+        const response = await request.get(UNKNOWN_DOCTOR_PATH)
+
+        expect(response.status()).toBe(404)
+    })
+
+    test('renders a seeded professional when the local API is up', async ({ page, request }) => {
+        let professional: {
+            id: string
+            names?: Array<{ firstName?: string, lastName?: string, locale?: string }>
+        } | undefined
+
+        try {
+            const response = await request.post('http://127.0.0.1:4000', {
+                data: {
+                    query: `query {
+                        healthcareProfessionals(filters: { limit: 1 }) {
+                            id
+                            names { firstName lastName locale }
+                        }
+                    }`
+                }
+            })
+            const json = await response.json() as {
+                data?: { healthcareProfessionals?: typeof professional[] }
+            }
+            professional = json.data?.healthcareProfessionals?.[0]
+        } catch {
+            test.skip(true, 'local API is not running')
+            return
+        }
+
+        if (!professional?.id) {
+            test.skip(true, 'local API returned no professionals')
+            return
+        }
+
+        const path = professionalPath({
+            id: professional.id,
+            names: professional.names ?? []
+        })
+        const english = professional.names?.find(name => name.locale === 'en_US')
+        const displayName = english
+            ? `${english.firstName ?? ''} ${english.lastName ?? ''}`.trim()
+            : `${professional.names?.[0]?.firstName ?? ''} ${professional.names?.[0]?.lastName ?? ''}`.trim()
+
+        await page.goto(path)
+
+        await expect(page.getByTestId('doctor-page')).toBeVisible()
+        if (displayName) {
+            await expect(page.getByRole('heading', { level: 1, name: displayName })).toBeVisible()
+            await expect(page).toHaveTitle(formatPageTitle(professionalDocumentTitle(displayName)))
+        }
+        await expect(page.getByTestId('doctor-back-to-search')).toBeVisible()
+    })
+})

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -233,13 +233,17 @@ test.describe('Search page', () => {
             await expect(page.getByTestId('search-result-card')).toHaveCount(3)
         })
 
-        test('search result cards link to the clinic page, not a query-param panel', async ({ page }) => {
+        test('search result cards link to clinic pages, and staff names to doctor pages', async ({ page }) => {
             await page.goto('/search')
 
             await expect(page.getByRole('link', { name: 'Tokyo Family Clinic' }))
                 .toHaveAttribute('href', '/clinic/tokyo/shibuya/tokyo-family-clinic--f1')
             await expect(page.getByRole('link', { name: 'Osaka Dental' }))
                 .toHaveAttribute('href', '/clinic/osaka/kita/osaka-dental--f2')
+            await expect(page.getByRole('link', { name: 'Aiko Tanaka' }))
+                .toHaveAttribute('href', '/doctor/aiko-tanaka--p1')
+            await expect(page.getByRole('link', { name: 'Maria Lopez' }))
+                .toHaveAttribute('href', '/doctor/maria-lopez--p3')
         })
 
         /*
@@ -251,6 +255,8 @@ test.describe('Search page', () => {
 
             const panel = page.getByTestId('search-details-panel')
             await expect(panel.getByRole('heading', { name: 'Sapporo Skin Clinic' })).toBeVisible()
+            await expect(panel.getByRole('link', { name: 'Yuki Mori' }))
+                .toHaveAttribute('href', '/doctor/yuki-mori--p4')
             await expect(page).toHaveURL(/facility=f3/)
         })
 

--- a/tests/e2e/seo.spec.ts
+++ b/tests/e2e/seo.spec.ts
@@ -36,11 +36,15 @@ test.describe('Discovery and social meta', () => {
         })
 
         const clinicPath = /^\/clinic\/[^/]+\/[^/]+\/.+--.+$/
-        const staticPaths = paths.filter(path => !path.startsWith('/clinic/'))
+        const doctorPath = /^\/doctor\/.+--.+$/
+        const staticPaths = paths.filter(path => !path.startsWith('/clinic/') && !path.startsWith('/doctor/'))
         expect(staticPaths.sort()).toEqual([...publicPaths].sort())
         for (const path of paths) {
             if (path.startsWith('/clinic/')) {
                 expect(path).toMatch(clinicPath)
+            }
+            if (path.startsWith('/doctor/')) {
+                expect(path).toMatch(doctorPath)
             }
         }
         expect(body).not.toContain(`${new URL(locs[0] ?? 'http://localhost/').origin}/login`)

--- a/tests/vitest/unit/appHead.spec.ts
+++ b/tests/vitest/unit/appHead.spec.ts
@@ -1,0 +1,64 @@
+/// <reference types="vitest/globals" />
+import { expect } from 'chai'
+import { COLOR_SCHEME_BOOTSTRAP, umamiScript } from '@/utils/nuxt/appHead'
+import { entityDirectoryVitePlugins } from '@/utils/nuxt/entityDirectoryGenerate'
+
+describe('umamiScript', () => {
+    const previousUrl = process.env.NUXT_PUBLIC_UMAMI_URL
+    const previousSiteId = process.env.NUXT_PUBLIC_UMAMI_SITE_ID
+    const previousNodeEnv = process.env.NODE_ENV
+
+    afterEach(() => {
+        process.env.NODE_ENV = previousNodeEnv
+        if (previousUrl === undefined) {
+            delete process.env.NUXT_PUBLIC_UMAMI_URL
+        } else {
+            process.env.NUXT_PUBLIC_UMAMI_URL = previousUrl
+        }
+        if (previousSiteId === undefined) {
+            delete process.env.NUXT_PUBLIC_UMAMI_SITE_ID
+        } else {
+            process.env.NUXT_PUBLIC_UMAMI_SITE_ID = previousSiteId
+        }
+    })
+
+    it('emits nothing outside production, even when env vars look set', () => {
+        process.env.NODE_ENV = 'test'
+        process.env.NUXT_PUBLIC_UMAMI_URL = 'https://analytics.example/script.js'
+        process.env.NUXT_PUBLIC_UMAMI_SITE_ID = 'abc'
+        expect(umamiScript()).to.deep.equal([])
+    })
+
+    it('treats the literal quoted-empty deploy values as unset', () => {
+        process.env.NODE_ENV = 'production'
+        process.env.NUXT_PUBLIC_UMAMI_URL = '""'
+        process.env.NUXT_PUBLIC_UMAMI_SITE_ID = '""'
+        expect(umamiScript()).to.deep.equal([])
+    })
+
+    it('emits the tag when production has a real URL and site id', () => {
+        process.env.NODE_ENV = 'production'
+        process.env.NUXT_PUBLIC_UMAMI_URL = 'https://analytics.example/script.js'
+        process.env.NUXT_PUBLIC_UMAMI_SITE_ID = 'site-1'
+        expect(umamiScript()).to.deep.equal([{
+            src: 'https://analytics.example/script.js',
+            async: true,
+            defer: true,
+            'data-website-id': 'site-1'
+        }])
+    })
+})
+
+describe('COLOR_SCHEME_BOOTSTRAP', () => {
+    it('is an inline IIFE that can run before hydration', () => {
+        expect(COLOR_SCHEME_BOOTSTRAP).to.match(/^\(function \(\)/)
+        expect(COLOR_SCHEME_BOOTSTRAP).to.include('localStorage.getItem(\'colorScheme\')')
+    })
+})
+
+describe('entityDirectoryVitePlugins', () => {
+    it('exposes the clinic and doctor virtual modules', () => {
+        expect(entityDirectoryVitePlugins().map(plugin => plugin.name))
+            .to.deep.equal(['clinic-directory', 'doctor-directory'])
+    })
+})

--- a/tests/vitest/unit/clinicPath.spec.ts
+++ b/tests/vitest/unit/clinicPath.spec.ts
@@ -2,9 +2,11 @@
 import { expect } from 'chai'
 import {
     FACILITY_ID_SEPARATOR,
+    canonicalPathMatches,
     facilityDocumentTitle,
     facilityIdFromSlugParam,
     facilityPath,
+    normaliseRoutePath,
     slugifySegment
 } from '@/utils/clinicPath'
 import { formatPageTitle, SITE_TITLE } from '@/utils/site'
@@ -83,6 +85,24 @@ describe('facilityIdFromSlugParam', () => {
     it('returns undefined when the separator is missing', () => {
         expect(facilityIdFromSlugParam('tokyo-family-clinic-f1')).to.equal(undefined)
         expect(facilityIdFromSlugParam('')).to.equal(undefined)
+    })
+})
+
+describe('canonicalPathMatches', () => {
+    const unicodePath = '/doctor/輝-山口--dba9e895-cb00-49af-bedb-1a993a16b704'
+
+    it('treats percent-encoded Unicode slugs as the same path', () => {
+        expect(canonicalPathMatches(encodeURI(unicodePath), unicodePath)).to.equal(true)
+        expect(normaliseRoutePath(encodeURI(unicodePath))).to.equal(unicodePath)
+    })
+
+    it('ignores a trailing slash', () => {
+        expect(canonicalPathMatches(`${unicodePath}/`, unicodePath)).to.equal(true)
+    })
+
+    it('still redirects when the slug actually differs', () => {
+        expect(canonicalPathMatches('/doctor/other--dba9e895-cb00-49af-bedb-1a993a16b704', unicodePath))
+            .to.equal(false)
     })
 })
 

--- a/tests/vitest/unit/doctorPath.spec.ts
+++ b/tests/vitest/unit/doctorPath.spec.ts
@@ -1,0 +1,79 @@
+/// <reference types="vitest/globals" />
+import { expect } from 'chai'
+import {
+    DOCTOR_ID_SEPARATOR,
+    professionalDocumentTitle,
+    professionalIdFromSlugParam,
+    professionalPath,
+    professionalSlugName
+} from '@/utils/doctorPath'
+import { formatPageTitle, SITE_TITLE } from '@/utils/site'
+import { joinDoctorDirectory } from '@/utils/clinicPrerender'
+import type { Facility, HealthcareProfessional } from '~/typedefs/gqlTypes'
+import { Locale } from '~/typedefs/gqlTypes'
+
+describe('professionalSlugName', () => {
+    it('prefers the English name, then Japanese, then the first locale', () => {
+        expect(professionalSlugName([
+            { firstName: '花子', lastName: '田中', locale: Locale.JaJp },
+            { firstName: 'Hanako', lastName: 'Tanaka', locale: Locale.EnUs }
+        ])).to.equal('Hanako Tanaka')
+
+        expect(professionalSlugName([
+            { firstName: '花子', lastName: '田中', locale: Locale.JaJp }
+        ])).to.equal('花子 田中')
+
+        expect(professionalSlugName([])).to.equal('')
+    })
+})
+
+describe('professionalPath', () => {
+    const sampleId = '48d89d58-b5bf-474c-a866-b64479e10cf2'
+
+    it('builds /doctor/{slug}--{id}', () => {
+        expect(professionalPath({
+            id: sampleId,
+            names: [{ firstName: 'Aiko', middleName: '', lastName: 'Tanaka', locale: Locale.EnUs }]
+        })).to.equal(`/doctor/aiko-tanaka${DOCTOR_ID_SEPARATOR}${sampleId}`)
+    })
+
+    it('falls back to doctor when no name is present', () => {
+        expect(professionalPath({
+            id: 'p1',
+            names: []
+        })).to.equal(`/doctor/doctor${DOCTOR_ID_SEPARATOR}p1`)
+    })
+})
+
+describe('professionalIdFromSlugParam', () => {
+    it('reads the id after the last --', () => {
+        expect(professionalIdFromSlugParam('aiko-tanaka--p1')).to.equal('p1')
+        expect(professionalIdFromSlugParam('missing-separator')).to.equal(undefined)
+    })
+})
+
+describe('professionalDocumentTitle', () => {
+    it('keeps short names intact so formatPageTitle stays under 60 characters', () => {
+        const title = professionalDocumentTitle('Aiko Tanaka')
+        expect(formatPageTitle(title).length).to.be.at.most(60)
+        expect(formatPageTitle(title)).to.equal(`Aiko Tanaka · ${SITE_TITLE}`)
+    })
+})
+
+describe('joinDoctorDirectory', () => {
+    it('attaches facilities in the professional id list order and still lists unaffiliated doctors', () => {
+        const facilities = [
+            { id: 'f1', nameEn: 'One' },
+            { id: 'f2', nameEn: 'Two' }
+        ] as Facility[]
+        const professionals = [
+            { id: 'p1', facilityIds: ['f2', 'missing', 'f1'], names: [] },
+            { id: 'p2', facilityIds: [], names: [] }
+        ] as unknown as HealthcareProfessional[]
+
+        const directory = joinDoctorDirectory(facilities, professionals)
+
+        expect(directory.p1?.facilities.map(facility => facility.id)).to.deep.equal(['f2', 'f1'])
+        expect(directory.p2?.facilities).to.deep.equal([])
+    })
+})

--- a/tests/vitest/unit/netlifyRedirects.spec.ts
+++ b/tests/vitest/unit/netlifyRedirects.spec.ts
@@ -69,9 +69,11 @@ describe('SPA fallbacks', () => {
      * Clinic pages are prerendered by id. An SPA rewrite would turn unknown IDs into
      * 200 HTML, which #1789 forbids. Missing files must hit the 404 catch-all.
      */
-    it('does not give /clinic an SPA rewrite', () => {
+    it('does not give /clinic or /doctor an SPA rewrite', () => {
         expect(readRedirects()).to.not.match(/^\/clinic/m)
+        expect(readRedirects()).to.not.match(/^\/doctor/m)
         const rewrites = readServeJson().rewrites ?? []
         expect(rewrites.some(rule => rule.source.startsWith('/clinic'))).to.equal(false)
+        expect(rewrites.some(rule => rule.source.startsWith('/doctor'))).to.equal(false)
     })
 })

--- a/tests/vitest/unit/siteTitle.spec.ts
+++ b/tests/vitest/unit/siteTitle.spec.ts
@@ -115,14 +115,17 @@ describe('pageTitleKeyForPath', () => {
         expect(pageTitleKeyForPath('/my-page')).to.equal(undefined)
         expect(pageTitleKeyForPath('/login')).to.equal(undefined)
         expect(pageTitleKeyForPath('/clinic/tokyo/nakano/a-one--f1')).to.equal(undefined)
+        expect(pageTitleKeyForPath('/doctor/aiko-tanaka--p1')).to.equal(undefined)
         expect(pageTitleKeyForPath('/not-a-page')).to.equal(undefined)
     })
 })
 
 describe('isEntityRoute', () => {
-    it('treats clinic detail URLs as entity pages that own their titles', () => {
+    it('treats clinic and doctor detail URLs as entity pages that own their titles', () => {
         expect(isEntityRoute('/clinic')).to.equal(true)
         expect(isEntityRoute('/clinic/tokyo/nakano/a-one--f1')).to.equal(true)
+        expect(isEntityRoute('/doctor')).to.equal(true)
+        expect(isEntityRoute('/doctor/aiko-tanaka--p1')).to.equal(true)
         expect(isEntityRoute('/search')).to.equal(false)
         expect(isEntityRoute('/about')).to.equal(false)
     })

--- a/tests/vitest/unit/sitemap.spec.ts
+++ b/tests/vitest/unit/sitemap.spec.ts
@@ -10,6 +10,7 @@ import {
     SITEMAP_DIRECTORY_PAGE_SIZE,
     sitemapUrlFromEntry
 } from '@/utils/sitemapDirectory'
+import { Locale } from '~/typedefs/gqlTypes'
 
 describe('publicSitemapUrls', () => {
     it('lists every titled public page and none of the robots-disallowed trees', () => {
@@ -32,13 +33,9 @@ describe('SITEMAP_EXCLUDE', () => {
 })
 
 describe('sitemapUrlFromEntry', () => {
-    const paths = { facility: '/clinic', professional: '/professionals' }
-
-    it('omits professionals until that page tree exists, and lists clinics at facilityPath', () => {
+    it('lists clinics and doctors at their canonical paths', () => {
         expect(DIRECTORY_SITEMAP_PATHS.facility).to.equal('/clinic')
-        expect(DIRECTORY_SITEMAP_PATHS.professional).to.equal(undefined)
-        expect(sitemapUrlFromEntry({ kind: 'professional', id: 'p1', updatedDate: '2026-08-01' }))
-            .to.equal(undefined)
+        expect(DIRECTORY_SITEMAP_PATHS.professional).to.equal('/doctor')
         expect(sitemapUrlFromEntry({
             kind: 'facility',
             id: 'abc',
@@ -50,18 +47,30 @@ describe('sitemapUrlFromEntry', () => {
             loc: '/clinic/tokyo/shibuya/tokyo-family-clinic--abc',
             lastmod: '2026-08-01T00:00:00.000Z'
         })
-    })
-
-    it('uses updatedDate as lastmod when the prefix is set', () => {
-        expect(sitemapUrlFromEntry(
-            { kind: 'professional', id: 'p1', updatedDate: '2026-08-01T00:00:00.000Z' },
-            paths
-        )).to.deep.equal({ loc: '/professionals/p1', lastmod: '2026-08-01T00:00:00.000Z' })
+        expect(sitemapUrlFromEntry({
+            kind: 'professional',
+            id: 'p1',
+            names: [{ firstName: 'Aiko', lastName: 'Tanaka', locale: Locale.EnUs }],
+            updatedDate: '2026-08-01T00:00:00.000Z'
+        })).to.deep.equal({
+            loc: '/doctor/aiko-tanaka--p1',
+            lastmod: '2026-08-01T00:00:00.000Z'
+        })
     })
 
     it('omits lastmod when the API did not send updatedDate', () => {
-        expect(sitemapUrlFromEntry({ kind: 'professional', id: 'p1' }, paths))
-            .to.deep.equal({ loc: '/professionals/p1' })
+        expect(sitemapUrlFromEntry({
+            kind: 'professional',
+            id: 'p1',
+            names: [{ firstName: 'Aiko', lastName: 'Tanaka', locale: Locale.EnUs }]
+        })).to.deep.equal({ loc: '/doctor/aiko-tanaka--p1' })
+    })
+
+    it('omits a kind when that prefix is unset', () => {
+        expect(sitemapUrlFromEntry(
+            { kind: 'professional', id: 'p1' },
+            { facility: '/clinic', professional: undefined }
+        )).to.equal(undefined)
     })
 })
 
@@ -103,7 +112,7 @@ describe('loadDirectorySitemapUrls', () => {
         expect(urls).to.deep.equal([])
     })
 
-    it('does not fetch professionals while that prefix is unset', async () => {
+    it('pages facilities and professionals once both prefixes exist', async () => {
         const urls = await loadDirectorySitemapUrls({
             fetchFacilities: async () => ({
                 rows: [{
@@ -114,14 +123,20 @@ describe('loadDirectorySitemapUrls', () => {
                 }],
                 totalCount: 1
             }),
-            fetchProfessionals: async () => {
-                throw new Error('professionals should not be fetched')
-            }
+            fetchProfessionals: async () => ({
+                rows: [{
+                    id: 'p1',
+                    names: [{ firstName: 'Aiko', lastName: 'Tanaka', locale: Locale.EnUs }],
+                    updatedDate: '2026-08-01T00:00:00.000Z'
+                }],
+                totalCount: 1
+            })
         })
 
-        expect(directoryKindsToFetch()).to.deep.equal(['facility'])
+        expect(directoryKindsToFetch()).to.deep.equal(['facility', 'professional'])
         expect(urls).to.deep.equal([
-            { loc: '/clinic/tokyo/shibuya/tokyo-family-clinic--f1', lastmod: '2026-08-01T00:00:00.000Z' }
+            { loc: '/clinic/tokyo/shibuya/tokyo-family-clinic--f1', lastmod: '2026-08-01T00:00:00.000Z' },
+            { loc: '/doctor/aiko-tanaka--p1', lastmod: '2026-08-01T00:00:00.000Z' }
         ])
     })
 
@@ -138,7 +153,7 @@ describe('loadDirectorySitemapUrls', () => {
         expect(urls).to.deep.equal([])
     })
 
-    it('pages facilities and maps lastmod once a prefix exists', async () => {
+    it('pages facilities and maps lastmod when only the clinic prefix exists', async () => {
         const urls = await loadDirectorySitemapUrls(
             {
                 fetchFacilities: async offset => ({

--- a/utils/clinicPath.ts
+++ b/utils/clinicPath.ts
@@ -53,6 +53,26 @@ export function facilityPath(facility: Pick<Facility, 'id' | 'nameEn'> & {
 }
 
 /**
+ * Vue Router / browsers may percent-encode Unicode path segments. Decode and
+ * NFC-normalise so `/doctor/輝-山口--id` matches the encoded form and we do
+ * not 301-loop on Japanese (or other non-ASCII) slugs.
+ */
+export function normaliseRoutePath(path: string): string {
+    const trimmed = path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path
+    let decoded = trimmed
+    try {
+        decoded = decodeURI(trimmed)
+    } catch {
+        // Malformed percent-encoding — compare the trimmed path as-is.
+    }
+    return decoded.normalize('NFC')
+}
+
+export function canonicalPathMatches(currentPath: string, canonicalPath: string): boolean {
+    return normaliseRoutePath(currentPath) === normaliseRoutePath(canonicalPath)
+}
+
+/**
  * Document title *before* `formatPageTitle` adds the brand suffix, so the
  * branded result stays within 60 characters.
  */

--- a/utils/clinicPrerender.ts
+++ b/utils/clinicPrerender.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { facilityPath } from './clinicPath'
+import { professionalPath } from './doctorPath'
 import { graphqlEndpoint } from './graphqlEndpoint'
 import type { Facility, HealthcareProfessional } from '~/typedefs/gqlTypes'
 import type { FacilitySearchResult } from './searchDirectory'
@@ -121,6 +122,28 @@ async function fetchAllPages<T>(
     return rows
 }
 
+export type ProfessionalSearchResult = HealthcareProfessional & {
+    facilities: Facility[]
+}
+
+export function joinDoctorDirectory(
+    facilities: readonly Facility[],
+    professionals: readonly HealthcareProfessional[]
+): Record<string, ProfessionalSearchResult> {
+    const byId = new Map(facilities.map(facility => [facility.id, facility]))
+    const directory: Record<string, ProfessionalSearchResult> = {}
+
+    for (const professional of professionals) {
+        const affiliated = (professional.facilityIds ?? [])
+            .map(id => byId.get(id))
+            .filter((facility): facility is Facility => !!facility)
+
+        directory[professional.id] = { ...professional, facilities: affiliated }
+    }
+
+    return directory
+}
+
 export function joinClinicDirectory(
     facilities: readonly Facility[],
     professionals: readonly HealthcareProfessional[]
@@ -176,19 +199,22 @@ export function readClinicPrerenderCache(id: string): FacilitySearchResult | nul
 }
 
 /**
- * Concrete `/clinic/...` paths for `nuxi generate`. Unknown IDs must stay a real
- * HTTP 404, so these are listed explicitly rather than given an SPA rewrite.
+ * Concrete `/clinic/...` and `/doctor/...` paths for `nuxi generate`. Unknown
+ * IDs must stay a real HTTP 404, so these are listed explicitly rather than
+ * given an SPA rewrite.
  *
  * The directory is stored on private `runtimeConfig` so prerender workers can
  * fill each page without calling `facility(id)`. Disk cache + env were invisible
  * to those workers, which 429'd production and failed Netlify.
  *
  * If the API is unreachable the generate still succeeds — it just ships no clinic
- * HTML, and those URLs 404 until the next build that can see the directory.
+ * or doctor HTML, and those URLs 404 until the next build that can see the directory.
  */
 export async function buildClinicPrerenderDirectory(): Promise<{
     directory: Record<string, FacilitySearchResult>
+    professionalDirectory: Record<string, ProfessionalSearchResult>
     paths: string[]
+    professionalPaths: string[]
 } | null> {
     const facilities = await fetchAllPages(async offset => {
         const data = await graphqlPost<FacilitiesPage>(FACILITIES_QUERY, {
@@ -220,11 +246,14 @@ export async function buildClinicPrerenderDirectory(): Promise<{
     }) ?? []
 
     const directory = joinClinicDirectory(facilities, professionals)
+    const professionalDirectory = joinDoctorDirectory(facilities, professionals)
     writeClinicPrerenderCache(directory)
 
     return {
         directory,
-        paths: Object.values(directory).map(facility => facilityPath(facility))
+        professionalDirectory,
+        paths: Object.values(directory).map(facility => facilityPath(facility)),
+        professionalPaths: Object.values(professionalDirectory).map(professional => professionalPath(professional))
     }
 }
 

--- a/utils/doctorPath.ts
+++ b/utils/doctorPath.ts
@@ -1,0 +1,57 @@
+import type { HealthcareProfessional, LocalizedName } from '~/typedefs/gqlTypes'
+import { FACILITY_ID_SEPARATOR, facilityIdFromSlugParam, slugifySegment } from './clinicPath'
+import { SITE_TITLE } from './site'
+
+/**
+ * Same `--` join as clinic URLs: professional IDs are UUIDs, so a single hyphen
+ * between slug and id cannot be parsed. Issue #1790 wrote `/doctor/[slug]-[id]`.
+ */
+export const DOCTOR_ID_SEPARATOR = FACILITY_ID_SEPARATOR
+
+const FALLBACK_SLUG = 'doctor'
+
+function segmentOrFallback(value: string | null | undefined, fallback: string): string {
+    return slugifySegment(value) || fallback
+}
+
+export const professionalIdFromSlugParam = facilityIdFromSlugParam
+
+/**
+ * Slug source: English name when present, then Japanese, then the first locale.
+ */
+export function professionalSlugName(names: readonly LocalizedName[] | null | undefined): string {
+    const english = names?.find(name => name.locale === 'en_US')
+    const japanese = names?.find(name => name.locale === 'ja_JP')
+    const first = names?.[0]
+
+    const from = (name?: LocalizedName) => [name?.firstName, name?.middleName, name?.lastName]
+        .map(part => part?.trim())
+        .filter((part): part is string => !!part)
+        .join(' ')
+
+    return from(english) || from(japanese) || from(first) || ''
+}
+
+export function professionalPath(professional: Pick<HealthcareProfessional, 'id' | 'names'>): string {
+    const slug = segmentOrFallback(professionalSlugName(professional.names), FALLBACK_SLUG)
+    return `/doctor/${slug}${DOCTOR_ID_SEPARATOR}${professional.id}`
+}
+
+/**
+ * Document title *before* `formatPageTitle` adds the brand suffix, so the
+ * branded result stays within 60 characters.
+ */
+export function professionalDocumentTitle(name: string): string {
+    const maxName = 60 - ` · ${SITE_TITLE}`.length
+    const trimmed = name.trim()
+
+    if (trimmed.length <= maxName) {
+        return trimmed
+    }
+
+    if (maxName <= 1) {
+        return '…'
+    }
+
+    return `${trimmed.slice(0, maxName - 1).trimEnd()}…`
+}

--- a/utils/doctorProfessional.ts
+++ b/utils/doctorProfessional.ts
@@ -1,0 +1,156 @@
+import { gql } from 'graphql-request'
+import { gqlClient, graphQLClientRequestWithRetry } from './graphql'
+import type { Facility, HealthcareProfessional } from '~/typedefs/gqlTypes'
+import type { ProfessionalSearchResult } from './clinicPrerender'
+import { useRuntimeConfig } from '#imports'
+
+export type { ProfessionalSearchResult }
+
+const PUBLIC_REQUEST_OPTIONS = {
+    skipAuth: true,
+    retryAmount: 2,
+    requestTimeoutInMilliseconds: 1500,
+    abortAfterMs: 10000
+}
+
+const doctorProfessionalQuery = gql`
+    query DoctorProfessional($id: ID!) {
+        healthcareProfessional(id: $id) {
+            id
+            names {
+                lastName
+                firstName
+                middleName
+                locale
+            }
+            degrees
+            specialties
+            facilityIds
+            spokenLanguages
+            acceptedInsurance
+            additionalInfoForPatients
+            createdDate
+            updatedDate
+        }
+    }
+`
+
+const doctorFacilitiesQuery = gql`
+    query DoctorFacilities($filters: FacilitySearchFilters!) {
+        facilities(filters: $filters) {
+            id
+            nameEn
+            nameJa
+            mapLatitude
+            mapLongitude
+            healthcareProfessionalIds
+            contact {
+                address {
+                    addressLine1En
+                    addressLine2En
+                    addressLine1Ja
+                    addressLine2Ja
+                    cityJa
+                    cityEn
+                    prefectureJa
+                    prefectureEn
+                    postalCode
+                }
+                email
+                googleMapsUrl
+                phone
+                website
+            }
+            createdDate
+            updatedDate
+        }
+    }
+`
+
+function doctorFromPrerenderDirectory(
+    directory: Record<string, ProfessionalSearchResult> | undefined | null,
+    id: string
+): ProfessionalSearchResult | null | undefined {
+    if (!directory || Object.keys(directory).length === 0) {
+        return undefined
+    }
+
+    return directory[id] ?? null
+}
+
+function doctorFromRuntimeConfig(id: string): ProfessionalSearchResult | null | undefined {
+    const directory = useRuntimeConfig().doctorPrerenderDirectory as
+        Record<string, ProfessionalSearchResult> | undefined
+
+    return doctorFromPrerenderDirectory(directory, id)
+}
+
+async function doctorFromBundledDirectory(id: string): Promise<ProfessionalSearchResult | null | undefined> {
+    try {
+        const mod = await import('#doctor-directory')
+        const directory = (mod.default ?? mod) as Record<string, ProfessionalSearchResult>
+        return doctorFromPrerenderDirectory(directory, id)
+    } catch {
+        return undefined
+    }
+}
+
+function facilitiesInListedOrder(
+    professional: HealthcareProfessional,
+    fetched: readonly Facility[]
+): Facility[] {
+    const byId = new Map(fetched.map(facility => [facility.id, facility]))
+    const ordered = (professional.facilityIds ?? [])
+        .map(id => byId.get(id))
+        .filter((facility): facility is Facility => !!facility)
+
+    if (ordered.length) {
+        return ordered
+    }
+
+    return [...fetched]
+}
+
+export async function fetchDoctorById(id: string): Promise<ProfessionalSearchResult | null> {
+    if (import.meta.server) {
+        const fromConfig = doctorFromRuntimeConfig(id)
+        if (fromConfig !== undefined) {
+            return fromConfig
+        }
+
+        const fromBundle = await doctorFromBundledDirectory(id)
+        if (fromBundle !== undefined) {
+            return fromBundle
+        }
+    }
+
+    const response = await graphQLClientRequestWithRetry<{
+        healthcareProfessional?: HealthcareProfessional | null
+    }>(
+        gqlClient.request.bind(gqlClient),
+        doctorProfessionalQuery,
+        { id },
+        PUBLIC_REQUEST_OPTIONS
+    )
+
+    const professional = response.data?.healthcareProfessional
+    if (response.hasErrors || !professional) {
+        return null
+    }
+
+    const facilitiesResponse = await graphQLClientRequestWithRetry<{ facilities?: Facility[] }>(
+        gqlClient.request.bind(gqlClient),
+        doctorFacilitiesQuery,
+        { filters: { healthcareProfessionalIds: [id], limit: 100 } },
+        PUBLIC_REQUEST_OPTIONS
+    )
+
+    const fetched = facilitiesResponse.hasErrors
+        ? []
+        : (facilitiesResponse.data?.facilities ?? [])
+
+    return {
+        ...professional,
+        facilities: facilitiesInListedOrder(professional, fetched)
+    }
+}

--- a/utils/graphqlEndpoint.ts
+++ b/utils/graphqlEndpoint.ts
@@ -4,8 +4,8 @@
  * `useRuntimeConfig`.
  *
  * Pass the flag in when you have it (runtime config). Omit it to read
- * `NUXT_USE_LOCAL_API` from the environment — that is how clinic (and later
- * doctor) prerender paging reaches the same host the app will query.
+ * `NUXT_USE_LOCAL_API` from the environment — that is how clinic and doctor
+ * prerender paging reaches the same host the app will query.
  */
 export const PRODUCTION_GRAPHQL_URL = 'https://api.findadoc.jp'
 export const LOCAL_GRAPHQL_URL = 'http://127.0.0.1:4000'

--- a/utils/nuxt/appHead.ts
+++ b/utils/nuxt/appHead.ts
@@ -1,0 +1,37 @@
+/**
+ * The analytics tag, only when it is actually configured.
+ *
+ * A bare truthiness check is not enough: the deploy environment sets these to the
+ * literal two-character string `""`, which is truthy, so the build emitted
+ * `<script src='""'>`. An empty `src` resolves against the current document, so every
+ * page requested itself as JavaScript — normally a harmless 404, but fatal on any path
+ * covered by an SPA rewrite, where it returns HTML with 200 and the parser throws
+ * `Unexpected token '<'` before the app can hydrate.
+ */
+export function umamiScript() {
+    const clean = (value?: string) => value?.replace(/^["']|["']$/g, '').trim() ?? ''
+    const url = clean(process.env.NUXT_PUBLIC_UMAMI_URL)
+    const siteId = clean(process.env.NUXT_PUBLIC_UMAMI_SITE_ID)
+
+    if (!url || !siteId || process.env.NODE_ENV !== 'production') {
+        return []
+    }
+
+    return [{ src: url, async: true, defer: true, 'data-website-id': siteId }]
+}
+
+/**
+ * Applies the stored colour scheme before first paint.
+ *
+ * Runs inline in <head> so a returning dark-mode visitor never sees a light flash on a
+ * prerendered page. Mirrors the migration in composables/useColorScheme.ts: only an explicit
+ * dark choice survives from the old five-colourway picker. Anything else means "auto", which
+ * is no class at all — the stylesheet then follows prefers-color-scheme.
+ */
+export const COLOR_SCHEME_BOOTSTRAP = `(function () {
+  try {
+    var s = localStorage.getItem('colorScheme')
+    if (s !== 'dark' && s !== 'light') s = localStorage.getItem('isDarkMode') === 'true' ? 'dark' : ''
+    if (s) document.documentElement.classList.add('theme-' + s)
+  } catch (e) {}
+})()`

--- a/utils/nuxt/entityDirectoryGenerate.ts
+++ b/utils/nuxt/entityDirectoryGenerate.ts
@@ -1,0 +1,94 @@
+import type { Nuxt } from '@nuxt/schema'
+import type { NitroConfig } from 'nitropack'
+import { buildClinicPrerenderDirectory, isNuxtGenerateCommand } from '../clinicPrerender'
+
+type EntityDirectoryBuild = Awaited<ReturnType<typeof buildClinicPrerenderDirectory>>
+
+let entityDirectoryBuild: EntityDirectoryBuild | undefined
+let entityDirectoryBuildPromise: Promise<EntityDirectoryBuild> | undefined
+
+/**
+ * One directory fetch for `nuxi generate`. Vite plugins and Nitro hooks share this
+ * so clinic and doctor HTML is filled from memory instead of `facility(id)` /
+ * `healthcareProfessional(id)` per page.
+ */
+export async function entityDirectoryForGenerate(): Promise<EntityDirectoryBuild> {
+    if (!isNuxtGenerateCommand()) {
+        return null
+    }
+
+    entityDirectoryBuildPromise ??= buildClinicPrerenderDirectory().then(built => {
+        entityDirectoryBuild = built
+        return built
+    })
+
+    return entityDirectoryBuildPromise
+}
+
+function directoryVitePlugin(
+    moduleId: '#clinic-directory' | '#doctor-directory',
+    directoryOf: (built: NonNullable<EntityDirectoryBuild>) => unknown
+) {
+    const resolvedId = `\0${moduleId.slice(1)}`
+
+    return {
+        name: moduleId.slice(1),
+        resolveId(id: string) {
+            if (id === moduleId) {
+                return resolvedId
+            }
+        },
+        load(this: { environment?: { name?: string } }, id: string) {
+            if (id !== resolvedId) {
+                return
+            }
+
+            if (this.environment?.name === 'client') {
+                return 'export default {}'
+            }
+
+            const directory = entityDirectoryBuild ? directoryOf(entityDirectoryBuild) : {}
+            return `export default ${JSON.stringify(directory)}`
+        }
+    }
+}
+
+export function entityDirectoryVitePlugins() {
+    return [
+        directoryVitePlugin('#clinic-directory', built => built.directory),
+        directoryVitePlugin('#doctor-directory', built => built.professionalDirectory)
+    ]
+}
+
+export async function applyEntityDirectoryToNuxt(nuxt: Nuxt) {
+    const built = await entityDirectoryForGenerate()
+    if (!built) {
+        return
+    }
+
+    nuxt.options.runtimeConfig.clinicPrerenderDirectory = built.directory
+    nuxt.options.runtimeConfig.doctorPrerenderDirectory = built.professionalDirectory
+}
+
+export async function applyEntityDirectoryToNitro(nitroConfig: NitroConfig) {
+    const built = await entityDirectoryForGenerate()
+    if (!built || nitroConfig.dev) {
+        return
+    }
+
+    console.warn(`[clinic prerender] ${built.paths.length} clinic pages, ${built.professionalPaths.length} doctor pages from directory payload`)
+    nitroConfig.runtimeConfig ??= {}
+    nitroConfig.runtimeConfig.clinicPrerenderDirectory = built.directory
+    nitroConfig.runtimeConfig.doctorPrerenderDirectory = built.professionalDirectory
+    nitroConfig.virtual = {
+        ...nitroConfig.virtual,
+        '#clinic-directory': `export default ${JSON.stringify(built.directory)}`,
+        '#doctor-directory': `export default ${JSON.stringify(built.professionalDirectory)}`
+    }
+    nitroConfig.prerender ??= {}
+    const existing = nitroConfig.prerender.routes
+    const entityPaths = [...built.paths, ...built.professionalPaths]
+    nitroConfig.prerender.routes = Array.isArray(existing)
+        ? [...existing, ...entityPaths]
+        : entityPaths
+}

--- a/utils/pageTitles.ts
+++ b/utils/pageTitles.ts
@@ -14,7 +14,7 @@ export function pageMetaI18nKey(key: PageMetaTitleKey): `pageMeta.${PageMetaTitl
  * New `pages/*.vue` files are a different axis: TypeScript cannot see the filesystem,
  * so `tests/vitest/unit/siteTitle.spec.ts` asserts every page is either in this map,
  * under an untitled prefix (`/my-page`, `/u`, `/login`), or an entity prefix
- * (`/clinic`) that owns its title.
+ * (`/clinic`, `/doctor`) that owns its title.
  */
 export const PAGE_META_TITLE_ROUTES = {
     homeTitle: '/',
@@ -35,10 +35,10 @@ const UNTITLED_ROUTE_PREFIXES = ['/my-page', '/u', '/login'] as const
 
 /**
  * Directory entity pages set their own `<title>` from the record. They are not
- * in PAGE_META_TITLE_ROUTES (one key cannot cover 465 clinics) and must not
- * fall through to the brand-only title in `app.vue`.
+ * in PAGE_META_TITLE_ROUTES (one key cannot cover hundreds of clinics or
+ * doctors) and must not fall through to the brand-only title in `app.vue`.
  */
-const ENTITY_ROUTE_PREFIXES = ['/clinic'] as const
+const ENTITY_ROUTE_PREFIXES = ['/clinic', '/doctor'] as const
 
 function normalisePagePath(path: string): string {
     if (path.length > 1 && path.endsWith('/')) {

--- a/utils/sitemapDirectory.ts
+++ b/utils/sitemapDirectory.ts
@@ -1,7 +1,8 @@
 import { gql, GraphQLClient } from 'graphql-request'
 import { facilityPath } from './clinicPath'
+import { professionalPath } from './doctorPath'
 import { graphqlEndpoint } from './graphqlEndpoint'
-import type { FacilitySearchFilters, HealthcareProfessionalSearchFilters } from '~/typedefs/gqlTypes'
+import type { FacilitySearchFilters, HealthcareProfessionalSearchFilters, LocalizedName } from '~/typedefs/gqlTypes'
 
 /**
  * Same cap the directory store uses. The API silently truncates or errors above this
@@ -11,15 +12,15 @@ export const SITEMAP_DIRECTORY_PAGE_SIZE = 100
 
 /**
  * Entity URL prefixes. A set prefix means that kind is listed. Facility locs
- * are `facilityPath` (#1789); the prefix is only the enable flag. Professional
- * stays unset until #1790. The sitemap fetch is skipped while every prefix is
- * unset so `nuxi generate` does not advertise URLs that 404.
+ * are `facilityPath` (#1789); professional locs are `professionalPath` (#1790).
+ * The prefix is only the enable flag. The sitemap fetch is skipped while every
+ * prefix is unset so `nuxi generate` does not advertise URLs that 404.
  *
  * Hub and facet pages (#1791, #1792) add their own prefixes here the same way.
  */
 export const DIRECTORY_SITEMAP_PATHS = {
     facility: '/clinic' as string | undefined,
-    professional: undefined as string | undefined
+    professional: '/doctor' as string | undefined
 }
 
 export type SitemapDirectoryKind = keyof typeof DIRECTORY_SITEMAP_PATHS
@@ -31,6 +32,7 @@ export type SitemapDirectoryEntry = {
     nameEn?: string | null
     cityEn?: string | null
     prefectureEn?: string | null
+    names?: LocalizedName[] | null
 }
 
 export type SitemapDirectoryUrl = {
@@ -64,7 +66,10 @@ export function directorySitemapLoc(
         })
     }
 
-    return `${paths[entry.kind]}/${entry.id}`
+    return professionalPath({
+        id: entry.id,
+        names: entry.names ?? []
+    })
 }
 
 export function sitemapUrlFromEntry(
@@ -134,6 +139,12 @@ const sitemapProfessionalsQuery = gql`
         healthcareProfessionals(filters: $filters) {
             id
             updatedDate
+            names {
+                firstName
+                middleName
+                lastName
+                locale
+            }
         }
         healthcareProfessionalsTotalCount(filters: $countFilters)
     }
@@ -151,9 +162,15 @@ type SitemapFacilityRow = {
     } | null
 }
 
+type SitemapProfessionalRow = {
+    id: string
+    updatedDate?: string | null
+    names?: LocalizedName[] | null
+}
+
 type DirectoryFetcher = {
     fetchFacilities: (offset: number) => Promise<DirectoryPage<SitemapFacilityRow>>
-    fetchProfessionals: (offset: number) => Promise<DirectoryPage<{ id: string, updatedDate?: string | null }>>
+    fetchProfessionals: (offset: number) => Promise<DirectoryPage<SitemapProfessionalRow>>
 }
 
 function graphqlDirectoryFetcher(apiUrl = graphqlEndpoint()): DirectoryFetcher {
@@ -186,7 +203,7 @@ function graphqlDirectoryFetcher(apiUrl = graphqlEndpoint()): DirectoryFetcher {
             } satisfies HealthcareProfessionalSearchFilters
 
             const data = await client.request<{
-                healthcareProfessionals: Array<{ id: string, updatedDate?: string | null }>
+                healthcareProfessionals: SitemapProfessionalRow[]
                 healthcareProfessionalsTotalCount: number
             }>(sitemapProfessionalsQuery, {
                 filters,
@@ -230,6 +247,7 @@ export async function loadDirectorySitemapUrls(
             entries.push(...professionals.map(row => ({
                 kind: 'professional' as const,
                 id: row.id,
+                names: row.names ?? [],
                 updatedDate: row.updatedDate
             })))
         }


### PR DESCRIPTION
✅ Resolves #1790

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed

Every healthcare professional gets a shareable, server-rendered URL at `/doctor/{slug}--{id}`. The page resolves on the UUID only (the slug is decorative) and 301s to the canonical path when it drifts. Unknown IDs are a real HTTP 404 — there is no `/doctor` SPA rewrite.

The page shows names, degrees, specialties, spoken languages, accepted insurance, patient notes, and affiliated clinics (linked to their #1789 `/clinic/…` pages). Search result cards and the in-search details panel now link staff names to those URLs.

`nuxi generate` reuses the existing clinic directory fetch so doctor HTML is filled from the same payload (no extra API paging). Doctor URLs join `sitemap.xml` via `/api/__sitemap__/directory`.

IDs are UUIDs, so the slug/id join is `--` rather than a single hyphen (same decision as #1789). Generate/head helpers that had grown in `nuxt.config.ts` now live under `utils/nuxt/`.

## 🧪 Testing instructions

- Unit: `yarn test:unit` (new `doctorPath`, sitemap professional locs, no-`/doctor`-rewrite, entity-title, and Umami empty-src cases)
- Open a search result and click a staff name; land on `/doctor/...--{id}` with specialties, languages, insurance, and clinic links
- Change the slug in the URL and get a 301 to the canonical path
- Hit a made-up UUID under `/doctor/...` and get HTTP 404, not a 200 SPA shell
- `nuxi generate` against production should include doctor URLs in `sitemap.xml` and prerendered HTML with a unique `<title>`

## 📸 Screenshots

- ### Before
Staff names existed only as text inside search / clinic details. No indexable professional URL.
- ### After
Each professional is its own document at `/doctor/{slug}--{id}`, listed in the sitemap, and linked from search.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated healthcare professional profile pages with specialties, languages, insurance, patient information, and affiliated clinics.
  - Added localized doctor profile content across supported languages.
  - Search results now link professional names to their profile pages.
  - Added canonical doctor URLs, redirects, metadata, and sitemap support.
  - Doctor pages are available during site generation and return a proper 404 for unknown professionals.

- **Tests**
  - Added coverage for doctor pages, links, routing, SEO metadata, sitemap entries, and localized profile behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->