### PR TITLE
chore(ci): add nuxi typecheck script and CI workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,34 @@
+name: Typecheck
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '45 15 * * 4'
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck:
+    name: Typecheck 🔎
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.12.0]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Install Yarn/ Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+      - name: Install Dependencies
+        run: yarn install --immutable
+      - name: Run typecheck
+        run: yarn typecheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We are working on the V2 version of the site, so if you've volunteered in the pa
 2. Find a good issue by checking out the [Issues Section](https://github.com/ourjapanlife/findadoc-web/issues). PLEASE only take tickets with the `help wanted` label.
 3. For new developers looking for easier tickets, look for an unassigned issue tagged `Good First Issue`.
 4. Create your own branch and start writing your code!  (we recommend prefixing your branch with your username, like `coolgithubname/mychange`)
-5. Submit a PR (Pull Request) on Github and work with the team to merge it. Make sure that all automated checks and linters pass, and please add a clear description of what you did and how you test it.
+5. Submit a PR (Pull Request) on Github and work with the team to merge it. Make sure that all automated checks pass — locally that is `yarn lint`, `yarn typecheck`, and `yarn test:unit` — and please add a clear description of what you did and how you test it.
 6. Give us a shout if you need any help on the `#frontend-team` channel on [Slack](https://join.slack.com/t/find-a-doc/shared_invite/zt-s4744a6o-MGaGHzLN5wB9aXeha3vdsQ)!
 
 👉️ Translators 🌐

--- a/components/moderation-panel/ModMainContent.vue
+++ b/components/moderation-panel/ModMainContent.vue
@@ -101,7 +101,7 @@ function syncSelectedModerationViewFromQuery() {
 const setActiveScreenBasedOnRoute = async () => {
     await nextTick()
     // grab the relevant part of the path
-    const pathSnippet = routePathForModerationScreen.value.split('/')[2]
+    const pathSnippet = routePathForModerationScreen.value.split('/')[2] ?? ''
 
     // for routes that require a selected ID, check before entering the switch
     const editRoutes = ['edit-submission', 'edit-facility', 'edit-healthcare-professional']

--- a/components/search/DoctorDetails.vue
+++ b/components/search/DoctorDetails.vue
@@ -133,7 +133,7 @@ import { useSpecialtiesStore } from '~/stores/specialtiesStore'
 import { formatHealthcareProfessionalName } from '~/utils/nameUtils'
 import { isJapaneseLocale, toGqlLocale } from '~/utils/activeLocale'
 import { facilityPath } from '~/utils/clinicPath'
-import type { ProfessionalSearchResult } from '~/utils/doctorProfessional'
+import type { ProfessionalSearchResult } from '~/utils/clinicPrerender'
 import { Insurance, Locale, type LocalizedName } from '~/typedefs/gqlTypes'
 
 const props = defineProps<{

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -16,17 +16,3 @@ declare module '@vue/runtime-core' {
     interface ComponentCustomProperties extends _ComponentCustomProperties {}
     interface ComponentCustomOptions extends _ComponentCustomOptions {}
 }
-
-declare module '#clinic-directory' {
-    import type { FacilitySearchResult } from './utils/searchDirectory'
-
-    const directory: Record<string, FacilitySearchResult>
-    export default directory
-}
-
-declare module '#doctor-directory' {
-    import type { ProfessionalSearchResult } from './utils/clinicPrerender'
-
-    const directory: Record<string, ProfessionalSearchResult>
-    export default directory
-}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "lint:locales": "node i18n/checkLocaleKeys.js",
         "lint:cleanlocales": "node i18n/cleanUnusedLocaleKeys.js",
         "lint:ci": "yarn prepare:ci && ESLINT_USE_FLAT_CONFIG=true eslint . -c eslint.config.js",
+        "typecheck": "nuxi prepare && nuxi typecheck",
         "prod:build": "yarn && yarn generate && nuxi generate",
         "prod:start": "nuxi start",
         "ci:build": "yarn && yarn generate && nuxi generate",
@@ -103,6 +104,7 @@
         "vite": "^7.3.0",
         "vitest": "^4.0.16",
         "vue-eslint-parser": "^10.2.0",
+        "vue-tsc": "^3.3.11",
         "wait-on": "^8.0.1"
     }
 }

--- a/plugins/unsaved-changes-plugin.client.ts
+++ b/plugins/unsaved-changes-plugin.client.ts
@@ -1,3 +1,5 @@
+import type { Pinia } from 'pinia'
+import type { Router } from 'vue-router'
 import { useModerationSubmissionUnsavedStore } from '~/stores/moderationSubmissionUnsavedStore'
 
 export default defineNuxtPlugin({
@@ -24,13 +26,15 @@ export default defineNuxtPlugin({
             if (registeredRouterGuard) return
             registeredRouterGuard = true
 
-            const submissionUnsavedStore = useModerationSubmissionUnsavedStore(nuxtApp.$pinia)
+            const submissionUnsavedStore = useModerationSubmissionUnsavedStore(nuxtApp.$pinia as Pinia)
+            const router = nuxtApp.$router as Router
+            const i18n = nuxtApp.$i18n as { t?: (key: string) => string } | undefined
 
-            nuxtApp.$router.beforeEach(() => {
+            router.beforeEach(() => {
                 if (!isGloballyDirty.value) return true
 
                 return new Promise<boolean>(resolve => {
-                    const message = nuxtApp.$i18n?.t('modEditFacilityOrHPTopbar.hasUnsavedChanges')
+                    const message = i18n?.t?.('modEditFacilityOrHPTopbar.hasUnsavedChanges')
                       ?? 'You have unsaved changes'
                     const confirm = nuxtApp.$withConfirmation
                     if (typeof confirm !== 'function') {

--- a/server/api/__sitemap__/directory.ts
+++ b/server/api/__sitemap__/directory.ts
@@ -1,4 +1,4 @@
-import { defineSitemapEventHandler } from '#imports'
+import { defineEventHandler } from 'h3'
 import { loadDirectorySitemapUrls } from '~/utils/sitemapDirectory'
 
-export default defineSitemapEventHandler(() => loadDirectorySitemapUrls())
+export default defineEventHandler(() => loadDirectorySitemapUrls())

--- a/stores/moderationSubmissionUnsavedStore.ts
+++ b/stores/moderationSubmissionUnsavedStore.ts
@@ -28,7 +28,10 @@ export const useModerationSubmissionUnsavedStore = defineStore('moderationSubmis
             registerEditFormTryLeave(null)
             return
         }
-        registerEditFormTryLeave(onLeave => onLeave(fn))
+        registerEditFormTryLeave(onLeave => {
+            fn()
+            void onLeave()
+        })
     }
 
     function runLeaveOr(onLeave: () => void | Promise<void>) {

--- a/stores/searchResultsStore.ts
+++ b/stores/searchResultsStore.ts
@@ -260,7 +260,7 @@ export const useSearchResultsStore = defineStore('searchResultsStore', () => {
             )
 
             if (response.hasErrors) {
-                throw new Error(response.errors.map(error => error.message).join('; ') || 'facilities request failed')
+                throw new Error((response.errors ?? []).map(error => error.message).join('; ') || 'facilities request failed')
             }
 
             return {
@@ -288,7 +288,7 @@ export const useSearchResultsStore = defineStore('searchResultsStore', () => {
             )
 
             if (response.hasErrors) {
-                throw new Error(response.errors.map(error => error.message).join('; ') || 'professionals request failed')
+                throw new Error((response.errors ?? []).map(error => error.message).join('; ') || 'professionals request failed')
             }
 
             return {

--- a/tests/e2e/seo.spec.ts
+++ b/tests/e2e/seo.spec.ts
@@ -29,7 +29,9 @@ test.describe('Discovery and social meta', () => {
         const body = await response.text()
         expect(body).toMatch(/<urlset\b/)
 
-        const locs = [...body.matchAll(/<loc>\s*([^<]+)\s*<\/loc>/g)].map(match => match[1].trim())
+        const locs = [...body.matchAll(/<loc>\s*([^<]+)\s*<\/loc>/g)]
+            .map(match => match[1]?.trim())
+            .filter((loc): loc is string => Boolean(loc))
         const paths = locs.map(loc => {
             const pathname = new URL(loc).pathname
             return pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname || '/'

--- a/utils/arrayUtils.ts
+++ b/utils/arrayUtils.ts
@@ -37,7 +37,13 @@ export function shuffleArray<T>(inputArray: T[]): T[] {
     // Fisher-Yates shuffle algorithm
     for (let i = copiedArray.length - 1; i > 0; i--) {
         const j = Math.floor(Math.random() * (i + 1));
-        [copiedArray[i], copiedArray[j]] = [copiedArray[j], copiedArray[i]]
+        const left = copiedArray[i]
+        const right = copiedArray[j]
+        if (left === undefined || right === undefined) {
+            continue
+        }
+        copiedArray[i] = right
+        copiedArray[j] = left
     }
     return copiedArray
 }

--- a/utils/arrayUtils.ts
+++ b/utils/arrayUtils.ts
@@ -36,7 +36,7 @@ export function shuffleArray<T>(inputArray: T[]): T[] {
 
     // Fisher-Yates shuffle algorithm
     for (let i = copiedArray.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
+        const j = Math.floor(Math.random() * (i + 1))
         const left = copiedArray[i]
         const right = copiedArray[j]
         if (left === undefined || right === undefined) {

--- a/utils/doctorProfessional.ts
+++ b/utils/doctorProfessional.ts
@@ -4,8 +4,6 @@ import type { Facility, HealthcareProfessional } from '~/typedefs/gqlTypes'
 import type { ProfessionalSearchResult } from './clinicPrerender'
 import { useRuntimeConfig } from '#imports'
 
-export type { ProfessionalSearchResult }
-
 const PUBLIC_REQUEST_OPTIONS = {
     skipAuth: true,
     retryAmount: 2,

--- a/utils/searchDirectory.ts
+++ b/utils/searchDirectory.ts
@@ -86,7 +86,7 @@ export function filterDirectory(
 const SPECIALTIES = new Set<string>(Object.values(Specialty))
 const LOCALES = new Set<string>(Object.values(Locale))
 
-function firstString(value: LocationQuery[string]): string | undefined {
+function firstString(value: LocationQuery[string] | undefined): string | undefined {
     const single = Array.isArray(value) ? value[0] : value
     return typeof single === 'string' && single.length ? single : undefined
 }

--- a/virtual-directories.d.ts
+++ b/virtual-directories.d.ts
@@ -1,0 +1,13 @@
+declare module '#clinic-directory' {
+    import type { FacilitySearchResult } from './utils/searchDirectory'
+
+    const directory: Record<string, FacilitySearchResult>
+    export default directory
+}
+
+declare module '#doctor-directory' {
+    import type { ProfessionalSearchResult } from './utils/clinicPrerender'
+
+    const directory: Record<string, ProfessionalSearchResult>
+    export default directory
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6161,6 +6161,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@volar/language-core@npm:2.4.28":
+  version: 2.4.28
+  resolution: "@volar/language-core@npm:2.4.28"
+  dependencies:
+    "@volar/source-map": "npm:2.4.28"
+  checksum: 10/6c735027df0dfee142654e0aa9265111a82c21134366c08f4764743f74875ba8314fdc98865d37bf83ac7409dfea90b8538181a966681f3d01f68bbd999fef3a
+  languageName: node
+  linkType: hard
+
 "@volar/source-map@npm:2.4.15":
   version: 2.4.15
   resolution: "@volar/source-map@npm:2.4.15"
@@ -6175,6 +6184,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@volar/source-map@npm:2.4.28":
+  version: 2.4.28
+  resolution: "@volar/source-map@npm:2.4.28"
+  checksum: 10/494b086be7ef6a46993941144a6961dcf9ecc4c830e2279031004496a7480727d6b0dc3f16776bf83aafe005084655c5664198f362a2c975d8267855de7b0a27
+  languageName: node
+  linkType: hard
+
 "@volar/typescript@npm:2.4.15":
   version: 2.4.15
   resolution: "@volar/typescript@npm:2.4.15"
@@ -6183,6 +6199,17 @@ __metadata:
     path-browserify: "npm:^1.0.1"
     vscode-uri: "npm:^3.0.8"
   checksum: 10/f5b7dccc6abfca8c1943076690788a6a05e8ecea880be2244c2588bb47835a399927092e200e3774abc33ed56551804c8acfff6d90685ff5acafc3409832ccc6
+  languageName: node
+  linkType: hard
+
+"@volar/typescript@npm:2.4.28":
+  version: 2.4.28
+  resolution: "@volar/typescript@npm:2.4.28"
+  dependencies:
+    "@volar/language-core": "npm:2.4.28"
+    path-browserify: "npm:^1.0.1"
+    vscode-uri: "npm:^3.0.8"
+  checksum: 10/6176e1fccc3c060a6393ab33b9befb828542a813a72201f0a83a8e6607055ac98a838db32ce9f54fe305df51cd1fa0eefc30d5e16dd2391af0563c76746f6679
   languageName: node
   linkType: hard
 
@@ -6406,6 +6433,21 @@ __metadata:
     typescript:
       optional: true
   checksum: 10/ff3c20da3656bd66786c7317df66d43c9b914778771571a029d019107b3bc83c8e8978514b6aa83b246efe6e2a30051bbb9332340b641b5874b34d72cea136c5
+  languageName: node
+  linkType: hard
+
+"@vue/language-core@npm:3.3.11":
+  version: 3.3.11
+  resolution: "@vue/language-core@npm:3.3.11"
+  dependencies:
+    "@volar/language-core": "npm:2.4.28"
+    "@vue/compiler-dom": "npm:^3.5.0"
+    "@vue/shared": "npm:^3.5.0"
+    alien-signals: "npm:^3.2.1"
+    muggle-string: "npm:^0.4.1"
+    path-browserify: "npm:^1.0.1"
+    picomatch: "npm:^4.0.4"
+  checksum: 10/18d1c4041a7804e80c4154794d80df97302ee6e52cacb8830b89b9695b7b4bf615a3ab617bab3ff5ea4ab95e65ce72341abe7fe77758f229f4dfe8d4cea3d542
   languageName: node
   linkType: hard
 
@@ -6649,6 +6691,13 @@ __metadata:
   version: 3.1.2
   resolution: "alien-signals@npm:3.1.2"
   checksum: 10/5095cc62a2d81a19f1c4187fdd87e73c07dbeb290995c413f179b9d7c498ce721067097e5ad4a00b3e4d2e91c88f5f041c5e6e7a1652cd027fa6ee1660e7274d
+  languageName: node
+  linkType: hard
+
+"alien-signals@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "alien-signals@npm:3.2.1"
+  checksum: 10/9c8b14c460e748f40d85bbe4e607f81a4177d8ca1c056eab86f9792297003ef10717690019e23cacf19bb68babba97d1cb0bb03c35ca495d736cb6809efb7291
   languageName: node
   linkType: hard
 
@@ -10078,6 +10127,7 @@ __metadata:
     vue-server-renderer: "npm:^2.7.16"
     vue-template-compiler: "npm:^2.7.16"
     vue-toastification: "npm:^2.0.0-rc.5"
+    vue-tsc: "npm:^3.3.11"
     vue3-google-map: "npm:^0.27.0"
     wait-on: "npm:^8.0.1"
   languageName: unknown
@@ -17672,6 +17722,20 @@ __metadata:
   peerDependencies:
     vue: ^3.0.2
   checksum: 10/da2698e8a24f3de99269d71327879c389236179225dca9112d1de971fcd2e809d83670e1195f3c59a232f8b53c5625b93d573e809da7cb587527b5d339ec9bdb
+  languageName: node
+  linkType: hard
+
+"vue-tsc@npm:^3.3.11":
+  version: 3.3.11
+  resolution: "vue-tsc@npm:3.3.11"
+  dependencies:
+    "@volar/typescript": "npm:2.4.28"
+    "@vue/language-core": "npm:3.3.11"
+  peerDependencies:
+    typescript: ">=5.0.0"
+  bin:
+    vue-tsc: bin/vue-tsc.js
+  checksum: 10/040ab3469c392475541f479187e1c0aee460d57ede3c8de44b09ccc89fc53c2052ec1c36de00841ea955275cc5dba69f3889f23d7134f7d41b513223308f57c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
✅ Resolves #1801

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specifications
- [x] PR assignee has been selected
- [x] PR label has been selected

## 🔧 What changed

- Added `yarn typecheck` (`nuxi prepare && nuxi typecheck`) and a GitHub Actions workflow that runs it on PRs, pushes to `main`, and a weekly cron — Node **22.12.0**, `yarn install --immutable`, `actions/checkout@v6` and `actions/setup-node@v6`.
- Declared `vue-tsc` as a direct devDependency so the check is not relying on a transitive install.
- Documented the script next to lint and unit tests in `CONTRIBUTING.md`.
- Fixed existing TypeScript errors so the job starts green, and stopped re-exporting `ProfessionalSearchResult` from `doctorProfessional.ts` (Nuxt was warning about a duplicated auto-import).

## 🧪 Testing instructions

- [ ] `yarn typecheck` passes locally
- [ ] The Typecheck workflow on this PR is green
- [ ] Confirm `package.json` engines / other CI jobs still use Node 22.12.0 (this job matches them)

## 📸 Screenshots

N/A — CI and type-only changes.


Made with [Cursor](https://cursor.com)